### PR TITLE
Support generating PRs for rollup-merged perf-testing

### DIFF
--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -270,8 +270,21 @@ pub mod github {
     }
 
     #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct CommitTree {
+        pub sha: String,
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct InnerCommit {
+        #[serde(default)]
+        pub message: String,
+        pub tree: CommitTree,
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Commit {
         pub sha: String,
+        pub commit: InnerCommit,
         pub parents: Vec<CommitParent>,
     }
 

--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -1,5 +1,6 @@
 use crate::api::{github, ServerResult};
 use crate::load::{Config, InputData, TryCommit};
+use anyhow::Context as _;
 use hashbrown::HashSet;
 use serde::Deserialize;
 
@@ -11,6 +12,10 @@ lazy_static::lazy_static! {
         Regex::new(r#"(?:\W|^)@rust-timer\s+build\s+(\w+)(?:\W|$)"#).unwrap();
     static ref BODY_QUEUE: Regex =
         Regex::new(r#"(?:\W|^)@rust-timer\s+queue(?:\W|$)"#).unwrap();
+    static ref BODY_MAKE_PR_FOR: Regex =
+        Regex::new(r#"(?:\W|^)@rust-timer\s+make-pr-for\s+(\w+)(?:\W|$)"#).unwrap();
+    static ref BODY_UDPATE_PR_FOR: Regex =
+        Regex::new(r#"(?:\W|^)@rust-timer\s+update-branch-for\s+(\w+)(?:\W|$)"#).unwrap();
 }
 
 async fn get_authorized_users() -> ServerResult<Vec<usize>> {
@@ -83,7 +88,383 @@ pub async fn handle_github(
         }
     }
 
+    let captures = BODY_MAKE_PR_FOR
+        .captures_iter(&request.comment.body)
+        .collect::<Vec<_>>();
+    for capture in captures {
+        if let Some(rollup_merge) = capture.get(1).map(|c| c.as_str().to_owned()) {
+            let rollup_merge =
+                rollup_merge.trim_start_matches("https://github.com/rust-lang/rust/commit/");
+            let client = reqwest::Client::new();
+            pr_and_try_for_rollup(
+                &client,
+                &data,
+                &request.issue.repository_url,
+                &rollup_merge,
+                &request.comment.html_url,
+            )
+            .await
+            .map_err(|e| e.to_string())?;
+        }
+    }
+
+    let captures = BODY_UDPATE_PR_FOR
+        .captures_iter(&request.comment.body)
+        .collect::<Vec<_>>();
+    for capture in captures {
+        if let Some(rollup_merge) = capture.get(1).map(|c| c.as_str().to_owned()) {
+            let rollup_merge =
+                rollup_merge.trim_start_matches("https://github.com/rust-lang/rust/commit/");
+
+            // This just creates or updates the branch for this merge commit.
+            // Intended for resolving the race condition of master merging in
+            // between us updating the commit and merging things.
+            let client = reqwest::Client::new();
+            let branch =
+                branch_for_rollup(&client, data, &request.issue.repository_url, rollup_merge)
+                    .await
+                    .map_err(|e| e.to_string())?;
+            post_comment(
+                &data.config,
+                request.issue.number,
+                &format!("Master base SHA: {}", branch.master_base_sha),
+            )
+            .await;
+        }
+    }
+
     Ok(github::Response)
+}
+
+// Returns the PR number
+async fn pr_and_try_for_rollup(
+    client: &reqwest::Client,
+    data: &InputData,
+    repository_url: &str,
+    rollup_merge_sha: &str,
+    origin_url: &str,
+) -> anyhow::Result<u32> {
+    log::trace!(
+        "creating PR for {:?} {:?}",
+        repository_url,
+        rollup_merge_sha
+    );
+    let branch = branch_for_rollup(client, data, repository_url, rollup_merge_sha).await?;
+
+    let pr = create_pr(
+        client,
+        data,
+        repository_url,
+        &format!(
+            "[DO NOT MERGE] perf-test for #{}",
+            branch.rolled_up_pr_number
+        ),
+        &format!("rust-timer:{}", branch.name),
+        "master",
+        &format!(
+            "This is an automatically generated pull request (from [here]({})) to \
+            run perf tests for #{} which merged in a rollup.
+
+            r? @ghost",
+            origin_url, branch.rolled_up_pr_number
+        ),
+    )
+    .await
+    .context("Created PR")?;
+
+    // This provides the master SHA so that we can check that we only queue
+    // an appropriate try build. If there's ever a race condition, i.e.,
+    // master was pushed while this command was running, the user will have to
+    // take manual action to detect it.
+    //
+    // Eventually we'll want to handle this automatically, but that's a ways
+    // off: we'd need to store the state in the database and handle the try
+    // build starting and generally that's a lot of work for not too much gain.
+    post_comment(
+        &data.config,
+        pr.number,
+        &format!(
+            "@bors try @rust-timer queue\n
+            The try commit's (master) parent should be {master}. If it isn't, \
+            then please:
+
+              * Stop this try build (`try-`).
+              * Run `@rust-timer update-pr-for {merge}`.
+              * Rerun `bors try`.
+
+            You do not need to reinvoke the queue command as long as the perf \
+            build hasn't yet started.",
+            master = branch.master_base_sha,
+            merge = rollup_merge_sha,
+        ),
+    )
+    .await;
+
+    Ok(pr.number)
+}
+
+struct RollupBranch {
+    master_base_sha: String,
+    rolled_up_pr_number: u32,
+    name: String,
+}
+
+async fn branch_for_rollup(
+    client: &reqwest::Client,
+    data: &InputData,
+    repository_url: &str,
+    rollup_merge_sha: &str,
+) -> anyhow::Result<RollupBranch> {
+    let rollup_merge = get_commit(&client, &data, repository_url, rollup_merge_sha)
+        .await
+        .context("got rollup merge")?;
+
+    let old_master_commit =
+        get_commit(&client, &data, repository_url, &rollup_merge.parents[0].sha)
+            .await
+            .context("success master get")?;
+
+    let current_master_commit = get_commit(&client, &data, repository_url, "master")
+        .await
+        .context("success master get")?;
+
+    let revert_sha = create_commit(
+        &client,
+        &data,
+        repository_url,
+        &format!("Revert to {}", old_master_commit.sha),
+        &old_master_commit.commit.tree.sha,
+        &[&current_master_commit.sha],
+    )
+    .await
+    .context("create revert")?;
+
+    let merge_sha = create_commit(
+        &client,
+        &data,
+        repository_url,
+        &format!(
+            "rust-timer simulated merge of {}\n\nOriginal message:\n{}",
+            rollup_merge.sha, rollup_merge.commit.message
+        ),
+        &rollup_merge.commit.tree.sha,
+        &[&revert_sha],
+    )
+    .await
+    .context("create merge commit")?;
+
+    let rolled_up_pr_number = if let Some(stripped) = rollup_merge
+        .commit
+        .message
+        .strip_prefix("Rollup merge of #")
+    {
+        stripped
+            .split_whitespace()
+            .next()
+            .unwrap()
+            .parse::<u32>()
+            .unwrap()
+    } else {
+        anyhow::bail!(
+            "not a rollup merge commit: {:?}",
+            rollup_merge.commit.message
+        )
+    };
+
+    let branch = format!("try-for-{}", rolled_up_pr_number);
+    create_ref(
+        &client,
+        &data,
+        repository_url,
+        &format!("refs/heads/{}", branch),
+        &merge_sha,
+    )
+    .await
+    .context("created branch")?;
+
+    Ok(RollupBranch {
+        rolled_up_pr_number,
+        master_base_sha: current_master_commit.sha,
+        name: branch,
+    })
+}
+
+#[derive(serde::Serialize)]
+struct CreateRefRequest<'a> {
+    // Must start with `refs/` and have at least two slashes.
+    // e.g. `refs/heads/master`.
+    #[serde(rename = "ref")]
+    ref_: &'a str,
+    sha: &'a str,
+}
+
+pub async fn create_ref(
+    client: &reqwest::Client,
+    data: &InputData,
+    repository_url: &str,
+    ref_: &str,
+    sha: &str,
+) -> anyhow::Result<()> {
+    let timer_token = data
+        .config
+        .keys
+        .github
+        .clone()
+        .expect("needs rust-timer token");
+    let url = format!("{}/git/refs", repository_url);
+    let response = client
+        .post(&url)
+        .json(&CreateRefRequest { ref_, sha })
+        .header(USER_AGENT, "perf-rust-lang-org-server")
+        .basic_auth("rust-timer", Some(timer_token))
+        .send()
+        .await
+        .context("POST git/refs failed")?;
+    if response.status() != reqwest::StatusCode::CREATED {
+        anyhow::bail!("{:?} != 201 CREATED", response.status());
+    }
+
+    Ok(())
+}
+
+#[derive(serde::Serialize)]
+struct CreatePrRequest<'a> {
+    title: &'a str,
+    // username:branch if cross-repo
+    head: &'a str,
+    // branch to pull into (e.g, master)
+    base: &'a str,
+    #[serde(rename = "body")]
+    description: &'a str,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct CreatePrResponse {
+    pub number: u32,
+    pub html_url: String,
+    pub comments_url: String,
+}
+
+pub async fn create_pr(
+    client: &reqwest::Client,
+    data: &InputData,
+    repository_url: &str,
+    title: &str,
+    head: &str,
+    base: &str,
+    description: &str,
+) -> anyhow::Result<CreatePrResponse> {
+    let timer_token = data
+        .config
+        .keys
+        .github
+        .clone()
+        .expect("needs rust-timer token");
+    let url = format!("{}/pulls", repository_url);
+    let response = client
+        .post(&url)
+        .json(&CreatePrRequest {
+            title,
+            head,
+            base,
+            description,
+        })
+        .header(USER_AGENT, "perf-rust-lang-org-server")
+        .basic_auth("rust-timer", Some(timer_token))
+        .send()
+        .await
+        .context("POST pulls failed")?;
+    if response.status() != reqwest::StatusCode::CREATED {
+        anyhow::bail!("{:?} != 201 CREATED", response.status());
+    }
+
+    Ok(response.json().await.context("deserializing failed")?)
+}
+
+#[derive(serde::Serialize)]
+struct CreateCommitRequest<'a> {
+    message: &'a str,
+    tree: &'a str,
+    parents: &'a [&'a str],
+}
+
+#[derive(serde::Deserialize)]
+struct CreateCommitResponse {
+    sha: String,
+}
+
+pub async fn create_commit(
+    client: &reqwest::Client,
+    data: &InputData,
+    repository_url: &str,
+    message: &str,
+    tree: &str,
+    parents: &[&str],
+) -> anyhow::Result<String> {
+    let timer_token = data
+        .config
+        .keys
+        .github
+        .clone()
+        .expect("needs rust-timer token");
+    let url = format!("{}/git/commits", repository_url);
+    let commit_response = client
+        .post(&url)
+        .json(&CreateCommitRequest {
+            message,
+            tree,
+            parents,
+        })
+        .header(USER_AGENT, "perf-rust-lang-org-server")
+        .basic_auth("rust-timer", Some(timer_token))
+        .send()
+        .await
+        .context("POST git/commits failed")?;
+    if commit_response.status() != reqwest::StatusCode::CREATED {
+        anyhow::bail!("{:?} != 201 CREATED", commit_response.status());
+    }
+
+    Ok(commit_response
+        .json::<CreateCommitResponse>()
+        .await
+        .context("deserializing failed")?
+        .sha)
+}
+
+pub async fn get_commit(
+    client: &reqwest::Client,
+    data: &InputData,
+    repository_url: &str,
+    sha: &str,
+) -> anyhow::Result<github::Commit> {
+    let timer_token = data
+        .config
+        .keys
+        .github
+        .clone()
+        .expect("needs rust-timer token");
+    let url = format!("{}/commits/{}", repository_url, sha);
+    let commit_response = client
+        .get(&url)
+        .header(USER_AGENT, "perf-rust-lang-org-server")
+        .basic_auth("rust-timer", Some(timer_token))
+        .send()
+        .await
+        .context("cannot get commit")?;
+    let commit_response = match commit_response.text().await {
+        Ok(c) => c,
+        Err(err) => {
+            anyhow::bail!("Failed to decode response for {}: {:?}", url, err);
+        }
+    };
+    match serde_json::from_str(&commit_response) {
+        Ok(c) => Ok(c),
+        Err(e) => Err(anyhow::anyhow!(
+            "cannot deserialize commit ({}): {:?}",
+            commit_response,
+            e
+        )),
+    }
 }
 
 async fn enqueue_sha(
@@ -91,36 +472,10 @@ async fn enqueue_sha(
     data: &InputData,
     commit: String,
 ) -> ServerResult<github::Response> {
-    let timer_token = data
-        .config
-        .keys
-        .github
-        .clone()
-        .expect("needs rust-timer token");
     let client = reqwest::Client::new();
-    let url = format!("{}/commits/{}", request.issue.repository_url, commit);
-    let commit_response = client
-        .get(&url)
-        .header(USER_AGENT, "perf-rust-lang-org-server")
-        .basic_auth("rust-timer", Some(timer_token))
-        .send()
+    let commit_response = get_commit(&client, data, &request.issue.repository_url, &commit)
         .await
-        .map_err(|_| String::from("cannot get commit"))?;
-    let commit_response = match commit_response.text().await {
-        Ok(c) => c,
-        Err(err) => {
-            return Err(format!("Failed to decode response for {}: {:?}", url, err));
-        }
-    };
-    let commit_response: github::Commit = match serde_json::from_str(&commit_response) {
-        Ok(c) => c,
-        Err(e) => {
-            return Err(format!(
-                "cannot deserialize commit ({:?}): {:?}",
-                commit_response, e
-            ));
-        }
-    };
+        .map_err(|e| e.to_string())?;
     if commit_response.parents.len() != 2 {
         log::error!(
             "Bors try commit {} unexpectedly has {} parents.",


### PR DESCRIPTION
This adds two new commands to rust-timer, both of which support being listed multiple times per comment, and can be made anywhere:

 * `@rust-timer make-pr-for <sha>`
 * `@rust-timer update-branch-for <sha>`

Both commands should be passed a rollup merge SHA, e.g., https://github.com/rust-lang/rust/commit/105cd4955425de2613ac2ae6c2d2d1baf17ebd2b (with or without a full https URL prefix, though `rust-lang/rust@SHA` is not supported).

We create a pull request on rust-lang/rust and immediately invoke try on it to gather perf statistics. The pull request is created such that it contains two commits:
 * A revert of *current* master back to master at the time of rollup merge creation. This is not perfect -- ideally it would be the previous commit of master when the rollup merged -- but finding which commit that was isn't trivial, so we go with this. It should be pretty close, as rollup PRs are generally retry'd into top of queue and are not long-lived.
 * The merge commit of the rolled-up PR's branch into that old master.

This should have the effect of mostly faithfully representing what it would look like to merge the PR into that old master by itself (rather than in the rollup), though it isn't absolutely perfect -- there's a number of things that *could* go wrong to make this infeasible.

One of the easiest ways for this to be problematic is if there have been CI-fixing changes landing in master since the creation of the rollup. Currently, those changes would likely mean that the pull request we've created is essentially useless, as it'll lack those changes and that means it cannot be easily run on its own. In such a scenario though nothing should stop the human operator from manually pushing some commits to the created PR.

An alternative to this is to generate a revert of the merge of *just the commit passed* onto current master, and benchmark that. The results would then be considered an "inverse" (i.e., good means the original PR was bad). This is much less prone to problems caused by external changes but is a less faithful and is somewhat harder to interpret the results of.

The second is basically solely for the edge case of something landing in master in the (short) amount of time the first one takes to work; this should be quite rare in practice. Eventually we may automatically detect this case, but the current PR doesn't do so as this is relatively hard.