### PR TITLE
Add support for `cargo llvm-lines`

### DIFF
--- a/collector/README.md
+++ b/collector/README.md
@@ -340,6 +340,16 @@ except that `$PROFILER` is one of the following.
     written to `stderr`) is written to files with an `eprintln` prefix. Those
     files can be post-processed in any appropriate fashion;
     [`counts`](https://github.com/nnethercote/counts) is one possibility.
+- `llvm-lines`: Profile with [`cargo
+  llvm-lines`](https://github.com/dtolnay/cargo-llvm-lines/) a code size
+  measurer.
+  - **Purpose**. This command counts the number of lines of LLVM IR are
+    generated across all instantiations of each function. In other words, it's
+    a tool for finding code bloat.
+  - **Slowdown**. It Is likely to run faster than normal compilation.
+  - **Output**. Human-readable output is written to files with an `ll` prefix.
+  - **Notes**. Does not work with the `Check` build kind. Also does not work
+    with the `IncrFull`, `IncrUnchanged`, and `IncrPatched` run kinds.
 
 ### Profiling options
 

--- a/collector/src/bin/rustc-fake.rs
+++ b/collector/src/bin/rustc-fake.rs
@@ -192,7 +192,7 @@ fn main() {
                 assert!(cmd.status().expect("failed to spawn").success());
             }
 
-            "eprintln" => {
+            "eprintln" | "llvm-lines" => {
                 let mut cmd = Command::new(&rustc);
                 cmd.args(&args);
 

--- a/collector/src/bin/rustc-perf-collector/background_worker.rs
+++ b/collector/src/bin/rustc-perf-collector/background_worker.rs
@@ -11,7 +11,10 @@ lazy_static::lazy_static! {
         RwLock::new(Some(start_bg_thread()));
 }
 
-fn call_home(client: &reqwest::blocking::Client, request: &collected::Request) -> anyhow::Result<()> {
+fn call_home(
+    client: &reqwest::blocking::Client,
+    request: &collected::Request,
+) -> anyhow::Result<()> {
     let resp = client
         .post(&format!(
             "{}/perf/collected",

--- a/collector/src/bin/rustc-perf-collector/main.rs
+++ b/collector/src/bin/rustc-perf-collector/main.rs
@@ -309,7 +309,10 @@ fn bench_commit(
             continue;
         }
 
-        eprintln!("{}", n_benchmarks_remaining(benchmarks.len() - results.len()));
+        eprintln!(
+            "{}",
+            n_benchmarks_remaining(benchmarks.len() - results.len())
+        );
 
         let mut processor = execute::MeasureProcessor::new(self_profile);
         let result =

--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -87,7 +87,12 @@ async fn enqueue_sha(
     data: &InputData,
     commit: String,
 ) -> ServerResult<github::Response> {
-    let timer_token = data.config.keys.github.clone().expect("needs rust-timer token");
+    let timer_token = data
+        .config
+        .keys
+        .github
+        .clone()
+        .expect("needs rust-timer token");
     let client = reqwest::Client::new();
     let url = format!("{}/commits/{}", request.issue.repository_url, commit);
     let commit_response = client
@@ -106,7 +111,10 @@ async fn enqueue_sha(
     let commit_response: github::Commit = match serde_json::from_str(&commit_response) {
         Ok(c) => c,
         Err(e) => {
-            return Err(format!("cannot deserialize commit ({:?}): {:?}", commit_response, e));
+            return Err(format!(
+                "cannot deserialize commit ({:?}): {:?}",
+                commit_response, e
+            ));
         }
     };
     if commit_response.parents.len() != 2 {


### PR DESCRIPTION
I have found `cargo llvm-lines` very useful recently.