### PR TITLE
Fix finishing comments being posted early

### DIFF
--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -71,8 +71,7 @@ pub trait Connection: Send + Sync {
     async fn collector_start_step(&self, aid: ArtifactIdNumber, step: &str) -> bool;
     async fn collector_end_step(&self, aid: ArtifactIdNumber, step: &str);
 
-    // Returns an artifact that is in progress.
-    async fn in_progress_artifact(&self) -> Option<ArtifactId>;
+    async fn in_progress_artifacts(&self) -> Vec<ArtifactId>;
 
     async fn in_progress_steps(&self, aid: &ArtifactId) -> Vec<Step>;
 }

--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -190,7 +190,7 @@ pub mod status {
 
     #[derive(Serialize, Debug)]
     pub struct Response {
-        pub last_commit: Commit,
+        pub last_commit: Option<Commit>,
         pub benchmarks: Vec<BenchmarkStatus>,
         pub missing: Vec<(Commit, MissingReason)>,
         pub current: Option<CurrentState>,

--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -596,26 +596,17 @@ pub async fn post_finished(data: &InputData) {
         .collect::<HashSet<_>>();
     let queued = conn.queued_commits().await;
 
-    // In theory this is insufficient -- there could be multiple commits in
-    // progress -- but in practice that really shouldn't happen.
-    //
-    // The failure case here is also just prematurely posting a single comment,
-    // which should be fine. mark_complete below will ensure that only happens
-    // once.
-    //
-    // If this becomes more of a problem, it should be fairly easy to instead
-    // query that there are no in progress benchmarks for commit X.
-    match conn.in_progress_artifact().await {
-        None => {}
-        Some(ArtifactId::Commit(c)) => {
-            commits.insert(c.sha);
-        }
-        Some(ArtifactId::Artifact(_)) => {
-            // do nothing, for now, though eventually we'll want an artifact
-            // queue
+    for aid in conn.in_progress_artifacts().await {
+        match aid {
+            ArtifactId::Commit(c) => {
+                commits.insert(c.sha);
+            }
+            ArtifactId::Artifact(_) => {
+                // do nothing, for now, though eventually we'll want an artifact
+                // queue
+            }
         }
     }
-
     for commit in queued {
         if !commits.contains(&commit.sha) {
             continue;

--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -582,6 +582,11 @@ where
 }
 
 pub async fn post_finished(data: &InputData) {
+    // If the github token is not configured, do not run this -- we don't want
+    // to mark things as complete without posting the comment.
+    if data.config.keys.github.is_none() {
+        return;
+    }
     let conn = data.conn().await;
     let index = data.index.load();
     let mut commits = index

--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -599,7 +599,7 @@ pub async fn post_finished(data: &InputData) {
     for aid in conn.in_progress_artifacts().await {
         match aid {
             ArtifactId::Commit(c) => {
-                commits.insert(c.sha);
+                commits.remove(&c.sha);
             }
             ArtifactId::Artifact(_) => {
                 // do nothing, for now, though eventually we'll want an artifact

--- a/site/src/load.rs
+++ b/site/src/load.rs
@@ -201,23 +201,24 @@ impl InputData {
             .chain(missing)
             .collect::<Vec<_>>();
 
-        match self.conn().await.in_progress_artifact().await {
-            None => {}
-            Some(ArtifactId::Commit(c)) => {
-                commits.insert(
-                    0,
-                    (
-                        rustc_artifacts::Commit {
-                            sha: c.sha,
-                            time: c.date.0,
-                        },
-                        MissingReason::InProgress,
-                    ),
-                );
-            }
-            Some(ArtifactId::Artifact(_)) => {
-                // do nothing, for now, though eventually we'll want an artifact
-                // queue
+        for aid in self.conn().await.in_progress_artifacts().await {
+            match aid {
+                ArtifactId::Commit(c) => {
+                    commits.insert(
+                        0,
+                        (
+                            rustc_artifacts::Commit {
+                                sha: c.sha,
+                                time: c.date.0,
+                            },
+                            MissingReason::InProgress,
+                        ),
+                    );
+                }
+                ArtifactId::Artifact(_) => {
+                    // do nothing, for now, though eventually we'll want an artifact
+                    // queue
+                }
             }
         }
 

--- a/site/src/server.rs
+++ b/site/src/server.rs
@@ -277,7 +277,7 @@ pub async fn handle_status_page(data: Arc<InputData>) -> status::Response {
     let missing = data.missing_commits().await;
     // FIXME: no current builds
     let conn = data.conn().await;
-    let current = if let Some(artifact) = conn.in_progress_artifact().await {
+    let current = if let Some(artifact) = conn.in_progress_artifacts().await.pop() {
         let steps = conn
             .in_progress_steps(&artifact)
             .await

--- a/site/src/server.rs
+++ b/site/src/server.rs
@@ -249,30 +249,7 @@ fn prettify_log(log: &str) -> Option<String> {
 
 pub async fn handle_status_page(data: Arc<InputData>) -> status::Response {
     let idx = data.index.load();
-    let last_commit = idx.commits().last().unwrap().clone();
-
-    let mut benchmark_state = data
-        .conn()
-        .await
-        .get_error(ArtifactId::from(last_commit.clone()).lookup(&idx).unwrap())
-        .await
-        .into_iter()
-        .map(|(name, error)| {
-            let msg = if let Some(error) = error {
-                Some(prettify_log(&error).unwrap_or(error))
-            } else {
-                None
-            };
-            status::BenchmarkStatus {
-                name,
-                success: msg.is_none(),
-                error: msg,
-            }
-        })
-        .collect::<Vec<_>>();
-
-    benchmark_state.sort_by_key(|s| s.error.is_some());
-    benchmark_state.reverse();
+    let last_commit = idx.commits().last().cloned();
 
     let missing = data.missing_commits().await;
     // FIXME: no current builds
@@ -297,6 +274,33 @@ pub async fn handle_status_page(data: Arc<InputData>) -> status::Response {
     } else {
         None
     };
+
+    let errors = if let Some(last) = &last_commit {
+        data.conn()
+            .await
+            .get_error(ArtifactId::from(last.clone()).lookup(&idx).unwrap())
+            .await
+    } else {
+        Default::default()
+    };
+    let mut benchmark_state = errors
+        .into_iter()
+        .map(|(name, error)| {
+            let msg = if let Some(error) = error {
+                Some(prettify_log(&error).unwrap_or(error))
+            } else {
+                None
+            };
+            status::BenchmarkStatus {
+                name,
+                success: msg.is_none(),
+                error: msg,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    benchmark_state.sort_by_key(|s| s.error.is_some());
+    benchmark_state.reverse();
 
     status::Response {
         last_commit,


### PR DESCRIPTION
Also cleans up the status page implementation to not panic if there aren't any benchmarked commits.