### PR TITLE
detailed-query: tweak column titles some more

### DIFF
--- a/site/static/detailed-query.html
+++ b/site/static/detailed-query.html
@@ -52,8 +52,7 @@
         <a href="dashboard.html">dashboard</a>, <a href="status.html">status</a>.</div>
     <div id="content">
         <h3 id="title"></h3>
-        <p>'Time (%)' is the percentage of the cpu-clock time spent on this query.
-        Totals row is as a comparison to the 'cpu-clock' stat (we do not use
+        <p>'Time (%)' is the percentage of the cpu-clock time spent on this query (we do not use
         wall-time as we want to account for parallelism).</p>
         <p>Executions do not include cached executions.</p>
         <table>

--- a/site/static/detailed-query.html
+++ b/site/static/detailed-query.html
@@ -52,17 +52,17 @@
         <a href="dashboard.html">dashboard</a>, <a href="status.html">status</a>.</div>
     <div id="content">
         <h3 id="title"></h3>
-        <p>Totals row '%total time' is as a comparison to the 'cpu-clock' stat (we do not use
+        <p>'Time (%)' is the percentage of the cpu-clock time spent on this query.
+        Totals row is as a comparison to the 'cpu-clock' stat (we do not use
         wall-time as we want to account for parallelism).</p>
-        <p>% total time is the percentage of the cpu-clock time spent on this query.</p>
         <p>Executions do not include cached executions.</p>
         <table>
             <thead>
                 <tr id="table-header">
                     <th data-sort-idx="1" data-default-sort-dir="1">Query/Function</th>
                     <th data-sort-idx="2" data-default-sort-dir="-1">Time (s)</th>
-                    <th data-sort-idx="10" data-default-sort-dir="-1">% Total Time</th>
-                    <th class="delta">Execution time delta</th>
+                    <th data-sort-idx="10" data-default-sort-dir="-1">Time (%)</th>
+                    <th class="delta">Time delta</th>
                     <th data-sort-idx="5" data-default-sort-dir="-1">Executions</th>
                     <th class="delta">Executions delta</th>
                     <th class="incr" data-sort-idx="7"


### PR DESCRIPTION
I found it strange that the 'Time (s)' delta column says 'Execution time', so I made the column titles consistent. I also merged the two paragraphs that both talk about the '% total time' column.

What I didn't do because I did not know how to is reorder the column such that 'Time delta' is directly to the right of 'Time (s)', like we do with the other columns. IMO it would be better for 'Time (%)' to move either one to the left or one to the right.