### PR TITLE
Overhaul the `collector` CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Check benchmarks
         run: sh -x -c "ci/check-benchmarks.sh"
         env:
-          COLLECTOR_ARGS: "--exclude script-servo"
+          BENCH_TEST_OPTS: "--exclude script-servo"
   test_script_servo:
     name: Test benchmark script-servo
     runs-on: ubuntu-latest
@@ -90,5 +90,5 @@ jobs:
       - name: Check benchmarks
         run: sh -x -c "ci/check-benchmarks.sh"
         env:
-          COLLECTOR_ARGS: "--include script-servo"
+          BENCH_TEST_OPTS: "--include script-servo"
           SHELL: "/bin/bash"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,5 +90,5 @@ jobs:
       - name: Check benchmarks
         run: sh -x -c "ci/check-benchmarks.sh"
         env:
-          COLLECTOR_ARGS: "--filter script-servo"
+          COLLECTOR_ARGS: "--include script-servo"
           SHELL: "/bin/bash"

--- a/ci/check-benchmarks.sh
+++ b/ci/check-benchmarks.sh
@@ -7,9 +7,7 @@ PING_LOOP_PID=$!
 trap - ERR
 RUST_BACKTRACE=1 RUST_LOG=collector=debug,rust_sysroot=debug \
     cargo run -p collector --bin collector -- \
-    --db temporary.db \
-    $COLLECTOR_ARGS \
-    bench_test;
+    bench_test $BENCH_TEST_OPTS
 code=$?
 kill $PING_LOOP_PID
 exit $code

--- a/collector/README.md
+++ b/collector/README.md
@@ -100,10 +100,13 @@ The following options, if present, must appear before `bench_local` in the
 command.
 - `--self-profile` can be used to do self-profiling, which requires the
   `measureme` tool.
-- `--filter $STR` can be used to run a subset of the benchmarks. `$STR` is a
-  substring of the name of the benchmark(s) you wish to run.
-- `--exclude $STR` is the inverse of `--filter`. `$STR` is a substring of the
-  name of the benchmark(s) you wish to skip.
+- `--include $STRS` can be used to run a subset of the benchmarks. `$STRS` is a
+  comma-separated list of strings. When this option is specified, a benchmark
+  is included in the run only if its name contains one or more of the given
+  strings.
+- `--exclude $STRS` is the inverse of `--include`. `$STRS` is a comma-separated
+  list of strings. When this option is specified, a benchmark is excluded from
+  the run if its name contains one or more of the given strings.
 
 The following options, if present, must appear after `bench_local` in the
 command.

--- a/collector/README.md
+++ b/collector/README.md
@@ -61,65 +61,69 @@ marked with a '?' in the `compare` page.
 
 ### How to benchmark a change on your own machine
 
-To benchmark a local build:
+The following command runs the benchmark suite using a local rustc:
 ```
-./target/release/collector --db $DATABASE \
-    bench_local --rustc $RUSTC --cargo $CARGO $ID
+./target/release/collector bench_local <RUSTC> <ID>
 ```
 
-`$DATABASE` is a path (relative or absolute) to a sqlite database file, in which
-the timing data will be placed. It will be created if it does not already exist.
-Alternatively, the collector supports postgres as a backend and the URL can be
-specified (beginning with `postgres://`), but this is unlikely to be useful for
-local collection.
+It will benchmark the entire suite and put the results in a SQLite database
+file called `results.db`. The full benchmark suite takes hours to run, but the
+time can be reduced greatly by using the options below to reduce the number of
+benchmarks, runs, or builds. Progress output is printed to stderr.
 
-`$RUSTC` is a path (relative or absolute) to a rustc executable. Some
-benchmarks use procedural macros, which require a stage 2 compiler. Therefore,
-the value is likely to be something like
-`$RUSTC_REPO/build/x86_64-unknown-linux-gnu/stage2/bin/rustc`, where
-`$RUSTC_REPO` is a path (relative or absolute) to a rustc repository.
+The following arguments are mandatory.
 
-`$CARGO` is a path (relative or absolute) to a Cargo executable. Using an
-installed Cargo is fine, e.g. ``--cargo `which cargo` ``, though you should
-prefer a nightly cargo -- and note that things may not closely match production
-measurements as Cargo sometimes begins passing (or stops passing) various flags
-to rustc.
+- `<RUSTC>`: a path (relative or absolute) to a rustc executable that will be
+  benchmarked. Some benchmarks use plugins, which require a stage 2 compiler.
+  Therefore, the value is likely to be something like
+  `$RUST/build/x86_64-unknown-linux-gnu/stage2/bin/rustc`, where `$RUST` is a
+  path (relative or absolute) to a `rust` repository.
 
-`$ID` is an identifier which will be used to identify the results in the
-collected data.
-
-The full benchmark suite takes some time to run: tens of minutes or more,
-depending on the speed of your machine. Progress output is printed to stderr.
-
-`RUST_LOG=debug` can be specified to enable some verbose logging, which is
-useful for debugging rustc-perf itself.
+- `<ID>`: an identifier which will be used to identify the results in the
+  database.
 
 ### Benchmarking options
 
-The following options, if present, must appear before `bench_local` in the
-command.
-- `--self-profile` can be used to do self-profiling, which requires the
-  `measureme` tool.
-- `--include $STRS` can be used to run a subset of the benchmarks. `$STRS` is a
+The following options alter the behaviour of the `bench_local` subcommand.
+- `--builds <BUILDS>`: the build kinds to be benchmarked. The possible choices
+  are one or more (comma-separated) of `Check`, `Debug`, `Doc`, `Opt`, and
+  `All`. The default is `Check,Debug,Opt`.
+- `--cargo <CARGO>`: a path (relative or absolute) to a Cargo executable that
+  will be used to build the benchmarks. By default, the nightly Cargo installed
+  by `rustup` will be used. This is usually fine, though in rare cases it may
+  cause local results to not exactly match production results, because Cargo
+  sometimes begins passing (or stops passing) various flags to rustc.
+- `--db $DATABASE`: a path (relative or absolute) to a sqlite database file in
+  which the timing data will be placed. It will be created if it does not
+  already exist. The default is `results.db`. Alternatively, the collector
+  supports postgres as a backend and the URL can be specified (beginning with
+  `postgres://`), but this is unlikely to be useful for local collection.
+- `--exclude <EXCLUDE>`: this is used to run a subset of the benchmarks. The
+  argument is a comma-separated list of strings. When this option is specified,
+  a benchmark is excluded from the run if its name contains one or more of the
+  given strings.
+- `--include <INCLUDE>`: the inverse of `--exclude`. The argument is a
   comma-separated list of strings. When this option is specified, a benchmark
   is included in the run only if its name contains one or more of the given
   strings.
