### PR TITLE
Happy birthday to the last noise run

### DIFF
--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -27,7 +27,7 @@ input[type="checkbox"] {
         <p>Warning: although measurements known to have high variation are marked with
             '?'/'??', this does not mean that unmarked measurements are guaranteed to have
             low variation. Verify the measurement against the
-            <a href="compare.html?start=333c32a5a4a51cae562c47e0669bc5aeaf741c45&end=1f8df2508f2772d83011f0f651de86181123e519&stat=instructions:u">
+            <a href="compare.html?start=cfba499271ba53190a1d3647ff8f7202ec9ed6f5&end=399b6452b5d9982438be208668bc758479f13725&stat=instructions:u">
             last "noise run"</a> which shows the perf difference of a non-functional change.
         </p>
     </div>

--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -27,7 +27,7 @@ input[type="checkbox"] {
         <p>Warning: although measurements known to have high variation are marked with
             '?'/'??', this does not mean that unmarked measurements are guaranteed to have
             low variation. Verify the measurement against the
-            <a href="compare.html?start=cfba499271ba53190a1d3647ff8f7202ec9ed6f5&end=399b6452b5d9982438be208668bc758479f13725&stat=instructions:u">
+            <a href="compare.html?start=3158857297417566824631a85c4cb3c0615ec6c2&end=7e0241c63755ea28045d512b742f50b307874419&stat=instructions:u">
             last "noise run"</a> which shows the perf difference of a non-functional change.
         </p>
     </div>


### PR DESCRIPTION
The old noise run is from 2020-02-06, which was exactly a year ago. 
The new noise run from 2021-02-06 measures the non-functional changes from rust-lang/rust#81792 "Bump nightly version to 1.52.0"