### PR TITLE
Make --self-profile work for rustdoc

### DIFF
--- a/collector/src/execute.rs
+++ b/collector/src/execute.rs
@@ -724,8 +724,8 @@ impl Upload {
 }
 
 impl<'a> Processor for MeasureProcessor<'a> {
-    fn profiler(&self, build: BuildKind) -> Profiler {
-        if self.is_first_collection && self.self_profile && build != BuildKind::Doc {
+    fn profiler(&self, _build: BuildKind) -> Profiler {
+        if self.is_first_collection && self.self_profile {
             Profiler::PerfStatSelfProfile
         } else {
             Profiler::PerfStat


### PR DESCRIPTION
This first requires the changes in https://github.com/rust-lang/rust/pull/79586/ to be merged.
Closes https://github.com/rust-lang/rustc-perf/issues/797 (I think? Are there any other steps to show this info for master commits?)

![image](https://user-images.githubusercontent.com/23638587/100696854-853b4e00-3362-11eb-9791-179f97ddaf9e.png)