### PR TITLE
Revert "Share target directories between benchmarks"

### DIFF
--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -13,7 +13,6 @@ use std::path::{Path, PathBuf};
 use std::process;
 use std::process::Command;
 use std::{str, time::Instant};
-use tempfile::TempDir;
 use tokio::runtime::Runtime;
 
 mod execute;
@@ -208,16 +207,6 @@ fn bench(
         );
     }
 
-    let bk_and_targets = build_kinds
-        .iter()
-        .map(|kind| Ok((*kind, TempDir::new()?)))
-        .collect::<anyhow::Result<Vec<_>>>()
-        .expect("created temp directories");
-    let bk_and_targets = bk_and_targets
-        .iter()
-        .map(|(k, td)| (*k, td.path()))
-        .collect::<Vec<_>>();
-
     let steps = benchmarks
         .iter()
         .map(|b| b.name.to_string())
@@ -261,13 +250,8 @@ fn bench(
             interned_cid,
             self_profile,
         );
-        let result = benchmark.measure(
-            &mut processor,
-            &bk_and_targets,
-            run_kinds,
-            compiler,
-            iterations,
-        );
+        let result =
+            benchmark.measure(&mut processor, build_kinds, run_kinds, compiler, iterations);
         if let Err(s) = result {
             eprintln!(
                 "collector error: Failed to benchmark '{}', recorded: {}",
@@ -750,22 +734,12 @@ fn main_result() -> anyhow::Result<i32> {
 
             eprintln!("Profiling with {:?}", profiler);
 
-            let bk_and_targets = build_kinds
-                .iter()
-                .map(|kind| Ok((*kind, TempDir::new()?)))
-                .collect::<anyhow::Result<Vec<_>>>()
-                .expect("created temp directories");
-            let bk_and_targets = bk_and_targets
-                .iter()
-                .map(|(k, td)| (*k, td.path()))
-                .collect::<Vec<_>>();
-
             let mut errors = BenchmarkErrors::new();
             for (i, benchmark) in benchmarks.iter().enumerate() {
                 eprintln!("{}", n_benchmarks_remaining(benchmarks.len() - i));
                 let mut processor = execute::ProfileProcessor::new(profiler, &out_dir, &id);
                 let result =
-                    benchmark.measure(&mut processor, &bk_and_targets, &run_kinds, compiler, 1);
+                    benchmark.measure(&mut processor, &build_kinds, &run_kinds, compiler, 1);
                 if let Err(ref s) = result {
                     errors.incr();
                     eprintln!(


### PR DESCRIPTION
Reverts rust-lang/rustc-perf#738

It appears to be a performance regression (up 5 minutes on the collector).