### PR TITLE
Skip building final rustc in preparatory steps

### DIFF
--- a/collector/src/execute.rs
+++ b/collector/src/execute.rs
@@ -345,6 +345,12 @@ impl<'a> CargoProcess<'a> {
                         ),
                     )?;
                 }
+            } else {
+                // If we're not going to record the final rustc, then there's
+                // absolutely no point in waiting for it to build. This will
+                // have the final rustc just immediately exit(0) without
+                // actually running it.
+                cmd.arg("--skip-this-rustc");
             }
 
             if self.incremental {

--- a/collector/src/rustc-fake.rs
+++ b/collector/src/rustc-fake.rs
@@ -229,6 +229,8 @@ fn main() {
                 panic!("unknown wrapper: {}", wrapper);
             }
         }
+    } else if let Some(pos) = args.iter().position(|arg| arg == "--skip-this-rustc") {
+        // do nothing
     } else {
         if env::var_os("EXPECT_ONLY_WRAPPED_RUSTC").is_some() {
             eprintln!("{:?} {:?}", tool, args);


### PR DESCRIPTION
This avoids waiting for the rustc to build and then throwing away the results;
dependencies will be cached in subsequent runs but this rustc will be thrown
away anyway.