### PR TITLE
Avoid collecting extraneous stuff on `eprintln` runs.

### DIFF
--- a/ci/check-profiling.sh
+++ b/ci/check-profiling.sh
@@ -76,7 +76,8 @@ RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=
 test -f results/msout-Test-helloworld-Check-Full
 grep -q "snapshot=0" results/msout-Test-helloworld-Check-Full
 
-# eprintln.
+# eprintln. The output file is empty because a vanilla rustc doesn't print
+# anything to stderr.
 RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=debug \
     cargo run -p collector --bin collector -- \
     profile_local eprintln $bindir/rustc Test \
@@ -84,8 +85,8 @@ RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=
         --cargo $bindir/cargo \
         --include helloworld \
         --runs Full
-test -f results/eprintln-Test-helloworld-Check-Full
-grep -q "Checking helloworld" results/eprintln-Test-helloworld-Check-Full
+test   -f results/eprintln-Test-helloworld-Check-Full
+test ! -s results/eprintln-Test-helloworld-Check-Full
 
 # llvm-lines. `Debug` not `Check` because it doesn't support `Check` builds.
 RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=debug \


### PR DESCRIPTION
Currently, `collector eprintln` collects stderr output for the `cargo
rustc` command. This means it will collect rustc's stderr output for the
leaf crate, but *also* rustc's stderr output for build scripts that run
for the leaf crate, and *also* for Cargo's stderr output for all of the
above.

This means it is different to all the other profilers, which only
profile rustc on the leaf crate.

With this change, `collector eprintln` now only collects rustc's stderr
output for the leaf crate, so it matches the other profiler's behaviour.

The commit also changes `time-passes` to use the same collection
strategy as `eprintln`. This wasn't actually necessary, but I did it for
consistency.

Finally, the commit does some minor clean-ups.