-- `--exclude $STRS` is the inverse of `--include`. `$STRS` is a comma-separated
-  list of strings. When this option is specified, a benchmark is excluded from
-  the run if its name contains one or more of the given strings.
+- `--runs $RUNS`: the run kinds to be benchmarked. The possible choices are one
+  or more (comma-separated) of `Full`, `IncrFull`, `IncrUnchanged`,
+  `IncrPatched`, and `All`. The default is `All`. Note that `IncrFull` is
+  always run (even if not requested) if either of `IncrUnchanged` or
+  `IncrPatched` are run.
+- `--rustdoc <RUSTDOC>`: a path (relative or absolute) to a rustdoc
+  executable that will be benchmarked (but only if a `Doc` build is requested
+  with `--builds`). If a `Doc` build is requested, by default the tool will
+  look for a rustdoc executable next to the rustc specified via the `<RUSTC>`
+  argument.
+- `--self-profile`: enable self-profiling, i.e. the inclusion of query
+  statistics in the output. The `measureme` tool must be installed for this to
+  work.
 
-The following options, if present, must appear after `bench_local` in the
-command.
-- `--builds $BUILDS` can be used to select what kind of builds are profiled.
-  The possible choices are one or more (comma-separated) of `Check`, `Debug`,
-  `Opt`, and `All` (the default).
-- `--runs $RUNS` can be used to select what profiling runs are done for each
-  build. The possible choices are one or more (comma-separated) of `Full`,
-  `IncrFull`, `IncrUnchanged`, `IncrPatched`, and `All` (the default). Note
-  that `IncrFull` is always run (even if not requested) if either of
-  `IncrUnchanged` or `IncrPatched` are run.
+`RUST_LOG=debug` can be specified to enable verbose logging, which is useful
+for debugging `collector` itself.
 
-### Comparing different versions on your own machine
+### How to compare different versions on your own machine
 
 Often you'll want to compare two different compiler versions. For example, you
 might have two clones of the rustc repository: one that is unmodified, and a
@@ -127,30 +131,26 @@ second that contains a branch of your changes. To compare the two versions, do
 something like this:
 
 ```
-./target/release/collector --db timings.db \
-    bench_local --rustc $RUST_TIP --cargo `which cargo` Orig
+./target/release/collector bench_local $RUST_ORIGINAL Original
 
-./target/release/collector --db timings.db \
-    bench_local --rustc $RUST_MODIFIED --cargo `which cargo` Modified
+./target/release/collector bench_local $RUST_MODIFIED Modified
 ```
 
-where `$RUST_TIP` and `$RUST_MODIFIED` are paths (relative or absolute) to the
-relevant rustc executables. The `--db` argument must be the same in
-each invocation.
+where `$RUST_ORIGINAL` and `$RUST_MODIFIED` are paths (relative or absolute) to
+the relevant rustc executables.
 
 ### How to view the measurements on your own machine
 
 Once the benchmarks have been run, start the website:
 ```
-./target/release/site $DATABASE
+./target/release/site <DATABASE>
 ```
