### PR TITLE
Remove njn from the triage roster.

### DIFF
--- a/triage/README.md
+++ b/triage/README.md
@@ -5,7 +5,7 @@ usage.
 
 ## Roster
 
-- Tuesday morning (Melbourne time): njn
+- Monday evening (North American time): TBD
 
 This is a good time to do it because This Week in Rust (see below) is usually
 published on Tuesday, US time, and so it means the PR to include the triage


### PR DESCRIPTION
Due to changes at Mozilla, unfortunately I won't be able to spend time on rustc perf triage any more.