### PR TITLE
Prepare build kinds in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,13 +37,12 @@ jobs:
     strategy:
       matrix:
         BENCH_INCLUDE_EXCLUDE_OPTS: [
-          "--exclude script-servo,webrender-wrench,style-servo",
-          "--include webrender-wrench,style-servo",
+          "--exclude script-servo,webrender-wrench,style-servo,cargo",
+          "--include webrender-wrench,style-servo,cargo",
           "--include script-servo",
         ]
         BUILD_KINDS: [
-          "Check,Doc",
-          "Debug",
+          "Check,Doc,Debug",
           "Opt",
         ]
     name: Test benchmarks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,13 +176,16 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "crossbeam-utils",
  "database",
  "env_logger",
  "futures",
  "intern",
+ "jobserver",
  "lazy_static",
  "libc",
  "log",
+ "num_cpus",
  "reqwest",
  "rustc-artifacts",
  "semver",
@@ -210,6 +213,17 @@ name = "core-foundation-sys"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "lazy_static",
+]
 
 [[package]]
 name = "crypto-mac"
@@ -732,6 +746,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
 dependencies = [
  "jemalloc-sys",
+ "libc",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2"
+dependencies = [
  "libc",
 ]
 

--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -25,6 +25,9 @@ rustc-artifacts = "0.2"
 database = { path = "../database" }
 intern = { path = "../intern" }
 futures = "0.3.5"
+num_cpus = "1.13"
+jobserver = "0.1.21"
+crossbeam-utils = "0.7"
 
 [[bin]]
 name = "collector"

--- a/collector/src/rustc-fake.rs
+++ b/collector/src/rustc-fake.rs
@@ -229,7 +229,7 @@ fn main() {
                 panic!("unknown wrapper: {}", wrapper);
             }
         }
-    } else if let Some(pos) = args.iter().position(|arg| arg == "--skip-this-rustc") {
+    } else if let Some(_) = args.iter().position(|arg| arg == "--skip-this-rustc") {
         // do nothing
     } else {
         if env::var_os("EXPECT_ONLY_WRAPPED_RUSTC").is_some() {


### PR DESCRIPTION
rustc is single threaded for a good portion of its compilation, and that means
that on many-core systems we're frequently only using one CPU core even during
preparation (where we don't care about noise). This builds all builds kinds in
parallel -- spawning N Cargos. We arrange for a jobserver to be passed to all
Cargos involved to make sure that we're not overloading the system with too many
processes.