### PR TITLE
Add a way to graph self-profiling data.

### DIFF
--- a/site/src/selector.rs
+++ b/site/src/selector.rs
@@ -122,7 +122,7 @@ pub trait Series<'a>: Sized {
         -> Result<Self, String>;
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Path {
     path: Vec<PathComponent>,
 }


### PR DESCRIPTION
I've tried to test this on the `rustc-timing` data (as opposed to the single-benchmark dataset I'm independently collecting), but it's too slow and times out (in ngrok, but it'd be unusably slow either way).

So I'm mostly opening this up looking for feedback. Maybe this is impossible without the recent changes on master (this is based on a week-old checkout).

Also I'm not sure how to best expose this in the UI, or if the way I made it configurable makes sense.
(Example URL: `?stat=self-profile:incr-full:top5` for top 5 queries for every `incr-full` run)

<hr/>

**EDIT**: by filtering for one crate and only `-check`, I was able to get the times down. Also, `end` is broken? Anyway, here are some screenshots (for `start=2020-03-25`, i.e. last 2 months):

#### Existing graphs: (unchanged by this PR, only shown as baselines)
* `stat=instructions:u`

  ![image](https://user-images.githubusercontent.com/77424/82834695-8595f080-9eca-11ea-9271-b7ee8da10132.png)

* `stat=wall-time` (noisier than `instructions:u`)

  ![image](https://user-images.githubusercontent.com/77424/82834829-f1785900-9eca-11ea-848d-b08cf1ae7321.png)

#### New graph: (added in this PR)

* `stat=self-profile:incr-full:top10` (can be noisier than `wall-time` but mostly spikes up, so if you look "below" the graph, the baseline shape is visible)

  ![image](https://user-images.githubusercontent.com/77424/82834758-b7a75280-9eca-11ea-85fe-3925cab21c34.png)