### PR TITLE
Add `S-waiting-on-perf` as soon as run is requested

### DIFF
--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -76,7 +76,9 @@ pub async fn handle_github(
         post_comment(
             &data.config,
             request.issue.number,
-            "Awaiting bors try build completion.",
+            "Awaiting bors try build completion.
+
+@rustbot label: +S-waiting-on-perf",
         )
         .await;
         return Ok(github::Response);
@@ -525,9 +527,7 @@ async fn enqueue_sha(
     };
     if queued {
         let msg = format!(
-            "Queued {} with parent {}, future [comparison URL]({}).
-
-@rustbot label: +S-waiting-on-perf",
+            "Queued {} with parent {}, future [comparison URL]({}).",
             commit_response.sha,
             commit_response.parents[0].sha,
             try_commit.comparison_url(),


### PR DESCRIPTION
I realized after #810 that it makes more sense to add the label as soon
as the run is requested, since it's still "waiting on perf" even though
the perf run itself hasn't started yet.