### PR TITLE
Adjust style-servo patch

### DIFF
--- a/collector/benchmarks/style-servo/0-println.patch
+++ b/collector/benchmarks/style-servo/0-println.patch
@@ -1,13 +1,11 @@
-diff --git a/components/style/properties/longhand/font.mako.rs b/components/style/properties/longhand/font.mako.rs
-index 04d6c69..ce76c97 100644
---- a/components/style/properties/longhand/font.mako.rs
-+++ b/components/style/properties/longhand/font.mako.rs
-@@ -174,6 +174,7 @@ macro_rules! impl_gecko_keyword_conversions {
-                     }))
-                 }
-                 let first_ident = input.expect_ident()?.clone();
-+                println!("font-family parsing first ident: {:?}", first_ident);
- 
-                 // FIXME(bholley): The fast thing to do here would be to look up the
-                 // string (as lowercase) in the static atoms table. We don't have an
+diff --git a/components/style/matching.rs b/components/style/matching.rs
+--- a/components/style/matching.rs
++++ b/components/style/matching.rs
+@@ -788,6 +788,7 @@ pub trait MatchMethods : TElement {
+         // Non-animation restyle hints will be processed in a subsequent
+         // normal traversal.
+         if replacements.intersects(RestyleHint::for_animations()) {
++            println!("{:?}", context.shared.traversal_flags.for_animation_only());
+             debug_assert!(context.shared.traversal_flags.for_animation_only());
 
+             if replacements.contains(RESTYLE_SMIL) {

--- a/collector/benchmarks/style-servo/components/style/build.rs
+++ b/collector/benchmarks/style-servo/components/style/build.rs
@@ -63,6 +63,7 @@ fn generate_properties() {
         let entry = entry.unwrap();
         match entry.path().extension().and_then(|e| e.to_str()) {
             Some("mako") | Some("rs") | Some("py") | Some("zip") => {
+                println!("cargo:rerun-if-changed={}", entry.path().display());
             }
             _ => {}
         }


### PR DESCRIPTION
This adjusts the style-servo println patch to be in a non-templated file.
Previously, the properties file change would cause the build script to rerun.