### PR TITLE
Fix some fallout from #758

### DIFF
--- a/site/static/index.html
+++ b/site/static/index.html
@@ -102,7 +102,10 @@
                 tooltip.style.top  = (tooltipTopOffset  + top + shiftX) + "px";
                 tooltip.style.left = (tooltipLeftOffset + lft + shiftY) + "px";
 
-                tooltip.style.borderColor = isInterpolated(dataIdx) ? interpolatedColor : "#000000";
+                tooltip.style.borderColor = isInterpolated(dataIdx) ?
+                    interpolatedColor :
+                    u.series[seriesIdx].stroke;
+
                 let trailer = "";
                 if (absoluteMode) {
                     let pctSinceStart = (((u.data[seriesIdx][dataIdx] - u.data[seriesIdx][0]) / u.data[seriesIdx][0]) * 100).toFixed(2);

--- a/site/static/index.html
+++ b/site/static/index.html
@@ -76,8 +76,8 @@
         const commonCacheStateColors = {
             "full": "#7cb5ec",
             "incr-full": "#434348",
-            "incr-unchanged": "#f7a35c",
-            "incr-patched: println": "#90ed7d",
+            "incr-unchanged": "#90ed7d",
+            "incr-patched: println": "#f7a35c",
         };
 
         const otherCacheStateColors = ["#8085e9", "#f15c80", "#e4d354", "#2b908f", "#f45b5b", "#91e8e1"];


### PR DESCRIPTION
This brings back the colored tooltip border and swaps the canonical colors for `incr-unchanged` and `incr-patched: println` to match those on the "Dashboard" page.