### PR TITLE
Restructure looks of compare.html site

### DIFF
--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -18,7 +18,7 @@ input[type="checkbox"] {
 }
 </style>
 </head>
-<body class="container">
+<body class="container" style="max-width:800px">
     <div>&gt; <a href="index.html">graphs</a>, <a href="compare.html">compare</a>,
         <a href="dashboard.html">dashboard</a>, <a href="bootstrap.html">bootstrap</a>,
         <a href="status.html">status</a>.</div>

--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -46,18 +46,20 @@ input[type="checkbox"] {
         </ul>
     </div>
     <div id="content" style="display: none"></div>
-    <div id="settings">
-        <div id="commits" class="settings" style="text-align:left;">
-            <h3>Commits</h3>
-            Commit/Date A: <input width="100em" placeholder="YYYY-MM-DD or SHA" id="start-bound" /><br>
-            Commit/Date B: <input width="100em" placeholder="YYYY-MM-DD or SHA" id="end-bound" /><br>
-            <select id='stats' name="stat">
-            </select>
-            <div class="submit">
-                <a href="#" onClick="submit_settings(); return false;">Submit</a>
-            </div>
-        </div>
-    </div>
+    <form id="settings" action="">
+        <fieldset id="commits">
+            <legend>Commits</legend>
+            <label for="start-bound">Commit/Date A:</label>
+            <input width="100em" placeholder="YYYY-MM-DD or SHA" id="start-bound" /><br>
+            <label for="end-bound">Commit/Date B:</label>
+            <input width="100em" placeholder="YYYY-MM-DD or SHA" id="end-bound" /><br>
+        </fieldset>
+        <label for="stats">Choose a comparison method:</label>
+        <select id='stats' name="stat">
+        </select><br>
+        <input type="submit" value="Submit" onclick="submit_settings(); return false;">
+    </form>
+    <br>
     <div id="as-of"></div>
     <a href="https://github.com/rust-lang-nursery/rustc-perf">
         <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">

--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>rustc performance data</title>
 <link rel="stylesheet" type="text/css" href="perf.css">
 <link rel="alternate icon" type="image/png" href="/favicon-32x32.png">


### PR DESCRIPTION
This PR:
* adjusted the look of input form in compare.html site.
* limited body max-width at 800px:
    * there are much blank space in desktop.
    * to move content to screen central.
* added lame support (just a meta header) for mobile.

Closes #776.

---

Below are some comparison of old and new looks.

## Old

<details><summary>Top</summary>

![image](https://user-images.githubusercontent.com/15225902/94905126-8ff27780-04c6-11eb-90fb-7e8b7d3a658d.png)
</details>

<details><summary>Bottom</summary>

![image](https://user-images.githubusercontent.com/15225902/94904434-8583ae00-04c5-11eb-8f83-2ede889beeb6.png)
</details>

## New

<details><summary>Top</summary>

![image](https://user-images.githubusercontent.com/15225902/94904784-0e9ae500-04c6-11eb-9654-f7e6a1ff1d1a.png)
</details>

<details><summary>Bottom</summary>

![image](https://user-images.githubusercontent.com/15225902/94904861-2a05f000-04c6-11eb-8f27-b7209aba8abb.png)
</details>

On emulated phone mode:

<details><summary>Warning: big picture</summary>

![image](https://user-images.githubusercontent.com/15225902/94904995-5cafe880-04c6-11eb-8066-49cefadaa3b3.png)
</details>
