### PR TITLE
Improve testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Check benchmarks
         run: sh -x -c "ci/check-benchmarks.sh"
         env:
-          BENCH_TEST_OPTS: "--exclude script-servo"
+          BENCH_INCLUDE_EXCLUDE_OPTS: "--exclude script-servo"
   test_script_servo:
     name: Test benchmark script-servo
     runs-on: ubuntu-latest
@@ -90,5 +90,5 @@ jobs:
       - name: Check benchmarks
         run: sh -x -c "ci/check-benchmarks.sh"
         env:
-          BENCH_TEST_OPTS: "--include script-servo"
+          BENCH_INCLUDE_EXCLUDE_OPTS: "--include script-servo"
           SHELL: "/bin/bash"

--- a/ci/check-benchmarks.sh
+++ b/ci/check-benchmarks.sh
@@ -6,8 +6,16 @@ bash -c "while true; do sleep 30; echo \$(date) - running ...; done" &
 PING_LOOP_PID=$!
 trap - ERR
 RUST_BACKTRACE=1 RUST_LOG=collector_raw_cargo=trace,collector=debug,rust_sysroot=debug \
+    bindir=`cargo run -p collector --bin collector install_next` \
+    && \
+RUST_BACKTRACE=1 RUST_LOG=collector_raw_cargo=trace,collector=debug,rust_sysroot=debug \
     cargo run -p collector --bin collector -- \
-    bench_test $BENCH_TEST_OPTS
+    bench_local $bindir/rustc Test \
+        --builds Check,Doc \
+        --cargo $bindir/cargo \
+        --runs All \
+        --rustdoc $bindir/rustdoc \
+        $BENCH_INCLUDE_EXCLUDE_OPTS
 code=$?
 kill $PING_LOOP_PID
 exit $code

--- a/collector/collect.sh
+++ b/collector/collect.sh
@@ -23,7 +23,6 @@ while : ; do
         touch todo-artifacts
 
         target/release/collector bench_next $SITE_URL --self-profile --db $DATABASE;
-        test $? -gt 0 && echo "sleeping 30 seconds -- failure detected" && sleep 30;
         echo sleeping for 30sec at `date`;
         sleep 30;
 done

--- a/collector/src/sysroot.rs
+++ b/collector/src/sysroot.rs
@@ -19,6 +19,7 @@ pub struct Sysroot {
     pub rustdoc: PathBuf,
     pub cargo: PathBuf,
     pub triple: String,
+    pub preserve: bool,
 }
 
 impl Sysroot {
@@ -42,10 +43,17 @@ impl Sysroot {
 
         Ok(sysroot)
     }
+
+    pub fn preserve(&mut self) {
+        self.preserve = true;
+    }
 }
 
 impl Drop for Sysroot {
     fn drop(&mut self) {
+        if self.preserve {
+            return;
+        }
         fs::remove_dir_all(format!("cache/{}", self.sha)).unwrap_or_else(|err| {
             log::info!(
                 "failed to remove {:?}, please do so manually: {:?}",
@@ -121,6 +129,7 @@ impl SysrootDownload {
             cargo: sysroot_bin("cargo")?,
             sha: self.rust_sha,
             triple: self.triple,
+            preserve: false,
         })
     }
 


### PR DESCRIPTION
With some effort, we can get rid of of `bench_test` and use `bench_local` in the test script.