### PR TITLE
Remove single-string API boundary

### DIFF
--- a/collector/src/api.rs
+++ b/collector/src/api.rs
@@ -22,3 +22,10 @@ pub mod collected {
         // nothing
     }
 }
+
+pub mod next_commit {
+    #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+    pub struct Response {
+        pub commit: Option<String>,
+    }
+}

--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -171,13 +171,14 @@ fn bench_next(
 ) -> anyhow::Result<()> {
     println!("processing commits");
     let client = reqwest::blocking::Client::new();
-    let commit: Option<String> = client
+    let response: collector::api::next_commit::Response = client
         .get(&format!("{}/perf/next_commit", site_url))
         .send()?
         .json()?;
-    let commit = if let Some(c) = commit {
+    let commit = if let Some(c) = response.commit {
         c
     } else {
+        println!("no commit to benchmark");
         // no missing commits
         return Ok(());
     };

--- a/site/src/server.rs
+++ b/site/src/server.rs
@@ -288,12 +288,15 @@ pub async fn handle_status_page(data: Arc<InputData>) -> status::Response {
     }
 }
 
-pub async fn handle_next_commit(data: Arc<InputData>) -> Option<String> {
-    data.missing_commits()
+pub async fn handle_next_commit(data: Arc<InputData>) -> collector::api::next_commit::Response {
+    let commit = data
+        .missing_commits()
         .await
         .iter()
         .next()
-        .map(|c| c.0.sha.to_string())
+        .map(|c| c.0.sha.to_string());
+
+    collector::api::next_commit::Response { commit }
 }
 
 struct CommitIdxCache {


### PR DESCRIPTION
The collector will likely want more than just the commit in the near future from
the server, so adjust our API to more easily allow extending it. For now though
only the commit is sent from the frontend to the backend.