### PR TITLE
Incremental progress

### DIFF
--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -65,20 +65,11 @@ pub trait Connection: Send + Sync {
     // Collector status API
 
     async fn collector_start(&self, aid: ArtifactIdNumber, steps: &[String]);
-    async fn collector_start_step(&self, aid: ArtifactIdNumber, step: &str);
-    async fn collector_end_step(&self, aid: ArtifactIdNumber, step: &str);
 
-    // This returns `true` if the collector commands can be placed in a separate
-    // transaction.
-    //
-    // Currently, the sqlite backend does not support "regular" usage where they
-    // are used for genuine progress reporting. sqlite does not support
-    // concurrent writers -- it will return an error (or wait, if a busy timeout
-    // is configured).
-    //
-    // For now we don't care much as sqlite is not used in production and in
-    // local usage you can just look at the logs.
-    fn separate_transaction_for_collector(&self) -> bool;
+    // Returns `true` if the step was started, i.e., it did not previously have
+    // an end. Otherwise returns false, indicating that we can skip it.
+    async fn collector_start_step(&self, aid: ArtifactIdNumber, step: &str) -> bool;
+    async fn collector_end_step(&self, aid: ArtifactIdNumber, step: &str);
 }
 
 #[async_trait::async_trait]

--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -70,6 +70,9 @@ pub trait Connection: Send + Sync {
     // an end. Otherwise returns false, indicating that we can skip it.
     async fn collector_start_step(&self, aid: ArtifactIdNumber, step: &str) -> bool;
     async fn collector_end_step(&self, aid: ArtifactIdNumber, step: &str);
+
+    // Returns an artifact that is in progress.
+    async fn in_progress_artifact(&self) -> Option<ArtifactId>;
 }
 
 #[async_trait::async_trait]

--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -772,6 +772,19 @@ where
             .unwrap();
     }
     async fn record_benchmark(&self, krate: &str, supports_stable: bool) {
+        if let Some(r) = self
+            .conn()
+            .query_opt(
+                "select stabilized from benchmark where name = $1",
+                &[&krate],
+            )
+            .await
+            .unwrap()
+        {
+            if r.get::<_, bool>(0) == supports_stable {
+                return;
+            }
+        }
         self.conn()
             .execute(
                 "insert into benchmark (name, stabilized) VALUES ($1, $2)

--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -167,6 +167,7 @@ static MIGRATIONS: &[&str] = &[
         end_time timestamptz
     );
     "#,
+    r#"alter table collector_progress add unique (aid, step);"#,
 ];
 
 #[async_trait::async_trait]
@@ -781,6 +782,7 @@ where
     }
 
     async fn collector_start(&self, aid: ArtifactIdNumber, steps: &[String]) {
+        // Clean up -- we'll re-insert any missing things in the loop below.
         self.conn()
             .execute(
                 "delete from collector_progress where start_time is null or end_time is null;",
@@ -792,34 +794,40 @@ where
         for step in steps {
             self.conn()
                 .execute(
-                    "insert into collector_progress(aid, step) VALUES ($1, $2)",
+                    "insert into collector_progress(aid, step) VALUES ($1, $2)
+                    ON CONFLICT DO NOTHING",
                     &[&(aid.0 as i16), &step],
                 )
                 .await
                 .unwrap();
         }
     }
-    async fn collector_start_step(&self, aid: ArtifactIdNumber, step: &str) {
+    async fn collector_start_step(&self, aid: ArtifactIdNumber, step: &str) -> bool {
+        // If we modified a row, then we populated a start time, so we're good
+        // to go. Otherwise we should just skip this step.
         self.conn()
             .execute(
                 "update collector_progress set start_time = statement_timestamp() \
-                where aid = $1 and step = $2 and start_time is null and end_time is null;",
+                where aid = $1 and step = $2 and end_time is null;",
                 &[&(aid.0 as i16), &step],
             )
             .await
-            .unwrap();
+            .unwrap()
+            == 1
     }
     async fn collector_end_step(&self, aid: ArtifactIdNumber, step: &str) {
-        self.conn()
+        let did_modify = self
+            .conn()
             .execute(
                 "update collector_progress set end_time = statement_timestamp() \
                 where aid = $1 and step = $2 and start_time is not null and end_time is null;",
                 &[&(aid.0 as i16), &step],
             )
             .await
-            .unwrap();
-    }
-    fn separate_transaction_for_collector(&self) -> bool {
-        true
+            .unwrap()
+            == 1;
+        if !did_modify {
+            log::error!("did not end {} for {:?}", step, aid);
+        }
     }
 }

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -145,7 +145,8 @@ static MIGRATIONS: &[&str] = &[
         aid integer not null references artifact(id) on delete cascade on update cascade,
         step text not null,
         start integer,
-        end integer
+        end integer,
+        UNIQUE(aid, step)
     );
     "#,
 ];
@@ -227,7 +228,7 @@ impl Connection for SqliteConnection {
     async fn record_duration(&self, artifact: ArtifactIdNumber, duration: Duration) {
         self.raw_ref()
             .prepare_cached(
-                "insert into artifact_collection_duration (aid, date_recorded, duration) VALUES (?, strftime('%s','now'), ?)",
+                "insert or ignore into artifact_collection_duration (aid, date_recorded, duration) VALUES (?, strftime('%s','now'), ?)",
             )
             .unwrap()
             .execute(params![artifact.0, duration.as_secs() as i64])
@@ -644,31 +645,34 @@ impl Connection for SqliteConnection {
         for step in steps {
             self.raw_ref()
                 .execute(
-                    "insert into collector_progress(aid, step) VALUES (?, ?)",
+                    "insert or ignore into collector_progress(aid, step) VALUES (?, ?)",
                     params![&aid.0, step],
                 )
                 .unwrap();
         }
     }
-    async fn collector_start_step(&self, aid: ArtifactIdNumber, step: &str) {
+    async fn collector_start_step(&self, aid: ArtifactIdNumber, step: &str) -> bool {
         self.raw_ref()
             .execute(
                 "update collector_progress set start = strftime('%s','now') \
-            where aid = ? and step = ? and start is null;",
+                where aid = ? and step = ? and end is null;",
                 params![&aid.0, &step],
             )
-            .unwrap();
+            .unwrap()
+            == 1
     }
     async fn collector_end_step(&self, aid: ArtifactIdNumber, step: &str) {
-        self.raw_ref()
+        let did_modify = self
+            .raw_ref()
             .execute(
                 "update collector_progress set end = strftime('%s','now') \
-            where aid = ? and step = ? and start is not null and end is null;",
+                where aid = ? and step = ? and start is not null and end is null;",
                 params![&aid.0, &step],
             )
-            .unwrap();
-    }
-    fn separate_transaction_for_collector(&self) -> bool {
-        false
+            .unwrap()
+            == 1;
+        if !did_modify {
+            log::error!("did not end {} for {:?}", step, aid);
+        }
     }
 }


### PR DESCRIPTION
This permits restarting of the collection server without losing hours of work.
It also removes the extremely long-lived (2h30m as of now) transaction in favor
of one wrapping each individual benchmark. Ideally, that would be by itself
"sufficiently short."

However, currently, even just limiting to one benchmark can mean a hour-long
transaction (for script-servo-2). This is a bit unfortunate, but at least
killing that transaction will not restart the whole collection.

This also means that we should be able to observe results on comparison pages
and the graph as they come in -- that's sort of questionably good; it might be a
bit confusing. But it seems not horrible, and slightly beneficial in some cases,
especially if we supported cancellation of runs.