### PR TITLE
Reduce run durations

### DIFF
--- a/ci/check-benchmarks.sh
+++ b/ci/check-benchmarks.sh
@@ -5,7 +5,7 @@ set -x;
 bash -c "while true; do sleep 30; echo \$(date) - running ...; done" &
 PING_LOOP_PID=$!
 trap - ERR
-RUST_BACKTRACE=1 RUST_LOG=collector=debug,rust_sysroot=debug \
+RUST_BACKTRACE=1 RUST_LOG=collector_raw_cargo=trace,collector=debug,rust_sysroot=debug \
     cargo run -p collector --bin collector -- \
     bench_test $BENCH_TEST_OPTS
 code=$?

--- a/collector/benchmarks/cranelift-codegen/perf-config.json
+++ b/collector/benchmarks/cranelift-codegen/perf-config.json
@@ -1,3 +1,4 @@
 {
-    "cargo_toml": "cranelift-codegen/Cargo.toml"
+    "cargo_toml": "cranelift-codegen/Cargo.toml",
+    "touch_file": "cranelift-codegen/src/lib.rs"
 }

--- a/collector/benchmarks/script-servo-2/components/selectors/build.rs
+++ b/collector/benchmarks/script-servo-2/components/selectors/build.rs
@@ -24,6 +24,7 @@ fn main() {
         set.build(),
     )
     .unwrap();
+    println!("cargo:rerun-if-changed=build.rs");
 }
 
 /// <https://html.spec.whatwg.org/multipage/#selectors>

--- a/collector/benchmarks/script-servo-2/perf-config.json
+++ b/collector/benchmarks/script-servo-2/perf-config.json
@@ -1,5 +1,6 @@
 {
     "cargo_opts": "--no-default-features",
     "cargo_toml": "components/script/Cargo.toml",
-    "runs": 1
+    "runs": 1,
+    "touch_file": "components/script/lib.rs"
 }

--- a/collector/benchmarks/serde/perf-config.json
+++ b/collector/benchmarks/serde/perf-config.json
@@ -1,3 +1,4 @@
 {
-    "cargo_toml": "serde/Cargo.toml"
+    "cargo_toml": "serde/Cargo.toml",
+    "touch_file": "serde/src/lib.rs"
 }

--- a/collector/benchmarks/style-servo/components/selectors/build.rs
+++ b/collector/benchmarks/style-servo/components/selectors/build.rs
@@ -10,18 +10,18 @@ use std::io::{BufWriter, Write};
 use std::path::Path;
 
 fn main() {
-    let path = Path::new(&env::var("OUT_DIR").unwrap())
-        .join("ascii_case_insensitive_html_attributes.rs");
+    let path =
+        Path::new(&env::var("OUT_DIR").unwrap()).join("ascii_case_insensitive_html_attributes.rs");
     let mut file = BufWriter::new(File::create(&path).unwrap());
 
-    write!(&mut file, "{{ static SET: ::phf::Set<&'static str> = ",
-    ).unwrap();
+    write!(&mut file, "{{ static SET: ::phf::Set<&'static str> = ",).unwrap();
     let mut set = phf_codegen::Set::new();
     for name in ASCII_CASE_INSENSITIVE_HTML_ATTRIBUTES.split_whitespace() {
         set.entry(name);
     }
     set.build(&mut file).unwrap();
     write!(&mut file, "; &SET }}").unwrap();
+    println!("cargo:rerun-if-changed=build.rs");
 }
 
 /// https://html.spec.whatwg.org/multipage/#selectors

--- a/collector/benchmarks/style-servo/perf-config.json
+++ b/collector/benchmarks/style-servo/perf-config.json
@@ -3,5 +3,6 @@
     "cargo_rustc_opts": "--cap-lints=warn",
     "cargo_toml": "components/style/Cargo.toml",
     "runs": 1,
-    "supports_stable": true
+    "supports_stable": true,
+    "touch_file": "components/style/lib.rs"
 }

--- a/collector/benchmarks/webrender-wrench/perf-config.json
+++ b/collector/benchmarks/webrender-wrench/perf-config.json
@@ -1,4 +1,5 @@
 {
     "cargo_toml": "wrench/Cargo.toml",
-    "runs": 1
+    "runs": 1,
+    "touch_file": "wrench/src/main.rs"
 }

--- a/collector/benchmarks/webrender/perf-config.json
+++ b/collector/benchmarks/webrender/perf-config.json
@@ -1,4 +1,5 @@
 {
     "cargo_toml": "webrender/Cargo.toml",
-    "runs": 1
+    "runs": 1,
+    "touch_file": "webrender/src/lib.rs"
 }

--- a/collector/src/execute.rs
+++ b/collector/src/execute.rs
@@ -396,10 +396,6 @@ pub trait Processor {
     fn finished_first_collection(&mut self) -> bool {
         false
     }
-
-    /// Called when all the runs of a benchmark for a particular `BuildKind`
-    /// and iteration have been completed. Can be used to process/reset accumulated state.
-    fn finish_build_kind(&mut self, _build_kind: BuildKind) {}
 }
 
 pub struct MeasureProcessor<'a> {
