### PR TITLE
collector: passthrough env vars

### DIFF
--- a/collector/src/bin/rustc-perf-collector/execute.rs
+++ b/collector/src/bin/rustc-perf-collector/execute.rs
@@ -232,17 +232,6 @@ impl<'a> CargoProcess<'a> {
         cmd
             // Not all cargo invocations (e.g. `cargo clean`) need all of these
             // env vars set, but it doesn't hurt to have them.
-            .env_clear()
-            // SHELL is needed for some benchmarks' build scripts.
-            .env("SHELL", env::var_os("SHELL").unwrap_or_default())
-            // PATH is needed to find things like linkers used by rustc/Cargo.
-            .env("PATH", env::var_os("PATH").unwrap_or_default())
-            // HOME is needed for cargo to find its home directory.
-            .env("HOME", env::var_os("HOME").unwrap_or_default())
-            .env(
-                "RUSTC_THREAD_COUNT",
-                env::var_os("RUSTC_THREAD_COUNT").unwrap_or_default(),
-            )
             .env("RUSTC", &*FAKE_RUSTC)
             .env("RUSTC_REAL", &self.compiler.rustc)
             .env(


### PR DESCRIPTION
This PR modifies the collector to stop clearing the environment when invoking the fake rustc.

This is helpful for users of Nix development shells where environment variables are required to inform tools of the location of C dependencies, and for setting `RUSTFLAGS` to collect data from the same build with different flags.

However, this change can result in some environment variables affecting the data collection where that isn't intended.