-and visit `localhost:2346/compare.html` in a web browser.
-
-Wait for the "Loading complete" message; it should come within a couple dozen
-seconds (or faster, depending on how much data you've collected).
+wait for the "Loading complete" message to be printed, and then visit
+`localhost:2346/compare.html` in a web browser.
 
 Enter the IDs for two runs in the "Commit/Date A" and "Commit/Date B" text
-boxes (the two IDs can be the same) and click on "Submit".
+boxes and click on "Submit". You can enter the same ID twice, though in that
+case you won't be shown any percentage differences.
 
 If you've collected new data, you can run `curl -X POST
 localhost:2346/perf/onpush` to update the site's view of the data, or just
@@ -190,28 +190,19 @@ Without this you won't get useful file names and line numbers in the output.
 
 ### Profiling local builds
 
-To self-profile a local build:
+To profile a local rustc with one of several profilers:
 ```
-./target/release/collector --db $DATABASE --self-profile \
-    bench_local --rustc $RUSTC --cargo $CARGO $ID
+./target/release/collector profile_local <PROFILER> <RUSTC> <ID>
 ```
+It will profile the entire suite and put the results in a directory called
+`results/`.
 
-Then view the results the same way as for the `bench_local` subcommand.
-
-To profile a local build with a different profiler:
-```
-./target/release/collector profile $PROFILER \
-    --output $OUTPUT_DIR --rustc $RUSTC --cargo $CARGO $ID
-```
-
-This is similar to the `bench_local` subcommand, with a couple of exceptions.
-First, `$OUTPUT_DIR` is a directory in which the output will be placed. If the
-directory doesn't exist, it will be created.
-
-Second, `$PROFILER` is one of the following.
+The mandatory `<PROFILER>` argument must be one of the following.
 - `self-profile`: Profile with rustc's `-Zself-profile`.
   - **Purpose**. This gives multiple high-level views of compiler performance,
-    in both tabular and graphical form.
+    in both tabular and graphical form. It is related to, but distinct from,
+    the profiling done by the `--self-profiling` option of the `bench_local`
+    subcommand.
   - **Slowdown**. Minimal.
   - **Output**. Raw output is written to a directory with a `Zsp` prefix.
     The files in that directory can be processed with various
@@ -258,7 +249,7 @@ Second, `$PROFILER` is one of the following.
     Cachegrind's results are almost deterministic, which eases comparisons
     across multiple runs.
   - **Slowdown**. Roughly 3--10x.
-  - **Configuration**. Within `profile`, Cachegrind is configured to not
+  - **Configuration**. Within `profile_local`, Cachegrind is configured to not
     simulate caches and the branch predictor, even though it can, because the
     simulation slows it down and 99% of the time instruction counts are all you
     need.
@@ -276,7 +267,7 @@ Second, `$PROFILER` is one of the following.
     function call information. So it can be used like either Cachegrind or
     `perf-record`. However, it cannot perform diffs between profiles.
   - **Slowdown**. Roughly 5--20x.
-  - **Configuration**. Like Cachegrind, within `profile` Callgrind is
+  - **Configuration**. Like Cachegrind, within `profile_local` Callgrind is
     configured to not simulate caches and the branch predictor.
   - **Output**. Raw output is written to files with a `clgout` prefix; those
     files can be viewed with the graphical
@@ -294,13 +285,13 @@ Second, `$PROFILER` is one of the following.
   - **Slowdown**. Roughly 5--20x.
   - **Prerequisites**. DHAT may require a rustc configured with `jemalloc =
     false` to work well.
-  - **Configuration**. DHAT is configured within `profile` to run with the
-    non-default `--num-callers=4` option, which dictates stack depths. (This
-    value of 4 does not include inlined stack frames, so in practice the depths
-    of stack traces are a lot more than 4.) This is almost always enough, but
-    on the rare occasion it isn't, you can the value in `rustc-fake.rs` and
-    rebuild `collector`. Note that higher values make DHAT run more slowly and
-    increase the size of its data files.
+  - **Configuration**. DHAT is configured within `profile_local` to run with
+    the non-default `--num-callers=4` option, which dictates stack depths.
+    (This value of 4 does not include inlined stack frames, so in practice the
+    depths of stack traces are a lot more than 4.) This is almost always
+    enough, but on the rare occasion it isn't, you can change the value in
+    `rustc-fake.rs` and rebuild `collector`. Note that higher values make DHAT
+    run more slowly and increase the size of its data files.
   - **Output**. Raw output is written to files with a `dhout` prefix. Those
     files can be viewed with DHAT's viewer (`dh_view.html`).
 - `massif`: Profile with
@@ -336,6 +327,24 @@ Second, `$PROFILER` is one of the following.
   - **Notes**. Does not work with the `Check` build kind. Also does not work
     with the `IncrFull`, `IncrUnchanged`, and `IncrPatched` run kinds.
 
+The mandatory `<RUSTC>` argument is a patch to a rustc executable, similar to
+`bench_local`.
+
+The mandatory `<ID>` argument is an identifer that will form part of the
+output filenames.
+
 ### Profiling options
 
-These are the same as the benchmarking options above.
+The following options alter the behaviour of the `profile_local` subcommand.
+- `--builds <BUILDS>`: as for `bench_local`.
+- `--cargo <CARGO>`: as for `bench_local`.
+- `--exclude <EXCLUDE>`: as for `bench_local`.
+- `--include <INCLUDE>`: as for `bench_local`.
+- `--out-dir <OUT_DIR>`: a path (relative or absolute) to a directory in
+  which the output will be placed. If the directory doesn't exist, it will be
+  created. The default is `results/`.
+- `--runs <RUNS>`: as for `bench_local`.
+- `--rustdoc <RUSTDOC>` as for `bench_local`.
+
+`RUST_LOG=debug` can be specified to enable verbose logging, which is useful
+for debugging `collector` itself.

--- a/collector/benchmarks/README.md
+++ b/collector/benchmarks/README.md
@@ -3,6 +3,10 @@
 This file describes the programs in the benchmark suite and explains why they
 were included.
 
+The suite changes over time. Sometimes the code for a benchmark is updated, in
+which case a small suffix will be added (starting with "-2", then "-3", and so
+on.)
+
 ## Real programs that are important
 
 These are real programs that are important in some way, and worth tracking.
@@ -20,7 +24,7 @@ These are real programs that are important in some way, and worth tracking.
 - **piston-image**: A modular game engine. An interesting Rust program.
 - **regex**: A regular expression parser. Used by many Rust programs.
 - **ripgrep**: A line-oriented search tool. A widely-used utility.
-- **script-servo**: Servo's `script` crate. A particularly large crate. At
+- **script-servo-2**: Servo's `script` crate. A particularly large crate. At
 5ad7e5b4fbd58, with [PR#27063](https://github.com/servo/servo/pull/27063)
 applied atop.
 - **serde**: A serialization/deserialization crate. Used by many other

--- a/collector/src/execute.rs
+++ b/collector/src/execute.rs
@@ -1,7 +1,7 @@
 //! Execute benchmarks.
 
 use crate::{BuildKind, Compiler, RunKind};
-use anyhow::{bail, Context};
+use anyhow::{anyhow, bail, Context};
 use collector::command_output;
 use database::{PatchName, QueryLabel};
 use futures::stream::FuturesUnordered;
@@ -97,21 +97,13 @@ pub enum Profiler {
     LlvmLines,
 }
 
-#[derive(thiserror::Error, PartialEq, Eq, Debug)]
-pub enum FromNameError {
-    #[error("'perf-stat' cannot be used as the profiler")]
-    PerfStat,
-    #[error("'{:?}' is not a known profiler", .0)]
-    UnknownProfiler(String),
-}
-
 impl Profiler {
-    pub fn from_name(name: &str) -> Result<Profiler, FromNameError> {
+    pub fn from_name(name: &str) -> anyhow::Result<Profiler> {
         match name {
             // Even though `PerfStat` is a valid `Profiler` value, "perf-stat"
             // is rejected because it can't be used with the `profiler`
             // subcommand. (It's used with `bench_local` instead.)
-            "perf-stat" => Err(FromNameError::PerfStat),
+            "perf-stat" => Err(anyhow!("'perf-stat' cannot be used as the profiler")),
             "self-profile" => Ok(Profiler::SelfProfile),
             "time-passes" => Ok(Profiler::TimePasses),
             "perf-record" => Ok(Profiler::PerfRecord),
@@ -122,7 +114,7 @@ impl Profiler {
             "massif" => Ok(Profiler::Massif),
             "eprintln" => Ok(Profiler::Eprintln),
             "llvm-lines" => Ok(Profiler::LlvmLines),
-            _ => Err(FromNameError::UnknownProfiler(name.to_string())),
+            _ => Err(anyhow!("'{}' is not a known profiler", name)),
         }
     }
 

--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -456,90 +456,90 @@ fn main_result() -> anyhow::Result<i32> {
     env_logger::init();
 
     let matches = clap_app!(rustc_perf_collector =>
-       (version: "0.1")
-       (author: "The Rust Compiler Team")
-       (about: "Collects Rust performance data")
+        (version: "0.1")
+        (author: "The Rust Compiler Team")
+        (about: "Collects Rust performance data")
 
-        // For each subcommand we list the mandatory arguments in the required
-        // order, followed by the options in alphabetical order.
+         // For each subcommand we list the mandatory arguments in the required
+         // order, followed by the options in alphabetical order.
 
-       (@subcommand bench_local =>
-           (about: "Benchmarks a local rustc")
+        (@subcommand bench_local =>
+            (about: "Benchmarks a local rustc")
 
-           // Mandatory arguments
-           (@arg RUSTC: +required +takes_value "The path to the local rustc to benchmark")
-           (@arg ID:    +required +takes_value "Identifier to associate benchmark results with")
-
-           // Options
-           (@arg BUILDS:  --builds  +takes_value
-            "One or more (comma-separated) of: 'Check', 'Debug',\n\
-            'Doc', 'Opt', 'All'")
-           (@arg CARGO:   --cargo   +takes_value "The path to the local Cargo to use")
-           (@arg DB:      --db      +takes_value "Database output file")
-           (@arg EXCLUDE: --exclude +takes_value "Exclude benchmarks matching these")
-           (@arg INCLUDE: --include +takes_value "Include benchmarks matching these")
-           (@arg RUNS:    --runs    +takes_value
-            "One or more (comma-separated) of: 'Full',\n\
-            'IncrFull', 'IncrUnchanged', 'IncrPatched', 'All'")
-           (@arg RUSTDOC: --rustdoc +takes_value "The path to the local rustdoc to benchmark")
-           (@arg SELF_PROFILE: --("self-profile") "Collect self-profile data")
-       )
-
-       (@subcommand bench_next =>
-           (about: "Benchmarks the next commit for perf.rust-lang.org")
-
-           // Mandatory arguments
-           (@arg SITE_URL: +required +takes_value "Site URL")
-
-           // Options
-           (@arg DB:           --db  +takes_value "Database output file")
-           (@arg SELF_PROFILE: --("self-profile") "Collect self-profile data")
-       )
-
-       (@subcommand bench_published =>
-           (about: "Benchmarks a published toolchain for perf.rust-lang.org's dashboard")
-
-           // Mandatory arguments
-           (@arg TOOLCHAIN: +required +takes_value "Toolchain (e.g. stable, beta, 1.26.0)")
-
-           // Options
-           (@arg DB: --db +takes_value "Database output file")
-       )
-
-       (@subcommand bench_test =>
-           (about: "Benchmarks the most recent commit for testing purposes")
-
-           // Mandatory arguments: (none)
-
-           // Options
-           (@arg DB:      --db      +takes_value "Database output file")
-           (@arg EXCLUDE: --exclude +takes_value "Exclude benchmarks matching these")
-           (@arg INCLUDE: --include +takes_value "Include benchmarks matching these")
-       )
-
-       (@subcommand profile_local =>
-           (about: "Profiles a local rustc with one of several profilers")
-
-           // Mandatory arguments
-           (@arg PROFILER: +required +takes_value
-            "One of: 'self-profile', 'time-passes', 'perf-record',\n\
-            'cachegrind', 'callgrind', ''dhat', 'massif', 'eprintln'")
-           (@arg RUSTC:    +required +takes_value "The path to the local rustc to benchmark")
-           (@arg ID:       +required +takes_value "Identifier to associate benchmark results with")
+            // Mandatory arguments
+            (@arg RUSTC: +required +takes_value "The path to the local rustc to benchmark")
+            (@arg ID:    +required +takes_value "Identifier to associate benchmark results with")
 
             // Options
-           (@arg BUILDS: --builds       +takes_value
-            "One or more (comma-separated) of: 'Check', 'Debug',\n\
-            'Doc', 'Opt', 'All'")
-           (@arg CARGO:   --cargo       +takes_value "The path to the local Cargo to use")
-           (@arg EXCLUDE: --exclude     +takes_value "Exclude benchmarks matching these")
-           (@arg INCLUDE: --include     +takes_value "Include benchmarks matching these")
-           (@arg OUT_DIR: --("out-dir") +takes_value "Output directory")
-           (@arg RUNS:    --runs        +takes_value
-            "One or more (comma-separated) of: 'Full',\n\
-            'IncrFull', 'IncrUnchanged', 'IncrPatched', 'All'")
-           (@arg RUSTDOC: --rustdoc +takes_value "The path to the local rustdoc to benchmark")
-       )
+            (@arg BUILDS:  --builds  +takes_value
+             "One or more (comma-separated) of: 'Check', 'Debug',\n\
+             'Doc', 'Opt', 'All'")
+            (@arg CARGO:   --cargo   +takes_value "The path to the local Cargo to use")
+            (@arg DB:      --db      +takes_value "Database output file")
+            (@arg EXCLUDE: --exclude +takes_value "Exclude benchmarks matching these")
+            (@arg INCLUDE: --include +takes_value "Include benchmarks matching these")
+            (@arg RUNS:    --runs    +takes_value
+             "One or more (comma-separated) of: 'Full',\n\
+             'IncrFull', 'IncrUnchanged', 'IncrPatched', 'All'")
+            (@arg RUSTDOC: --rustdoc +takes_value "The path to the local rustdoc to benchmark")
+            (@arg SELF_PROFILE: --("self-profile") "Collect self-profile data")
+        )
+
+        (@subcommand bench_next =>
+            (about: "Benchmarks the next commit for perf.rust-lang.org")
+
+            // Mandatory arguments
+            (@arg SITE_URL: +required +takes_value "Site URL")
+
+            // Options
+            (@arg DB:           --db  +takes_value "Database output file")
+            (@arg SELF_PROFILE: --("self-profile") "Collect self-profile data")
+        )
+
+        (@subcommand bench_published =>
+            (about: "Benchmarks a published toolchain for perf.rust-lang.org's dashboard")
+
+            // Mandatory arguments
+            (@arg TOOLCHAIN: +required +takes_value "Toolchain (e.g. stable, beta, 1.26.0)")
+
+            // Options
+            (@arg DB: --db +takes_value "Database output file")
+        )
+
+        (@subcommand bench_test =>
+            (about: "Benchmarks the most recent commit for testing purposes")
+
+            // Mandatory arguments: (none)
+
+            // Options
+            (@arg DB:      --db      +takes_value "Database output file")
+            (@arg EXCLUDE: --exclude +takes_value "Exclude benchmarks matching these")
+            (@arg INCLUDE: --include +takes_value "Include benchmarks matching these")
+        )
+
+        (@subcommand profile_local =>
+            (about: "Profiles a local rustc with one of several profilers")
+
+            // Mandatory arguments
+            (@arg PROFILER: +required +takes_value
+             "One of: 'self-profile', 'time-passes', 'perf-record',\n\
+             'cachegrind', 'callgrind', ''dhat', 'massif', 'eprintln'")
+            (@arg RUSTC:    +required +takes_value "The path to the local rustc to benchmark")
+            (@arg ID:       +required +takes_value "Identifier to associate benchmark results with")
+
+             // Options
+            (@arg BUILDS: --builds       +takes_value
+             "One or more (comma-separated) of: 'Check', 'Debug',\n\
+             'Doc', 'Opt', 'All'")
+            (@arg CARGO:   --cargo       +takes_value "The path to the local Cargo to use")
+            (@arg EXCLUDE: --exclude     +takes_value "Exclude benchmarks matching these")
+            (@arg INCLUDE: --include     +takes_value "Include benchmarks matching these")
+            (@arg OUT_DIR: --("out-dir") +takes_value "Output directory")
+            (@arg RUNS:    --runs        +takes_value
+             "One or more (comma-separated) of: 'Full',\n\
+             'IncrFull', 'IncrUnchanged', 'IncrPatched', 'All'")
+            (@arg RUSTDOC: --rustdoc +takes_value "The path to the local rustdoc to benchmark")
+        )
     )
     .get_matches();
 

--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -8,7 +8,6 @@ use collector::api::collected;
 use database::{pool::Connection, ArtifactId, Commit};
 use log::{debug, error};
 use std::collections::HashSet;
-use std::env;
 use std::fs;
 use std::io::{stderr, Write};
 use std::path::{Path, PathBuf};
@@ -63,6 +62,11 @@ impl BuildKind {
             BuildKind::Opt,
         ]
     }
+
+    fn default() -> Vec<Self> {
+        // Don't run rustdoc by default.
+        vec![BuildKind::Check, BuildKind::Debug, BuildKind::Opt]
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -85,6 +89,10 @@ impl RunKind {
 
     fn all_non_incr() -> Vec<RunKind> {
         vec![RunKind::Full]
+    }
+
+    fn default() -> Vec<RunKind> {
+        Self::all()
     }
 }
 
@@ -114,8 +122,7 @@ pub fn build_kinds_from_arg(arg: &Option<&str>) -> Result<Vec<BuildKind>, KindEr
     if let Some(arg) = arg {
         kinds_from_arg(STRINGS_AND_BUILD_KINDS, arg)
     } else {
-        // don't run rustdoc by default
-        Ok(vec![BuildKind::Check, BuildKind::Debug, BuildKind::Opt])
+        Ok(BuildKind::default())
     }
 }
 
@@ -123,7 +130,7 @@ pub fn run_kinds_from_arg(arg: &Option<&str>) -> Result<Vec<RunKind>, KindError>
     if let Some(arg) = arg {
         kinds_from_arg(STRINGS_AND_RUN_KINDS, arg)
     } else {
-        Ok(RunKind::all())
+        Ok(RunKind::default())
     }
 }
 
@@ -157,8 +164,9 @@ where
     Ok(v)
 }
 
-fn process(
+fn bench_next(
     rt: &mut Runtime,
+    site_url: &str,
     pool: &database::Pool,
     benchmarks: &[Benchmark],
     self_profile: bool,
@@ -166,10 +174,7 @@ fn process(
     println!("processing commits");
     let client = reqwest::blocking::Client::new();
     let commit: Option<String> = client
-        .get(&format!(
-            "{}/perf/next_commit",
-            env::var("SITE_URL").expect("SITE_URL defined")
-        ))
+        .get(&format!("{}/perf/next_commit", site_url))
         .send()?
         .json()?;
     let commit = if let Some(c) = commit {
@@ -192,7 +197,7 @@ fn process(
                 Compiler::from_sysroot(&sysroot),
                 &benchmarks,
                 3,
-                true,
+                /* call_home */ true,
                 self_profile,
             );
         }
@@ -201,12 +206,7 @@ fn process(
         }
     }
 
-    client
-        .post(&format!(
-            "{}/perf/onpush",
-            env::var("SITE_URL").expect("SITE_URL defined")
-        ))
-        .send()?;
+    client.post(&format!("{}/perf/onpush", site_url)).send()?;
 
     Ok(())
 }
@@ -239,11 +239,6 @@ fn bench(
     call_home: bool,
     self_profile: bool,
 ) -> BenchmarkErrors {
-    if compiler.rustdoc.is_none() && build_kinds.iter().any(|b| *b == BuildKind::Doc) {
-        eprintln!("Rustdoc build specified but rustdoc path not provided");
-        std::process::exit(1);
-    }
-
     let mut errors_recorded = 0;
     eprintln!("Benchmarking {} for triple {}", cid, compiler.triple);
 
@@ -272,7 +267,7 @@ fn bench(
         ArtifactId::Artifact(id) => index.artifacts().any(|a| a == id),
     };
     if has_collected {
-        eprintln!("{} has previously been collected, skipping.", cid);
+        eprintln!("'{}' has previously been collected, aborting.", cid);
         eprintln!(
             "Note that this behavior is likely to change in the future \
             to collect and append the data instead."
@@ -301,7 +296,10 @@ fn bench(
         let result =
             benchmark.measure(&mut processor, build_kinds, run_kinds, compiler, iterations);
         if let Err(s) = result {
-            eprintln!("Failed to benchmark {}, recorded: {}", benchmark.name, s);
+            eprintln!(
+                "collector error: Failed to benchmark '{}', recorded: {}",
+                benchmark.name, s
+            );
             errors_recorded += 1;
             rt.block_on(tx.conn().record_error(
                 interned_cid,
@@ -337,7 +335,7 @@ fn get_benchmarks(
 ) -> anyhow::Result<Vec<Benchmark>> {
     let mut benchmarks = Vec::new();
     'outer: for entry in fs::read_dir(benchmark_dir)
-        .with_context(|| format!("failed to list benchmark dir {}", benchmark_dir.display()))?
+        .with_context(|| format!("failed to list benchmark dir '{}'", benchmark_dir.display()))?
     {
         let entry = entry?;
         let path = entry.path();
@@ -386,11 +384,71 @@ fn get_benchmarks(
     Ok(benchmarks)
 }
 
+/// Get a toolchain from the input.
+/// - `rustc`: check if the given one is acceptable.
+/// - `rustdoc`: if one is given, check if it is acceptable. Otherwise, if
+///   `Doc` builds are requested, look for one next to the given `rustc`.
+/// - `cargo`: if one is given, check if it is acceptable. Otherwise, look
+///   for the nightly Cargo via `rustup`.
+fn get_local_toolchain(
+    build_kinds: &[BuildKind],
+    rustc: &str,
+    rustdoc: Option<&str>,
+    cargo: Option<&str>,
+) -> anyhow::Result<(PathBuf, Option<PathBuf>, PathBuf)> {
+    let rustc = PathBuf::from(rustc)
+        .canonicalize()
+        .with_context(|| format!("failed to canonicalize rustc executable '{}'", rustc))?;
+
+    let rustdoc =
+        if let Some(rustdoc) = rustdoc {
+            Some(PathBuf::from(rustdoc).canonicalize().with_context(|| {
+                format!("failed to canonicalize rustdoc executable '{}'", rustdoc)
+            })?)
+        } else if build_kinds.contains(&BuildKind::Doc) {
+            // We need a `rustdoc`. Look for one next to `rustc`.
+            if let Ok(rustdoc) = rustc.with_file_name("rustdoc").canonicalize() {
+                debug!("found rustdoc: {:?}", &rustdoc);
+                Some(rustdoc)
+            } else {
+                anyhow::bail!(
+                    "'Doc' build specified but '--rustdoc' not specified and no 'rustdoc' found \
+                    next to 'rustc'"
+                );
+            }
+        } else {
+            // No `rustdoc` provided, but none needed.
+            None
+        };
+
+    let cargo = if let Some(cargo) = cargo {
+        PathBuf::from(cargo)
+            .canonicalize()
+            .with_context(|| format!("failed to canonicalize cargo executable '{}'", cargo))?
+    } else {
+        // Use the nightly cargo from `rustup`.
+        let s = String::from_utf8(
+            Command::new("rustup")
+                .args(&["which", "cargo", "--toolchain=nightly"])
+                .output()
+                .context("failed to run `rustup which cargo`")?
+                .stdout,
+        )
+        .context("failed to convert `rustup which cargo` output to utf8")?;
+
+        let cargo = PathBuf::from(s.trim());
+        debug!("found cargo: {:?}", &cargo);
+        cargo
+    };
+
+    Ok((rustc, rustdoc, cargo))
+}
+
 fn main() {
     match main_result() {
         Ok(code) => process::exit(code),
         Err(err) => {
-            eprintln!("{:#}\n{}", err, err.backtrace());
+            eprintln!("collector error: {:#}\n{}", err, err.backtrace());
             process::exit(1);
         }
     }
@@ -404,59 +462,90 @@ fn main_result() -> anyhow::Result<i32> {
        (author: "The Rust Compiler Team")
        (about: "Collects Rust performance data")
 
-       (@arg INCLUDE: --include +takes_value "Include benchmarks matching these")
-       (@arg EXCLUDE: --exclude +takes_value "Exclude benchmarks matching these")
-       (@arg DB: --db +takes_value "Database file")
-       (@arg SELF_PROFILE: --("self-profile") "Collect self-profile")
+        // For each subcommand we list the mandatory arguments in the required
+        // order, followed by the options in alphabetical order.
 
        (@subcommand bench_local =>
            (about: "Benchmarks a local rustc")
-           (@arg RUSTC: --rustc +required +takes_value "The path to the local rustc to benchmark")
-           (@arg RUSTDOC: --rustdoc +takes_value "The path to the local rustdoc to benchmark")
-           (@arg CARGO: --cargo +required +takes_value "The path to the local Cargo to use")
-           (@arg BUILDS: --builds +takes_value
+
+           // Mandatory arguments
+           (@arg RUSTC: +required +takes_value "The path to the local rustc to benchmark")
+           (@arg ID:    +required +takes_value "Identifier to associate benchmark results with")
+
+           // Options
+           (@arg BUILDS:  --builds  +takes_value
             "One or more (comma-separated) of: 'Check', 'Debug',\n\
             'Doc', 'Opt', 'All'")
-           (@arg RUNS: --runs +takes_value
+           (@arg CARGO:   --cargo   +takes_value "The path to the local Cargo to use")
+           (@arg DB:      --db      +takes_value "Database output file")
+           (@arg EXCLUDE: --exclude +takes_value "Exclude benchmarks matching these")
+           (@arg INCLUDE: --include +takes_value "Include benchmarks matching these")
+           (@arg RUNS:    --runs    +takes_value
             "One or more (comma-separated) of: 'Full',\n\
             'IncrFull', 'IncrUnchanged', 'IncrPatched', 'All'")
-           (@arg ID: +required +takes_value "Identifier to associate benchmark results with")
+           (@arg RUSTDOC: --rustdoc +takes_value "The path to the local rustdoc to benchmark")
+           (@arg SELF_PROFILE: --("self-profile") "Collect self-profile data")
        )
+
+       (@subcommand bench_next =>
+           (about: "Benchmarks the next commit for perf.rust-lang.org")
+
+           // Mandatory arguments
+           (@arg SITE_URL: +required +takes_value "Site URL")
+
+           // Options
+           (@arg DB:           --db  +takes_value "Database output file")
+           (@arg SELF_PROFILE: --("self-profile") "Collect self-profile data")
+       )
+
        (@subcommand bench_published =>
-           (about: "Benchmarks a specified toolchain")
-           (@arg TOOLCHAIN: +required +takes_value "Toolchain to install (e.g. stable, beta, 1.26.0)")
+           (about: "Benchmarks a published toolchain for perf.rust-lang.org's dashboard")
+
+           // Mandatory arguments
+           (@arg TOOLCHAIN: +required +takes_value "Toolchain (e.g. stable, beta, 1.26.0)")
+
+           // Options
+           (@arg DB: --db +takes_value "Database output file")
        )
+
        (@subcommand bench_test =>
            (about: "Benchmarks the most recent commit for testing purposes")
+
+           // Mandatory arguments: (none)
+
+           // Options
+           (@arg DB:      --db      +takes_value "Database output file")
+           (@arg EXCLUDE: --exclude +takes_value "Exclude benchmarks matching these")
+           (@arg INCLUDE: --include +takes_value "Include benchmarks matching these")
        )
-       (@subcommand process =>
-           (about: "Syncs to git and collects performance data for all versions")
-       )
-       (@subcommand profile =>
-           (about: "Profiles a local rustc")
-           (@arg OUTPUT: --output +required +takes_value "Output directory")
-           (@arg RUSTC: --rustc +required +takes_value "The path to the local rustc to benchmark")
-           (@arg RUSTDOC: --rustdoc +takes_value "The path to the local rustdoc to benchmark")
-           (@arg CARGO: --cargo +required +takes_value "The path to the local Cargo to use")
-           (@arg BUILDS: --builds +takes_value
-            "One or more (comma-separated) of: 'Check', 'Debug',\n\
-            'Opt', 'All'")
-           (@arg RUNS: --runs +takes_value
-            "One or more (comma-separated) of: 'Full',\n\
-            'IncrFull', 'IncrUnchanged', 'IncrPatched', 'All'")
+
+       (@subcommand profile_local =>
+           (about: "Profiles a local rustc with one of several profilers")
+
+           // Mandatory arguments
            (@arg PROFILER: +required +takes_value
             "One of: 'self-profile', 'time-passes', 'perf-record',\n\
             'cachegrind', 'callgrind', ''dhat', 'massif', 'eprintln'")
-           (@arg ID: +required +takes_value "Identifier to associate benchmark results with")
+           (@arg RUSTC:    +required +takes_value "The path to the local rustc to benchmark")
+           (@arg ID:       +required +takes_value "Identifier to associate benchmark results with")
+
+            // Options
+           (@arg BUILDS: --builds       +takes_value
+            "One or more (comma-separated) of: 'Check', 'Debug',\n\
+            'Doc', 'Opt', 'All'")
+           (@arg CARGO:   --cargo       +takes_value "The path to the local Cargo to use")
+           (@arg EXCLUDE: --exclude     +takes_value "Exclude benchmarks matching these")
+           (@arg INCLUDE: --include     +takes_value "Include benchmarks matching these")
+           (@arg OUT_DIR: --("out-dir") +takes_value "Output directory")
+           (@arg RUNS:    --runs        +takes_value
+            "One or more (comma-separated) of: 'Full',\n\
+            'IncrFull', 'IncrUnchanged', 'IncrPatched', 'All'")
+           (@arg RUSTDOC: --rustdoc +takes_value "The path to the local rustdoc to benchmark")
        )
     )
     .get_matches();
 
     let benchmark_dir = PathBuf::from("collector/benchmarks");
-    let include = matches.value_of("INCLUDE");
-    let exclude = matches.value_of("EXCLUDE");
-    let mut benchmarks = get_benchmarks(&benchmark_dir, include, exclude)?;
-    let self_profile = matches.is_present("SELF_PROFILE");
 
     let mut builder = tokio::runtime::Builder::new();
     // We want to minimize noise from the runtime
@@ -467,25 +556,32 @@ fn main_result() -> anyhow::Result<i32> {
         .basic_scheduler();
     let mut rt = builder.build().expect("built runtime");
 
-    let pool = matches.value_of("DB").map(|db| database::Pool::open(db));
+    let default_db = "results.db";
+    let default_out_dir = std::ffi::OsStr::new("results");
 
     let ret = match matches.subcommand() {
         ("bench_local", Some(sub_m)) => {
+            // Mandatory arguments
             let rustc = sub_m.value_of("RUSTC").unwrap();
-            let rustdoc = sub_m.value_of("RUSTDOC");
-            let cargo = sub_m.value_of("CARGO").unwrap();
-            let build_kinds = build_kinds_from_arg(&sub_m.value_of("BUILDS"))?;
-            let run_kinds = run_kinds_from_arg(&sub_m.value_of("RUNS"))?;
             let id = sub_m.value_of("ID").unwrap();
 
-            let rustc_path = PathBuf::from(rustc).canonicalize()?;
-            let rustdoc_path = if let Some(r) = rustdoc {
-                Some(PathBuf::from(r).canonicalize()?)
-            } else {
-                None
-            };
-            let cargo_path = PathBuf::from(cargo).canonicalize()?;
-            let conn = rt.block_on(pool.expect("--db passed").connection());
+            // Options
+            let build_kinds = build_kinds_from_arg(&sub_m.value_of("BUILDS"))?;
+            let cargo = sub_m.value_of("CARGO");
+            let db = sub_m.value_of("DB").unwrap_or(default_db);
+            let exclude = sub_m.value_of("EXCLUDE");
+            let include = sub_m.value_of("INCLUDE");
+            let run_kinds = run_kinds_from_arg(&sub_m.value_of("RUNS"))?;
+            let rustdoc = sub_m.value_of("RUSTDOC");
+            let self_profile = sub_m.is_present("SELF_PROFILE");
+
+            let pool = database::Pool::open(db);
+            let conn = rt.block_on(pool.connection());
+
+            let (rustc, rustdoc, cargo) = get_local_toolchain(&build_kinds, rustc, rustdoc, cargo)?;
+
+            let benchmarks = get_benchmarks(&benchmark_dir, include, exclude)?;
+
             bench(
                 &mut rt,
                 conn,
@@ -493,22 +589,43 @@ fn main_result() -> anyhow::Result<i32> {
                 &build_kinds,
                 &run_kinds,
                 Compiler {
-                    rustc: &rustc_path,
-                    rustdoc: rustdoc_path.as_deref(),
-                    cargo: &cargo_path,
-                    triple: "x86_64-unknown-linux-gnu",
+                    rustc: &rustc,
+                    rustdoc: rustdoc.as_deref(),
+                    cargo: &cargo,
+                    triple: "x86_64-unknown-linux-gnu", // XXX: technically not necessarily true
                     is_nightly: true,
                 },
                 &benchmarks,
                 1,
-                false,
+                /* call_home */ false,
                 self_profile,
             );
             Ok(0)
         }
 
+        ("bench_next", Some(sub_m)) => {
+            // Mandatory arguments
+            let site_url = sub_m.value_of("SITE_URL").unwrap();
+
+            // Options
+            let db = sub_m.value_of("DB").unwrap_or(default_db);
+            let self_profile = sub_m.is_present("SELF_PROFILE");
+
+            let pool = database::Pool::open(db);
+
+            let benchmarks = get_benchmarks(&benchmark_dir, None, None)?;
+
+            bench_next(&mut rt, &site_url, &pool, &benchmarks, self_profile)?;
+            Ok(0)
+        }
+
         ("bench_published", Some(sub_m)) => {
+            // Mandatory arguments
             let toolchain = sub_m.value_of("TOOLCHAIN").unwrap();
+
+            // Options
+            let db = sub_m.value_of("DB").unwrap_or(default_db);
+
             let status = Command::new("rustup")
                 .args(&["install", "--profile=minimal", &toolchain])
                 .status()
@@ -516,6 +633,15 @@ fn main_result() -> anyhow::Result<i32> {
             if !status.success() {
                 anyhow::bail!("failed to install toolchain for {}", toolchain);
             }
+
+            let pool = database::Pool::open(db);
+            let conn = rt.block_on(pool.connection());
+
+            let run_kinds = if collector::version_supports_incremental(toolchain) {
+                RunKind::all()
+            } else {
+                RunKind::all_non_incr()
+            };
 
             let which = |tool| {
                 String::from_utf8(
@@ -534,15 +660,10 @@ fn main_result() -> anyhow::Result<i32> {
             let rustdoc = which("rustdoc")?;
             let cargo = which("cargo")?;
 
-            // Remove benchmarks that don't work with a stable compiler.
+            // Exclude benchmarks that don't work with a stable compiler.
+            let mut benchmarks = get_benchmarks(&benchmark_dir, None, None)?;
             benchmarks.retain(|b| b.supports_stable());
 
-            let run_kinds = if collector::version_supports_incremental(toolchain) {
-                RunKind::all()
-            } else {
-                RunKind::all_non_incr()
-            };
-            let conn = rt.block_on(pool.expect("--db passed").connection());
             bench(
                 &mut rt,
                 conn,
@@ -558,13 +679,23 @@ fn main_result() -> anyhow::Result<i32> {
                 },
                 &benchmarks,
                 3,
-                false,
-                false,
+                /* call_home */ false,
+                /* self_profile */ false,
             );
             Ok(0)
         }
 
-        ("bench_test", Some(_)) => {
+        ("bench_test", Some(sub_m)) => {
+            // Mandatory arguments: (none)
+
+            // Options
+            let db = sub_m.value_of("DB").unwrap_or(default_db);
+            let exclude = sub_m.value_of("EXCLUDE");
+            let include = sub_m.value_of("INCLUDE");
+
+            let pool = database::Pool::open(db);
+            let conn = rt.block_on(pool.connection());
+
             let last_sha = Command::new("git")
                 .arg("ls-remote")
                 .arg("https://github.com/rust-lang/rust.git")
@@ -575,7 +706,9 @@ fn main_result() -> anyhow::Result<i32> {
             let last_sha = last_sha.split_whitespace().next().expect(&last_sha);
             let commit = get_commit_or_fake_it(&last_sha).expect("success");
             let sysroot = Sysroot::install(commit.sha.to_string(), "x86_64-unknown-linux-gnu")?;
-            let conn = rt.block_on(pool.expect("--db passed").connection());
+
+            let benchmarks = get_benchmarks(&benchmark_dir, include, exclude)?;
+
             let res = bench(
                 &mut rt,
                 conn,
@@ -585,49 +718,41 @@ fn main_result() -> anyhow::Result<i32> {
                 Compiler::from_sysroot(&sysroot),
                 &benchmarks,
                 1,
-                false,
-                self_profile,
+                /* call_home */ false,
+                /* self_profile */ false,
             );
             res.fail_if_error()?;
             Ok(0)
         }
 
-        ("process", Some(_)) => {
-            process(
-                &mut rt,
-                &pool.expect("--db passed"),
-                &benchmarks,
-                self_profile,
-            )?;
-            Ok(0)
-        }
-
-        ("profile", Some(sub_m)) => {
-            let rustc = sub_m.value_of("RUSTC").unwrap();
-            let rustdoc = sub_m.value_of("RUSTDOC");
-            let cargo = sub_m.value_of("CARGO").unwrap();
-            let build_kinds = build_kinds_from_arg(&sub_m.value_of("BUILDS"))?;
-            let run_kinds = run_kinds_from_arg(&sub_m.value_of("RUNS"))?;
+        ("profile_local", Some(sub_m)) => {
+            // Mandatory arguments
             let profiler = Profiler::from_name(sub_m.value_of("PROFILER").unwrap())?;
+            let rustc = sub_m.value_of("RUSTC").unwrap();
             let id = sub_m.value_of("ID").unwrap();
-            let out_dir = PathBuf::from(sub_m.value_of_os("OUTPUT").unwrap());
+
+            // Options
+            let build_kinds = build_kinds_from_arg(&sub_m.value_of("BUILDS"))?;
+            let cargo = sub_m.value_of("CARGO");
+            let exclude = sub_m.value_of("EXCLUDE");
+            let include = sub_m.value_of("INCLUDE");
+            let out_dir = PathBuf::from(sub_m.value_of_os("OUT_DIR").unwrap_or(default_out_dir));
+            let run_kinds = run_kinds_from_arg(&sub_m.value_of("RUNS"))?;
+            let rustdoc = sub_m.value_of("RUSTDOC");
+
+            let (rustc, rustdoc, cargo) = get_local_toolchain(&build_kinds, rustc, rustdoc, cargo)?;
+
+            let compiler = Compiler {
+                rustc: &rustc,
+                rustdoc: rustdoc.as_deref(),
+                cargo: &cargo,
+                triple: "x86_64-unknown-linux-gnu", // XXX: technically not necessarily true
+                is_nightly: true,
+            };
+
+            let benchmarks = get_benchmarks(&benchmark_dir, include, exclude)?;
 
             eprintln!("Profiling with {:?}", profiler);
-
-            let rustc_path = PathBuf::from(rustc).canonicalize()?;
-            let rustdoc_path = if let Some(r) = rustdoc {
-                Some(PathBuf::from(r).canonicalize()?)
-            } else {
-                None
-            };
-            let cargo_path = PathBuf::from(cargo).canonicalize()?;
-            let compiler = Compiler {
-                rustc: &rustc_path,
-                rustdoc: rustdoc_path.as_deref(),
-                cargo: &cargo_path,
-                is_nightly: true,
-                triple: "x86_64-unknown-linux-gnu", // XXX: Technically not necessarily true
-            };
 
             for (i, benchmark) in benchmarks.iter().enumerate() {
                 eprintln!("{}", n_benchmarks_remaining(benchmarks.len() - i));
@@ -636,7 +761,7 @@ fn main_result() -> anyhow::Result<i32> {
                     benchmark.measure(&mut processor, &build_kinds, &run_kinds, compiler, 1);
                 if let Err(ref s) = result {
                     eprintln!(
-                        "Failed to profile {} with {:?}, recorded: {:?}",
+                        "collector error: Failed to profile '{}' with {:?}, recorded: {:?}",
                         benchmark.name, profiler, s
                     );
                 }

--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -404,10 +404,10 @@ fn main_result() -> anyhow::Result<i32> {
        (author: "The Rust Compiler Team")
        (about: "Collects Rust performance data")
 
-       (@arg include: --include +takes_value "Include benchmarks matching these")
-       (@arg exclude: --exclude +takes_value "Exclude benchmarks matching these")
-       (@arg db: --("db") +takes_value "Database file")
-       (@arg self_profile: --("self-profile") "Collect self-profile")
+       (@arg INCLUDE: --include +takes_value "Include benchmarks matching these")
+       (@arg EXCLUDE: --exclude +takes_value "Exclude benchmarks matching these")
+       (@arg DB: --db +takes_value "Database file")
+       (@arg SELF_PROFILE: --("self-profile") "Collect self-profile")
 
        (@subcommand bench_local =>
            (about: "Benchmarks a local rustc")
@@ -434,7 +434,7 @@ fn main_result() -> anyhow::Result<i32> {
        )
        (@subcommand profile =>
            (about: "Profiles a local rustc")
-           (@arg output_dir: --("output") +required +takes_value "Output directory")
+           (@arg OUTPUT: --output +required +takes_value "Output directory")
            (@arg RUSTC: --rustc +required +takes_value "The path to the local rustc to benchmark")
            (@arg RUSTDOC: --rustdoc +takes_value "The path to the local rustdoc to benchmark")
            (@arg CARGO: --cargo +required +takes_value "The path to the local Cargo to use")
@@ -453,10 +453,10 @@ fn main_result() -> anyhow::Result<i32> {
     .get_matches();
 
     let benchmark_dir = PathBuf::from("collector/benchmarks");
-    let include = matches.value_of("include");
-    let exclude = matches.value_of("exclude");
+    let include = matches.value_of("INCLUDE");
+    let exclude = matches.value_of("EXCLUDE");
     let mut benchmarks = get_benchmarks(&benchmark_dir, include, exclude)?;
-    let self_profile = matches.is_present("self_profile");
+    let self_profile = matches.is_present("SELF_PROFILE");
 
     let mut builder = tokio::runtime::Builder::new();
     // We want to minimize noise from the runtime
@@ -467,7 +467,7 @@ fn main_result() -> anyhow::Result<i32> {
         .basic_scheduler();
     let mut rt = builder.build().expect("built runtime");
 
-    let pool = matches.value_of("db").map(|db| database::Pool::open(db));
+    let pool = matches.value_of("DB").map(|db| database::Pool::open(db));
 
     let ret = match matches.subcommand() {
         ("bench_local", Some(sub_m)) => {
@@ -610,7 +610,7 @@ fn main_result() -> anyhow::Result<i32> {
             let run_kinds = run_kinds_from_arg(&sub_m.value_of("RUNS"))?;
             let profiler = Profiler::from_name(sub_m.value_of("PROFILER").unwrap())?;
             let id = sub_m.value_of("ID").unwrap();
-            let out_dir = PathBuf::from(sub_m.value_of_os("output_dir").unwrap());
+            let out_dir = PathBuf::from(sub_m.value_of_os("OUTPUT").unwrap());
 
             eprintln!("Profiling with {:?}", profiler);
 

--- a/site/src/main.rs
+++ b/site/src/main.rs
@@ -42,9 +42,10 @@ async fn main() {
                 std::process::exit(1);
             }
             eprintln!(
-                "Loading complete; {} commits and {} artifacts.",
+                "Loading complete; {} commits and {} artifacts",
                 commits, artifacts,
             );
+            eprintln!("View the results in a web browser at 'localhost:2346/compare.html'");
             // Spawn off a task to post the results of any commit results that we
             // are now aware of.
             site::github::post_finished(&res).await;


### PR DESCRIPTION
This fixes #683.

Here is a summary of the new subcommand names, arguments, and options.
```
bench_local
  <RUSTC>               // mandatory
  <ID>                  // mandatory
  --builds <BUILDS>     // default: Check,Debug,Opt
  --cargo <CARGO>       // default: `rustup which cargo --toolchain nightly`
  --db <DB>             // default: results.db
  --exclude <EXCLUDE>   // default: None (i.e. run all benchmarks)
  --include <INCLUDE>   // default: None (i.e. run all benchmarks)
  --runs <RUNS>         // default: All (i.e. Full, IncrFull, IncrUnchanged, IncrPatched)
  --rustdoc <RUSTDOC>   // default: rustdoc next to <RUSTC>
  --self-profile        // default: false

bench_next
  <SITE_URL>            // mandatory
  --db <DB>             // default: results.db
  --self-profile        // default: false

bench_published
  <TOOLCHAIN>           // mandatory
  --db <DB>             // default: results.db

bench_test
  --db <DB>             // default: results.db
  --exclude <EXCLUDE>   // default: None (i.e. run all benchmarks)
  --include <INCLUDE>   // default: None (i.e. run all benchmarks)

profile_local
  <PROFILER>            // mandatory
  <RUSTC>               // mandatory
  <ID>                  // mandatory
  --builds <BUILDS>     // default: Check,Debug,Opt
  --cargo <CARGO>       // default: cargo in PATH
  --exclude <EXCLUDE>   // default: None (i.e. run all benchmarks)
  --include <INCLUDE>   // default: None (i.e. run all benchmarks)
  --out-dir <OUT_DIR>   // default: results/
  --runs <RUNS>         // default: All (i.e. Full, IncrFull, IncrUnchanged, IncrPatched)
  --rustdoc <RUSTDOC>   // default: rustdoc next to <RUSTC>
```