### PR TITLE
Exclude rustc bootstrap from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,8 @@ jobs:
     strategy:
       matrix:
         BENCH_INCLUDE_EXCLUDE_OPTS: [
-          "--exclude webrender-wrench,style-servo,cargo",
-          "--include webrender-wrench,style-servo,cargo",
+          "--exclude webrender-wrench,style-servo,cargo,rustc",
+          "--include webrender-wrench,style-servo,cargo --exclude rustc",
         ]
         BUILD_KINDS: [
           "Check,Doc,Debug",


### PR DESCRIPTION
It's not working right now because "Test" is not a git tag or commit sha -- something to fix, for sure, but not right now.