### PR TITLE
fix time diff

### DIFF
--- a/site/static/status.html
+++ b/site/static/status.html
@@ -118,7 +118,7 @@
                 let end = new Date(data.most_recent_end * 1000);
                 element.innerHTML = `No current collection in progress. Last one
                     finished at ${end.toLocaleString()} local time,
-                    ${format_duration(Math.trunc((new Date()/1000 - end)))} ago.`;
+                    ${format_duration(Math.trunc((new Date() - end)/1000))} ago.`;
             } else {
                 element.innerHTML = "No current collection in progress.";
             }


### PR DESCRIPTION
Currently at https://perf.rust-lang.org/status.html
time shown as
```
No current collection in progress. Last one finished at 2/26/2021, 7:30:10 PM local time, -14m0-31s ago.
```
so fixing last portion to real time diff.