### PR TITLE
Benchmark oldest commits first

### DIFF
--- a/site/static/status.html
+++ b/site/static/status.html
@@ -153,7 +153,7 @@
             }
             {
                 let element = document.createElement("td");
-                element.innerHTML = reason;
+                element.innerText = reason.InProgress ? `In Progress - ${reason.InProgress}` : reason;
                 row.appendChild(element);
             }
             table.appendChild(row);

--- a/site/static/status.html
+++ b/site/static/status.html
@@ -153,7 +153,17 @@
             }
             {
                 let element = document.createElement("td");
-                element.innerText = typeof reason == 'string' ? reason : `In Progress - ${reason.InProgress}`;
+                if (typeof reason == 'string') {
+                    element.innerText = reason;
+                } else if (reason.InProgress) {
+                    element.innerText = `{reason.InProgress} - in progress`;
+                } else if (reason["Try"] != undefined && reason.Try.pr) {
+                    console.log(reason);
+                    element.innerHTML = `Try for <a
+                        href="https://github.com/rust-lang/rust/pull/${reason["Try"].pr}">#${reason["Try"].pr}</a>`;
+                } else {
+                    element.innerText = JSON.stringify(reason);
+                }
                 row.appendChild(element);
             }
             table.appendChild(row);

--- a/site/static/status.html
+++ b/site/static/status.html
@@ -153,7 +153,7 @@
             }
             {
                 let element = document.createElement("td");
-                element.innerText = reason.InProgress ? `In Progress - ${reason.InProgress}` : reason;
+                element.innerText = typeof reason == 'string' ? reason : `In Progress - ${reason.InProgress}`;
                 row.appendChild(element);
             }
             table.appendChild(row);


### PR DESCRIPTION
This means that we have less cases of "straggler" holes being left behind. It can still happen, due to try parents being prioritized above anything else -- but mostly non-single commit gaps will be left.