### PR TITLE
move the stat selector UI above the content

### DIFF
--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -46,7 +46,6 @@ input[type="checkbox"] {
                 the addition of a `println!` macro somewhere in the source code.</li>
         </ul>
     </div>
-    <div id="content" style="display: none"></div>
     <form id="settings" action="">
         <fieldset id="commits">
             <legend>Commits</legend>
@@ -60,6 +59,7 @@ input[type="checkbox"] {
         </select><br>
         <input type="submit" value="Submit" onclick="submit_settings(); return false;">
     </form>
+    <div id="content" style="display: none; margin-top: 15px"></div>
     <br>
     <div id="as-of"></div>
     <a href="https://github.com/rust-lang-nursery/rustc-perf">


### PR DESCRIPTION
As requested [on zulip here](https://rust-lang.zulipchat.com/#narrow/stream/247081-t-compiler.2Fperformance/topic/lets.20keep.20talking.20about.20perf.2Erlo/near/225597033)

![image](https://user-images.githubusercontent.com/247183/107277308-7a80f180-6a54-11eb-86a8-4f1d79add04b.png)
