### PR TITLE
Improve the output for `collector profile` and `collector bench_local`.

### DIFF
--- a/collector/README.md
+++ b/collector/README.md
@@ -62,15 +62,9 @@ marked with a '?' in the `compare` page.
 
 To benchmark a local build:
 ```
-RUST_LOG=info ./target/release/collector --output-repo $OUTPUT_DIR \
+./target/release/collector --output-repo $OUTPUT_DIR \
     bench_local --rustc $RUSTC --cargo $CARGO $ID
 ```
-
-`RUST_LOG=info` defines an environment variable that enables `info`-level
-logging. This is optional but recommended, because without it there is no
-output and thus no indication of progress. `RUST_LOG=debug` is an alternative
-that enables more verbose logging, which is mostly useful for debugging
-rustc-perf itself.
 
 `$OUTPUT_DIR` is a path (relative or absolute) to a directory, in which the
 timing data will be placed. It will be created if it does not already exist.
@@ -88,7 +82,10 @@ installed Cargo is fine, e.g. ``--cargo `which cargo` ``.
 contents.
 
 The full benchmark suite takes some time to run: tens of minutes or more,
-depending on the speed of your machine.
+depending on the speed of your machine. Progress output is printed to stderr.
+
+`RUST_LOG=debug` can be specified to enable some verbose logging, which is
+useful for debugging rustc-perf itself.
 
 ### Benchmarking options
 
@@ -123,10 +120,10 @@ second that contains a branch of your changes. To compare the two versions, do
 something like this:
 
 ```
-RUST_LOG=info ./target/release/collector --output-repo sep03 \
+./target/release/collector --output-repo sep03 \
     bench_local --rustc $RUST_TIP --cargo `which cargo` Orig
 
-RUST_LOG=info ./target/release/collector --output-repo sep03 \
+./target/release/collector --output-repo sep03 \
     bench_local --rustc $RUST_MODIFIED --cargo `which cargo` Modified
 ```
 
@@ -200,7 +197,7 @@ might be optimized.
 
 To self-profile a local build:
 ```
-RUST_LOG=info ./target/release/collector --output-repo $OUTPUT_DIR --self-profile \
+./target/release/collector --output-repo $OUTPUT_DIR --self-profile \
     bench_local $PROFILER --rustc $RUSTC --cargo $CARGO $ID
 ```
 
@@ -208,7 +205,7 @@ Then view the results the same way as for the `bench_local` subcommand.
 
 To profile a local build with a different profiler:
 ```
-RUST_LOG=info ./target/release/collector --output-repo $OUTPUT_DIR \
+./target/release/collector --output-repo $OUTPUT_DIR \
     profile $PROFILER --rustc $RUSTC --cargo $CARGO $ID
 ```
 

--- a/collector/src/bin/rustc-perf-collector/execute.rs
+++ b/collector/src/bin/rustc-perf-collector/execute.rs
@@ -804,14 +804,14 @@ impl Benchmark {
         let iterations = cmp::min(iterations, self.config.runs);
 
         if self.config.disabled {
-            eprintln!("skipping {}: disabled", self.name);
+            eprintln!("Skipping {}: disabled", self.name);
             bail!("disabled benchmark");
         }
 
         let mut runs = Vec::new();
 
         for &build_kind in build_kinds {
-            log::info!("Running {}: {:?} + {:?}", self.name, build_kind, run_kinds);
+            eprintln!("Running {}: {:?} + {:?}", self.name, build_kind, run_kinds);
 
             // Build everything, including all dependent crates, in a temp dir.
             // We do this before the iterations so that dependent crates aren't
@@ -940,10 +940,6 @@ fn process_perf_stat_output(
             cnt.parse()
                 .map_err(|e| DeserializeStatError::ParseError(cnt.to_string(), e))?,
         );
-    }
-
-    if profile.is_none() {
-        eprintln!("stdout: {}", stdout);
     }
 
     if stats.is_empty() {

--- a/collector/src/bin/rustc-perf-collector/outrepo.rs
+++ b/collector/src/bin/rustc-perf-collector/outrepo.rs
@@ -94,7 +94,7 @@ impl Repo {
 
     pub fn success_artifact(&self, data: &ArtifactData) -> anyhow::Result<()> {
         let filepath = self.times().join(format!("artifact-{}.json", data.id));
-        info!("creating file {}", filepath.display());
+        eprintln!("Creating file {}", filepath.display());
         let serialized = serde_json::to_string(&data)?;
         fs::write(&filepath, &serialized)?;
         self.commit_and_push(&format!("{} - success", data.id))?;
@@ -164,7 +164,7 @@ impl Repo {
             "commit-{}-x86_64-unknown-linux-gnu.json.sz",
             commit.sha
         ));
-        info!("creating file {}", filepath.display());
+        eprintln!("Creating file {}", filepath.display());
         let mut v = snap::write::FrameEncoder::new(Vec::new());
         serde_json::to_writer(&mut v, &data)?;
         fs::write(&filepath, v.into_inner()?)?;


### PR DESCRIPTION
This commit does the following.

- Changes all `info!` calls hit when running these commands to
  `eprintln!`, so they will show up without having to set RUST_LOG.

- Removes the uninteresting `stdout:` output from `bench_local` output.

- Prints the number of benchmarks remaining *before* rather than *after*
  each benchmark. So when you start you immediately know how many
  remain, instead of having to wait until after the first benchmark
  finishes.

- Correctly pluralizes "1 benchmark" :)

- Changes "N benchmarks left" to "N benchmarks remaining", because the
  latter is clearer, especially for non-native English speakers.

- Makes all output lines start with an upper-case letter.

Fixes #651.