### PR TITLE
Add benchmarks for rustdoc

### DIFF
--- a/collector/src/bin/rustc-perf-collector/execute.rs
+++ b/collector/src/bin/rustc-perf-collector/execute.rs
@@ -238,7 +238,7 @@ impl<'a> CargoProcess<'a> {
             .env("RUSTC", &*FAKE_RUSTC)
             .env("RUSTDOC", &*FAKE_RUSTDOC)
             .env("RUSTC_REAL", &self.compiler.rustc)
-            .env("RUSTDOC_REAL", dbg!(&self.compiler.rustdoc))
+            .env("RUSTDOC_REAL", &self.compiler.rustdoc)
             .env(
                 "CARGO_INCREMENTAL",
                 &format!("{}", self.incremental as usize),
@@ -247,7 +247,7 @@ impl<'a> CargoProcess<'a> {
             .arg(subcommand)
             .arg("--manifest-path")
             .arg(&self.manifest_path);
-        dbg!(cmd)
+        cmd
     }
 
     fn get_pkgid(&self, cwd: &Path) -> String {

--- a/collector/src/bin/rustc-perf-collector/execute.rs
+++ b/collector/src/bin/rustc-perf-collector/execute.rs
@@ -339,7 +339,12 @@ lazy_static::lazy_static! {
         fake_rustdoc.push("rustdoc-fake");
         // link from rustc-fake to rustdoc-fake
         if !fake_rustdoc.exists() {
-            std::fs::hard_link(&*FAKE_RUSTC, &fake_rustdoc).expect("failed to make hard link");
+            #[cfg(unix)]
+            use std::os::unix::fs::symlink;
+            #[cfg(windows)]
+            use std::os::windows::fs::symlink_file as symlink;
+
+            symlink(&*FAKE_RUSTC, &fake_rustdoc).expect("failed to make symbolic link");
         }
         fake_rustdoc
     };

--- a/collector/src/bin/rustc-perf-collector/main.rs
+++ b/collector/src/bin/rustc-perf-collector/main.rs
@@ -49,6 +49,7 @@ impl<'a> Compiler<'a> {
 pub enum BuildKind {
     Check,
     Debug,
+    Doc,
     Opt,
 }
 

--- a/collector/src/bin/rustc-perf-collector/main.rs
+++ b/collector/src/bin/rustc-perf-collector/main.rs
@@ -55,6 +55,17 @@ pub enum BuildKind {
     Opt,
 }
 
+impl BuildKind {
+    fn all() -> Vec<Self> {
+        vec![
+            BuildKind::Check,
+            BuildKind::Debug,
+            BuildKind::Doc,
+            BuildKind::Opt,
+        ]
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum RunKind {
     Full,
@@ -104,7 +115,7 @@ pub fn build_kinds_from_arg(arg: &Option<&str>) -> Result<Vec<BuildKind>, KindEr
     if let Some(arg) = arg {
         kinds_from_arg(STRINGS_AND_BUILD_KINDS, arg)
     } else {
-        Ok(vec![BuildKind::Check, BuildKind::Debug, BuildKind::Opt])
+        Ok(BuildKind::all())
     }
 }
 
@@ -176,7 +187,7 @@ fn process_commits(
                 rt,
                 conn,
                 &ArtifactId::Commit(commit),
-                &[BuildKind::Check, BuildKind::Debug, BuildKind::Opt],
+                &BuildKind::all(),
                 &RunKind::all(),
                 Compiler::from_sysroot(&sysroot),
                 &benchmarks,
@@ -402,7 +413,7 @@ fn main_result() -> anyhow::Result<i32> {
            (@arg CARGO: --cargo +required +takes_value "The path to the local Cargo to use")
            (@arg BUILDS: --builds +takes_value
             "One or more (comma-separated) of: 'Check', 'Debug',\n\
-            'Opt', 'All'")
+            'Doc', 'Opt', 'All'")
            (@arg RUNS: --runs +takes_value
             "One or more (comma-separated) of: 'Full',\n\
             'IncrFull', 'IncrUnchanged', 'IncrPatched', 'All'")
@@ -466,14 +477,14 @@ fn main_result() -> anyhow::Result<i32> {
             let commit = sub_m.value_of("COMMIT").unwrap();
             let commit = get_commit_or_fake_it(&commit)?;
             let sysroot = Sysroot::install(commit.sha.to_string(), "x86_64-unknown-linux-gnu")?;
-            let build_kinds = &[BuildKind::Check, BuildKind::Debug, BuildKind::Opt];
+            let build_kinds = BuildKind::all();
             let run_kinds = RunKind::all();
             let conn = rt.block_on(pool.expect("--db passed").connection());
             bench_commit(
                 &mut rt,
                 conn,
                 &ArtifactId::Commit(commit),
-                build_kinds,
+                &build_kinds,
                 &run_kinds,
                 Compiler::from_sysroot(&sysroot),
                 &benchmarks,
@@ -557,7 +568,7 @@ fn main_result() -> anyhow::Result<i32> {
                 &mut rt,
                 conn,
                 &ArtifactId::Artifact(id.to_string()),
-                &[BuildKind::Check, BuildKind::Debug, BuildKind::Opt],
+                &BuildKind::all(),
                 &run_kinds,
                 Compiler {
                     rustc: Path::new(rustc.trim()),

--- a/collector/src/bin/rustc-perf-collector/main.rs
+++ b/collector/src/bin/rustc-perf-collector/main.rs
@@ -331,7 +331,8 @@ fn get_benchmarks(
     exclude: Option<&str>,
 ) -> anyhow::Result<Vec<Benchmark>> {
     let mut benchmarks = Vec::new();
-    'outer: for entry in fs::read_dir(benchmark_dir).context("failed to list benchmarks")? {
+    'outer: for entry in fs::read_dir(benchmark_dir)
+                        .with_context(|| format!("failed to list benchmark dir {}", benchmark_dir.display()))? {
         let entry = entry?;
         let path = entry.path();
         let name = match entry.file_name().into_string() {
@@ -383,7 +384,7 @@ fn main() {
     match main_result() {
         Ok(code) => process::exit(code),
         Err(err) => {
-            eprintln!("{}", err);
+            eprintln!("{:#}\n{}", err, err.backtrace());
             process::exit(1);
         }
     }

--- a/collector/src/bin/rustc-perf-collector/main.rs
+++ b/collector/src/bin/rustc-perf-collector/main.rs
@@ -29,6 +29,7 @@ use sysroot::Sysroot;
 #[derive(Debug, Copy, Clone)]
 pub struct Compiler<'a> {
     pub rustc: &'a Path,
+    pub rustdoc: &'a Path,
     pub cargo: &'a Path,
     pub triple: &'a str,
     pub is_nightly: bool,
@@ -38,6 +39,7 @@ impl<'a> Compiler<'a> {
     fn from_sysroot(sysroot: &'a Sysroot) -> Compiler<'a> {
         Compiler {
             rustc: &sysroot.rustc,
+            rustdoc: &sysroot.rustdoc,
             cargo: &sysroot.cargo,
             triple: &sysroot.triple,
             is_nightly: true,
@@ -86,6 +88,7 @@ pub enum KindError {
 const STRINGS_AND_BUILD_KINDS: &[(&str, BuildKind)] = &[
     ("Check", BuildKind::Check),
     ("Debug", BuildKind::Debug),
+    ("Doc", BuildKind::Doc),
     ("Opt", BuildKind::Opt),
 ];
 
@@ -395,6 +398,7 @@ fn main_result() -> anyhow::Result<i32> {
        (@subcommand bench_local =>
            (about: "benchmark a local rustc")
            (@arg RUSTC: --rustc +required +takes_value "The path to the local rustc to benchmark")
+           (@arg RUSTDOC: --rustdoc +required +takes_value "The path to the local rustdoc to benchmark")
            (@arg CARGO: --cargo +required +takes_value "The path to the local Cargo to use")
            (@arg BUILDS: --builds +takes_value
             "One or more (comma-separated) of: 'Check', 'Debug',\n\
@@ -482,12 +486,14 @@ fn main_result() -> anyhow::Result<i32> {
 
         ("bench_local", Some(sub_m)) => {
             let rustc = sub_m.value_of("RUSTC").unwrap();
+            let rustdoc = sub_m.value_of("RUSTDOC").unwrap();
             let cargo = sub_m.value_of("CARGO").unwrap();
             let build_kinds = build_kinds_from_arg(&sub_m.value_of("BUILDS"))?;
             let run_kinds = run_kinds_from_arg(&sub_m.value_of("RUNS"))?;
             let id = sub_m.value_of("ID").unwrap();
 
             let rustc_path = PathBuf::from(rustc).canonicalize()?;
+            let rustdoc_path = PathBuf::from(rustdoc).canonicalize()?;
             let cargo_path = PathBuf::from(cargo).canonicalize()?;
             let conn = rt.block_on(pool.expect("--db passed").connection());
             bench_commit(
@@ -498,6 +504,7 @@ fn main_result() -> anyhow::Result<i32> {
                 &run_kinds,
                 Compiler {
                     rustc: &rustc_path,
+                    rustdoc: &rustdoc_path,
                     cargo: &cargo_path,
                     triple: "x86_64-unknown-linux-gnu",
                     is_nightly: true,
@@ -520,28 +527,22 @@ fn main_result() -> anyhow::Result<i32> {
                 anyhow::bail!("failed to install toolchain for {}", id);
             }
 
-            let rustc = String::from_utf8(
-                Command::new("rustup")
-                    .arg("which")
-                    .arg("--toolchain")
-                    .arg(&id)
-                    .arg("rustc")
-                    .output()
-                    .context("rustup which rustc")?
-                    .stdout,
-            )
-            .context("utf8")?;
-            let cargo = String::from_utf8(
-                Command::new("rustup")
-                    .arg("which")
-                    .arg("--toolchain")
-                    .arg(&id)
-                    .arg("cargo")
-                    .output()
-                    .context("rustup which cargo")?
-                    .stdout,
-            )
-            .context("utf8")?;
+            let which = |tool| {
+                String::from_utf8(
+                    Command::new("rustup")
+                        .arg("which")
+                        .arg("--toolchain")
+                        .arg(&id)
+                        .arg(tool)
+                        .output()
+                        .context(format!("rustup which {}", tool))?
+                        .stdout,
+                )
+                .context("utf8")
+            };
+            let rustc = which("rustc")?;
+            let rustdoc = which("rustdoc")?;
+            let cargo = which("cargo")?;
 
             // Remove benchmarks that don't work with a stable compiler.
             benchmarks.retain(|b| b.supports_stable());
@@ -560,6 +561,7 @@ fn main_result() -> anyhow::Result<i32> {
                 &run_kinds,
                 Compiler {
                     rustc: Path::new(rustc.trim()),
+                    rustdoc: Path::new(rustdoc.trim()),
                     cargo: Path::new(cargo.trim()),
                     is_nightly: false,
                     triple: "x86_64-unknown-linux-gnu",
@@ -584,6 +586,7 @@ fn main_result() -> anyhow::Result<i32> {
 
         ("profile", Some(sub_m)) => {
             let rustc = sub_m.value_of("RUSTC").unwrap();
+            let rustdoc = sub_m.value_of("RUSTDOC").unwrap();
             let cargo = sub_m.value_of("CARGO").unwrap();
             let build_kinds = build_kinds_from_arg(&sub_m.value_of("BUILDS"))?;
             let run_kinds = run_kinds_from_arg(&sub_m.value_of("RUNS"))?;
@@ -594,9 +597,11 @@ fn main_result() -> anyhow::Result<i32> {
             eprintln!("Profiling with {:?}", profiler);
 
             let rustc_path = PathBuf::from(rustc).canonicalize()?;
+            let rustdoc_path = PathBuf::from(rustdoc).canonicalize()?;
             let cargo_path = PathBuf::from(cargo).canonicalize()?;
             let compiler = Compiler {
                 rustc: &rustc_path,
+                rustdoc: &rustdoc_path,
                 cargo: &cargo_path,
                 is_nightly: true,
                 triple: "x86_64-unknown-linux-gnu", // XXX: Technically not necessarily true

--- a/collector/src/bin/rustc-perf-collector/main.rs
+++ b/collector/src/bin/rustc-perf-collector/main.rs
@@ -650,7 +650,7 @@ fn main_result() -> anyhow::Result<i32> {
                 &mut rt,
                 conn,
                 &ArtifactId::Commit(commit),
-                &[BuildKind::Check], // no Debug or Opt builds
+                &[BuildKind::Check, BuildKind::Doc], // no Debug or Opt builds
                 &RunKind::all(),
                 Compiler::from_sysroot(&sysroot),
                 &benchmarks,

--- a/database/src/bin/ingest-json.rs
+++ b/database/src/bin/ingest-json.rs
@@ -934,6 +934,7 @@ async fn ingest<T: Ingesting>(conn: &T, caches: &mut IdCache, path: &Path) {
             let profile_str = match profile {
                 Profile::Check => "check",
                 Profile::Debug => "debug",
+                Profile::Doc => "doc",
                 Profile::Opt => "opt",
             };
             let state = match &run.state {

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -284,6 +284,7 @@ impl Ord for Commit {
 pub enum Profile {
     Check,
     Debug,
+    Doc,
     Opt,
 }
 
@@ -293,6 +294,7 @@ impl std::str::FromStr for Profile {
         Ok(match s.to_ascii_lowercase().as_str() {
             "check" => Profile::Check,
             "debug" => Profile::Debug,
+            "doc" => Profile::Doc,
             "opt" => Profile::Opt,
             _ => return Err(format!("{} is not a profile", s)),
         })
@@ -308,6 +310,7 @@ impl fmt::Display for Profile {
                 Profile::Check => "check",
                 Profile::Opt => "opt",
                 Profile::Debug => "debug",
+                Profile::Doc => "doc",
             }
         )
     }

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -298,6 +298,7 @@ impl Connection for SqliteConnection {
                                 "check" => Profile::Check,
                                 "opt" => Profile::Opt,
                                 "debug" => Profile::Debug,
+                                "doc" => Profile::Doc,
                                 o => unreachable!("{}: not a profile", o),
                             },
                             row.get::<_, String>(3)?.as_str().parse().unwrap(),

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -331,7 +331,6 @@ impl Connection for SqliteConnection {
                         cid.and_then(|cid| {
                             query
                                 .query_row(params![&sid, &cid.0], |row| row.get(0))
-                                .optional()
                                 .unwrap_or_else(|e| {
                                     panic!("{:?}: series={:?}, aid={:?}", e, sid, cid);
                                 })

--- a/site/src/server.rs
+++ b/site/src/server.rs
@@ -109,14 +109,18 @@ pub async fn handle_dashboard(data: Arc<InputData>) -> ServerResult<dashboard::R
         ) {
             (Some(a), Some(b)) => a.cmp(&b),
             (_, _) => {
+                use std::cmp::Ordering;
+
                 if a.starts_with("beta") && b.starts_with("beta") {
                     a.cmp(b)
                 } else if a.starts_with("beta") {
-                    std::cmp::Ordering::Greater
+                    Ordering::Greater
                 } else if b.starts_with("beta") {
-                    std::cmp::Ordering::Less
+                    Ordering::Less
                 } else {
-                    panic!("unexpected version")
+                    // These are both local ids, not a commit.
+                    // There's no way to tell which version they are, so just pretend they're the same.
+                    Ordering::Equal
                 }
             }
         }

--- a/site/src/server.rs
+++ b/site/src/server.rs
@@ -64,6 +64,7 @@ pub fn handle_info(data: &InputData) -> info::Response {
 pub struct ByProfile<T> {
     pub check: T,
     pub debug: T,
+    pub doc: T,
     pub opt: T,
 }
 
@@ -76,6 +77,7 @@ impl<T> ByProfile<T> {
         Ok(ByProfile {
             check: f(Profile::Check).await?,
             debug: f(Profile::Debug).await?,
+            doc: f(Profile::Doc).await?,
             opt: f(Profile::Opt).await?,
         })
     }
@@ -87,6 +89,7 @@ impl<T> std::ops::Index<Profile> for ByProfile<T> {
         match index {
             Profile::Check => &self.check,
             Profile::Debug => &self.debug,
+            Profile::Doc => &self.doc,
             Profile::Opt => &self.opt,
         }
     }


### PR DESCRIPTION
This runs rustdoc by default and requires that you set rustdoc for every perf run. This is probably not the desired behavior, I can change it once everything is working.

Closes https://github.com/rust-lang/rustc-perf/issues/673
Status: Waiting on review

Example usage:
```
$ cargo run --release --bin collector -- --filter hyper --db doc.db bench_local --rustc $RUSTUP_HOME/toolchains/stage1/bin/rustc --rustdoc $RUSTUP_HOME/toolchains/stage1/bin/rustdoc --cargo $RUSTUP_HOME/toolchains/nightly-x86_64-unknown-linux-gnu/bin/cargo no-loops --builds Doc
```

I got it to show up on the site for `bench_commit` but not for `bench_local`. I'm not sure where in the code to look. Suggestions welcome.

![image](https://user-images.githubusercontent.com/23638587/85924439-490a3b80-b860-11ea-9d74-9509e70623e5.png)
![image](https://user-images.githubusercontent.com/23638587/85924445-5e7f6580-b860-11ea-908c-2f548c6e2591.png)

The way this works is by having `rustc-fake` also pretend to be rustdoc if called as `rustdoc-fake`. Additionally there is some hacking around to make the subcommand `rustdoc` instead of `rustc` since currently the subcommand can only be set by a `Profiler`, not by a `BuildKind`.

r? @Mark-Simulacrum 