### PR TITLE
Add performance triage instructions and an initial triage log entry.

### DIFF
--- a/triage/2020.md
+++ b/triage/2020.md
@@ -1,0 +1,24 @@
+# 2020 Triage Logs
+
+These are in reverse chronological order.
+
+## 2020-05-26
+
+Triage done by njn.
+
+Regressions
+- [Update to LLVM 10](https://github.com/rust-lang/rust/pull/67759)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=0aa6751c19d3ba80df5b0b02c00bf44e13c97e80&end=82911b3bba76e73afe2881b732fe6b0edb35d5d3&stat=instructions:u)):
+  Lots of grumbling about this. wg-prioritization will consider at their next meeting?
+- [Intern predicates](https://github.com/rust-lang/rust/pull/72055)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=9310e3bd4f425f84fc27878ebf2bda1f30935a63&end=d9417b385145af1cabd0be8a95c65075d2fc30ff&stat=instructions:u)):
+  @lcnr has promised a follow-up to at least partly fix it, currently in
+  [#72494](https://github.com/rust-lang/rust/pull/72494).
+
+Improvements
+- [Remove ReScope](https://github.com/rust-lang/rust/pull/72362)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=3137f8e2d141d7d7c65040a718a9193f50e1282e&end=52b605c8cb2f730e607de0777a694cd1b9bb3e15&stat=instructions:u))
+- [Dumb NRVO](https://github.com/rust-lang/rust/pull/72205)
+  ([instructions](https://perf.rust-lang.org/compare.html?start=963bf528292d8f97104515e32908e30c2467b6a8&end=7f79e98c0356642db62e5113327e436c951e843d&stat=instructions:u))
+
+

--- a/triage/README.md
+++ b/triage/README.md
@@ -1,0 +1,54 @@
+# Rust Compiler Performance Triage
+
+We regularly triage the effects of merged PRs on rustc's speed and memory
+usage.
+
+## Roster
+
+- Tuesday morning (Melbourne time): njn
+
+## Instructions
+
+Steps:
+- Check the most recent triage log entry. Look for responses in PRs, and follow
+  up on any promised actions. (I.e. nag people!)
+- Start a new triage log entry.
+- Look through the [`instructions:u` graphs](https://perf.rust-lang.org) for
+  each benchmark, looking for significant changes (regressions or improvements)
+  in the period since the last triage.
+  - Click and drag a region of a graph to zoom in on it. This is useful when
+    data points are close together.
+  - Click on a data point to open the "compare" page for that merge.
+  - Click on the "compare" link at the top of the measurements on that page to
+    open the page of commits in the merge.
+- Easy cases: there is only a single PR in the merge.
+  - Add a comment to the PR pointing to the "compare" page (unless someone else
+    has already done that).
+  - In the case of a regression, ask the author for a response. If it's a big
+    regression, consider requesting a backout. It may be worth looking through
+    the comments to see if any perf CI runs were done, and whether the
+    regression was expected.
+  - Add an entry to the triage log. Include useful details, especially promises
+    of follow-up action from authors.
+- Difficult cases: the merge was a rollup of multiple PRs.
+  - Look through the PRs and try to determine which was the cause. Often you
+    can easily tell that one or more PRs could not have caused the change, e.g.
+    because they made trivial changes, documentation-only changes, etc.
+  - If you can't narrow it down to a single PR, in the rollup PR ask all the
+    authors who might be responsible.
+  - Once you have narrowed it down to a single PR, treat it like an easy case,
+    above.
+  - You might want to remind the author to use "@bors rollup=never" for PRs
+    that are likely to affect performance.
+- Repeat with the [`max-rss`
+  graphs](https://perf.rust-lang.org/?start=&end=&absolute=true&stat=max-rss).
+  These measurements are much noisier than `instructions:u`, so only larger
+  changes will be clear.
+
+The #wg-compiler-performance channel on Discord and the t-compiler stream on
+Zulip are good places to ask questions.
+
+## Triage logs
+
+- [2020](2020.md)
+


### PR DESCRIPTION
For now I have just put everything in a single file. Once we have more triage log entries we can consider putting them into a different file.