@@ -566,10 +562,6 @@ impl<'a> Processor for MeasureProcessor<'a> {
                 panic!("process_perf_stat_output failed: {:?}", e);
             }
         }
-    }
-
-    fn finish_build_kind(&mut self, _: BuildKind) {
-        // do nothing
     }
 }
 
@@ -1010,8 +1002,6 @@ impl Benchmark {
                             .run_rustc()?;
                     }
                 }
-
-                processor.finish_build_kind(build_kind);
             }
         }
 

--- a/collector/src/read2.rs
+++ b/collector/src/read2.rs
@@ -1,0 +1,74 @@
+// This is copied from
+// https://github.com/rust-lang/rust/blob/master/src/tools/compiletest/src/read2.rs
+// and falls under the MIT or Apache 2.0 licenses.
+
+use std::io;
+use std::io::prelude::*;
+use std::mem;
+use std::os::unix::prelude::*;
+use std::process::{ChildStderr, ChildStdout};
+
+pub fn read2(
+    mut out_pipe: ChildStdout,
+    mut err_pipe: ChildStderr,
+    data: &mut dyn FnMut(bool, &mut Vec<u8>, bool),
+) -> io::Result<()> {
+    unsafe {
+        libc::fcntl(out_pipe.as_raw_fd(), libc::F_SETFL, libc::O_NONBLOCK);
+        libc::fcntl(err_pipe.as_raw_fd(), libc::F_SETFL, libc::O_NONBLOCK);
+    }
+
+    let mut out_done = false;
+    let mut err_done = false;
+    let mut out = Vec::new();
+    let mut err = Vec::new();
+
+    let mut fds: [libc::pollfd; 2] = unsafe { mem::zeroed() };
+    fds[0].fd = out_pipe.as_raw_fd();
+    fds[0].events = libc::POLLIN;
+    fds[1].fd = err_pipe.as_raw_fd();
+    fds[1].events = libc::POLLIN;
+    let mut nfds = 2;
+    let mut errfd = 1;
+
+    while nfds > 0 {
+        // wait for either pipe to become readable using `select`
+        let r = unsafe { libc::poll(fds.as_mut_ptr(), nfds, -1) };
+        if r == -1 {
+            let err = io::Error::last_os_error();
+            if err.kind() == io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(err);
+        }
+
+        // Read as much as we can from each pipe, ignoring EWOULDBLOCK or
+        // EAGAIN. If we hit EOF, then this will happen because the underlying
+        // reader will return Ok(0), in which case we'll see `Ok` ourselves. In
+        // this case we flip the other fd back into blocking mode and read
+        // whatever's leftover on that file descriptor.
+        let handle = |res: io::Result<_>| match res {
+            Ok(_) => Ok(true),
+            Err(e) => {
+                if e.kind() == io::ErrorKind::WouldBlock {
+                    Ok(false)
+                } else {
+                    Err(e)
+                }
+            }
+        };
+        if !err_done && fds[errfd].revents != 0 && handle(err_pipe.read_to_end(&mut err))? {
+            err_done = true;
+            nfds -= 1;
+        }
+        data(false, &mut err, err_done);
+        if !out_done && fds[0].revents != 0 && handle(out_pipe.read_to_end(&mut out))? {
+            out_done = true;
+            fds[0].fd = err_pipe.as_raw_fd();
+            errfd = 0;
+            nfds -= 1;
+        }
+        data(true, &mut out, out_done);
+    }
+    Ok(())
+}

--- a/collector/src/rustc-fake.rs
+++ b/collector/src/rustc-fake.rs
@@ -25,6 +25,7 @@ fn main() {
     }
 
     args.push(std::ffi::OsString::from("-Adeprecated"));
+    args.push(std::ffi::OsString::from("-Aunknown-lints"));
 
     if let Some(pos) = args.iter().position(|arg| arg == "--wrap-rustc-with") {
         // Strip out the flag and its argument, and run rustc under the wrapper


### PR DESCRIPTION
* Removes rustdoc incremental runs; rustdoc does not support incremental.
* Reduces files touched for some crates, hopefully reducing rebuilds of dependencies for script-servo and other similar crates.
* Fixes `style-servo` and `script-servo-2` to not spuriously rebuild a bunch of dependencies on every iteration.
* Adds support for raw stderr/stdout logging via `RUST_LOG=collector_raw_cargo=trace`, mostly intended for debugging.

In sum, this PR brings the script-servo builder from 1h 4m 39s to 48m 47s and the general builder from 45m 2s to 34m 19s. I expect even larger effects on the collection machine, since our CI only does Check/Doc builds which are quite fast to recover from spurious rebuilding (unlike Opt/Debug runs, which are quite a bit more expensive).