### PR TITLE
detailed-query page: add links to load the crox profile in speedscope and the FF profiler

### DIFF
--- a/site/static/detailed-query.html
+++ b/site/static/detailed-query.html
@@ -128,14 +128,34 @@
                 let url = dl_url(commit, bench, run);
                 return `<a href="${url}">raw</a>`;
             };
+            let processed_url = (commit, bench, run, ty) => {
+                return `/perf/processed-self-profile?commit=${commit}&benchmark=${bench}&run_name=${run}&type=${ty}`;
+            };
             let processed_link = (commit, bench, run, ty) => {
-                let url = `/perf/processed-self-profile?commit=${commit}&benchmark=${bench}&run_name=${run}&type=${ty}`;
+                let url = processed_url(commit, bench, run, ty);
                 return `<a href="${url}">${ty}</a>`;
+            };
+            let processed_crox_url = (commit, bench, run) => {
+                let crox_url = window.location.origin + processed_url(commit, bench, run, "crox");                
+                return encodeURIComponent(crox_url);
+            };
+            let speedscope_link = (commit, bench, run) => {
+                let benchmark_name = `${bench} run ${run}`;
+                let crox_url = processed_crox_url(commit, bench, run);
+                let speedscope_url = `https://www.speedscope.app/#profileURL=${crox_url}&title=${encodeURIComponent(benchmark_name)}`;
+                return `<a href="${speedscope_url}">speedscope.app</a>`;
+            };
+            let firefox_profiler_link = (commit, bench, run) => {
+                let crox_url = processed_crox_url(commit, bench, run);
+                let ff_url = `https://profiler.firefox.com/from-url/${crox_url}/marker-chart/?v=5`;
+                return `<a href="${ff_url}">Firefox profiler</a>`;
             };
             txt = `Download/view
                 ${dl_link(state.commit, state.benchmark, state.run_name)},
                 ${processed_link(state.commit, state.benchmark, state.run_name, "flamegraph")},
                 ${processed_link(state.commit, state.benchmark, state.run_name, "crox")}
+                (${speedscope_link(state.commit, state.benchmark, state.run_name)}, 
+                 ${firefox_profiler_link(state.commit, state.benchmark, state.run_name)})
                 results for ${state.commit.substring(0, 10)}`;
             if (state.base_commit) {
                 txt += "<br>";
@@ -143,6 +163,8 @@
                     ${dl_link(state.base_commit, state.benchmark, state.run_name)},
                     ${processed_link(state.base_commit, state.benchmark, state.run_name, "flamegraph")},
                     ${processed_link(state.base_commit, state.benchmark, state.run_name, "crox")}
+                    (${speedscope_link(state.base_commit, state.benchmark, state.run_name)}, 
+                     ${firefox_profiler_link(state.base_commit, state.benchmark, state.run_name)})
                     results for ${state.base_commit.substring(0, 10)}`;
             }
             document.querySelector("#raw-urls").innerHTML = txt;


### PR DESCRIPTION
I've tested this locally as we discussed, on [an older PR](https://perf.rust-lang.org/compare.html?start=de32266a1780aa4ef748ce7f6200a1554fad0aca&end=4e4e6f15b872a60816b90eed0c8a72b153d4460c), so I hope it works deployed on perf.rlo.

(Technically, we could *also* use the FF profiler to compare two profiles, but it had errors when I tried it. I'll leave that for the future)