### PR TITLE
Avoid common failure modes

### DIFF
--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -118,6 +118,8 @@ pub trait Connection: Send + Sync {
         profile: &str,
         cache: &str,
     ) -> Vec<(ArtifactIdNumber, i32)>;
+
+    async fn purge_previous_results(&self, aid: &ArtifactId);
 }
 
 #[async_trait::async_trait]

--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -1076,4 +1076,16 @@ where
             .map(|r| (ArtifactIdNumber(r.get::<_, i16>(0) as u32), r.get(1)))
             .collect()
     }
+
+    async fn purge_previous_results(&self, artifact: &ArtifactId) {
+        let name = match artifact {
+            ArtifactId::Commit(commit) => commit.sha.to_string(),
+            ArtifactId::Artifact(a) => a.clone(),
+        };
+
+        self.conn()
+            .execute("delete from artifact where name = $1", &[&name])
+            .await
+            .unwrap();
+    }
 }

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -862,4 +862,15 @@ impl Connection for SqliteConnection {
     ) -> Vec<(ArtifactIdNumber, i32)> {
         Vec::new()
     }
+
+    async fn purge_previous_results(&self, artifact: &ArtifactId) {
+        let name = match artifact {
+            ArtifactId::Commit(commit) => commit.sha.to_string(),
+            ArtifactId::Artifact(a) => a.clone(),
+        };
+
+        self.raw_ref()
+            .execute("delete from artifact where name = ?", params![&name])
+            .unwrap();
+    }
 }

--- a/site/src/main.rs
+++ b/site/src/main.rs
@@ -25,12 +25,13 @@ async fn main() {
 
     let data: Arc<RwLock<Option<Arc<load::InputData>>>> = Arc::new(RwLock::new(None));
     let data_ = data.clone();
-    let db_url = env::var("DATABASE_URL").ok().or_else(|| {
-        env::args().nth(1)
-    }).unwrap_or_else(|| {
-        eprintln!("Either $DATABASE_URL or first argument must be a filepath to sqlite database or postgres:// URL");
-        std::process::exit(1);
-    });
+    let db_url = env::var("DATABASE_URL")
+        .ok()
+        .or_else(|| env::args().nth(1))
+        .unwrap_or_else(|| {
+            eprintln!("Defaulting to loading from `results.db`");
+            String::from("results.db")
+        });
     let fut = tokio::task::spawn_blocking(move || {
         tokio::task::spawn(async move {
             let res = Arc::new(load::InputData::from_fs(&db_url).await.unwrap());


### PR DESCRIPTION
This changes two things that @jonas-schievink hit recently:
 * Changes the default to replacing, rather than appending to existing collected data (on CI, we still append)
 * Adds the default database path to the server, matching the collector.