### PR TITLE
Don't run rustdoc by default

### DIFF
--- a/collector/src/bin/rustc-perf-collector/main.rs
+++ b/collector/src/bin/rustc-perf-collector/main.rs
@@ -115,7 +115,12 @@ pub fn build_kinds_from_arg(arg: &Option<&str>) -> Result<Vec<BuildKind>, KindEr
     if let Some(arg) = arg {
         kinds_from_arg(STRINGS_AND_BUILD_KINDS, arg)
     } else {
-        Ok(BuildKind::all())
+        // don't run rustdoc by default
+        Ok(vec![
+            BuildKind::Check,
+            BuildKind::Debug,
+            BuildKind::Opt,
+        ])
     }
 }
 


### PR DESCRIPTION
Previously, running `bench_local` without `--builds` would give the error

```
Rustdoc build specified but rustdoc path not provided
```

Now it will run all builds except for doc builds.