### PR TITLE
Add basic help page to document rust-timer commands

### DIFF
--- a/site/static/bootstrap.html
+++ b/site/static/bootstrap.html
@@ -54,7 +54,7 @@
 <body>
     <div>&gt; <a href="index.html">graphs</a>, <a href="compare.html">compare</a>,
         <a href="dashboard.html">dashboard</a>, <a href="bootstrap.html">bootstrap</a>,
-        <a href="status.html">status</a>.</div>
+        <a href="status.html">status</a>, <a href="help.html">help</a>.</div>
     <div id="settings">
         start: <input placeholder="yyyy-mm-dd or commit" id="start-bound" />
         end: <input placeholder="yyyy-mm-dd or commit" id="end-bound" />

--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -22,7 +22,7 @@ input[type="checkbox"] {
 <body class="container" style="max-width:800px">
     <div>&gt; <a href="index.html">graphs</a>, <a href="compare.html">compare</a>,
         <a href="dashboard.html">dashboard</a>, <a href="bootstrap.html">bootstrap</a>,
-        <a href="status.html">status</a>.</div>
+        <a href="status.html">status</a>, <a href="help.html">help</a>.</div>
     <div style=''>
         <p>Warning: although measurements known to have high variation are marked with
             '?'/'??', this does not mean that unmarked measurements are guaranteed to have

--- a/site/static/dashboard.html
+++ b/site/static/dashboard.html
@@ -11,7 +11,7 @@
 <body class="container">
     <div>&gt; <a href="index.html">graphs</a>, <a href="compare.html">compare</a>,
         <a href="dashboard.html">dashboard</a>, <a href="bootstrap.html">bootstrap</a>,
-        <a href="status.html">status</a>.</div>
+        <a href="status.html">status</a>, <a href="help.html">help</a>.</div>
     <div id="check-average-times"></div>
     <div id="debug-average-times"></div>
     <div id="opt-average-times"></div>

--- a/site/static/detailed-query.html
+++ b/site/static/detailed-query.html
@@ -52,7 +52,7 @@
 <body class="container">
     <div>&gt; <a href="index.html">graphs</a>, <a href="compare.html">compare</a>,
         <a href="dashboard.html">dashboard</a>, <a href="bootstrap.html">bootstrap</a>,
-        <a href="status.html">status</a>.</div>
+        <a href="status.html">status</a>, <a href="help.html">help</a>.</div>
     <div id="content">
         <h3 id="title"></h3>
         <div id="raw-urls"></div>

--- a/site/static/help.html
+++ b/site/static/help.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>rustc performance data</title>
+<link rel="stylesheet" type="text/css" href="perf.css">
+<link rel="alternate icon" type="image/png" href="/favicon-32x32.png">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<style>
+    .help-content {
+        font-family: Helvetica, Arial, sans-serif;
+        line-height: 140%;
+        font-size: 16px;
+        max-width: 50em;
+    }
+    .help-content code {
+        background: #eee;
+        border-radius: 5px;
+        padding: 2px;
+    }
+</style>
+</head>
+<body class="container">
+    <div>&gt; <a href="index.html">graphs</a>, <a href="compare.html">compare</a>,
+        <a href="dashboard.html">dashboard</a>, <a href="bootstrap.html">bootstrap</a>,
+        <a href="status.html">status</a>, <a href="help.html">help</a>.</div>
+    <div style="text-align: center;">
+        <a href="https://github.com/rust-lang-nursery/rustc-perf">Contribute on GitHub</a>
+    </div>
+    <div class="help-content">
+        <h3><b><code>@rust-timer</code> commands</b></h3>
+        <p><code>@rust-timer</code> supports several commands, the most common (and simple) being <code>@rust-timer queue</code>. This command is usually invoked as <code>@bors try @rust-timer queue</code>, which starts a bors "try" run (not a merge). <code>@rust-timer</code> will wait for the try run to finish, and if it succeeds will then queue a perf run.</p>
+        <p><code>@rust-timer queue</code> has a few extra options that can be useful:</p>
+        <ul>
+            <li><code>include=&lt;INCLUDE&gt;</code> only runs benchmarks with <code>&lt;INCLUDE&gt;</code> in their title. For example, if you just want to run rustdoc benchmarks, do <code>@bors try @rust-timer queue include=-doc</code>; the <code>-doc</code> matches the <code>-doc</code> appended to rustdoc benchmarks. <code>&lt;INCLUDE&gt;</code> is a comma-separated list of substrings; only one of the items in the list of substrings must match.</li>
+            <li><code>exclude=&lt;EXCLUDE&gt;</code> is similar to <code>include=</code>, but instead skips any benchmarks that have one of the items in the list of substrings as a substring of its name.</li>
+            <li><code>runs=&lt;RUNS&gt;</code> configures how many times the benchmark is run. <code>&lt;RUNS&gt;</code> is an integer.</li>
+        </ul>
+        <p><code>@rust-timer</code> has more commands than just <code>@rust-timer queue</code>, but the <code>queue</code> command is the most used.</p>
+    <script src="shared.js"></script>
+</body>
+</html>

--- a/site/static/help.html
+++ b/site/static/help.html
@@ -34,7 +34,7 @@
         <ul>
             <li><code>include=&lt;INCLUDE&gt;</code> only runs benchmarks with <code>&lt;INCLUDE&gt;</code> in their title. For example, if you just want to run rustdoc benchmarks, do <code>@bors try @rust-timer queue include=-doc</code>; the <code>-doc</code> matches the <code>-doc</code> appended to rustdoc benchmarks. <code>&lt;INCLUDE&gt;</code> is a comma-separated list of substrings; only one of the items in the list of substrings must match.</li>
             <li><code>exclude=&lt;EXCLUDE&gt;</code> is similar to <code>include=</code>, but instead skips any benchmarks that have one of the items in the list of substrings as a substring of its name.</li>
-            <li><code>runs=&lt;RUNS&gt;</code> configures how many times the benchmark is run. <code>&lt;RUNS&gt;</code> is an integer.</li>
+            <li><code>runs=&lt;RUNS&gt;</code> configures how many times the benchmark is run. <code>&lt;RUNS&gt;</code> is an integer. All benchmarks run at least once by default, but some run more than one time. You can use the <code>runs</code> option to override the default run count and make every benchmark run for <code>&lt;RUNS&gt;</code> times.</li>
         </ul>
         <p><code>@rust-timer</code> has more commands than just <code>@rust-timer queue</code>, but the <code>queue</code> command is the most used.</p>
     <script src="shared.js"></script>

--- a/site/static/index.html
+++ b/site/static/index.html
@@ -54,7 +54,7 @@
 <body>
     <div>&gt; <a href="index.html">graphs</a>, <a href="compare.html">compare</a>,
         <a href="dashboard.html">dashboard</a>, <a href="bootstrap.html">bootstrap</a>,
-        <a href="status.html">status</a>.</div>
+        <a href="status.html">status</a>, <a href="help.html">help</a>.</div>
     <div id="settings">
         start: <input placeholder="yyyy-mm-dd or commit" id="start-bound" />
         end: <input placeholder="yyyy-mm-dd or commit" id="end-bound" />

--- a/site/static/status.html
+++ b/site/static/status.html
@@ -20,7 +20,7 @@
 <body class="container">
     <div>&gt; <a href="index.html">graphs</a>, <a href="compare.html">compare</a>,
         <a href="dashboard.html">dashboard</a>, <a href="bootstrap.html">bootstrap</a>,
-        <a href="status.html">status</a>.</div>
+        <a href="status.html">status</a>, <a href="help.html">help</a>.</div>
     <div id="data">
         <div id="data-insert-js"></div>
         Benchmarks for last commit:


### PR DESCRIPTION
Both I and `@jyn514` had no idea that `@rust-timer queue exclude`
existed because there's no documentation, or at least I wasn't able to
find any publicized documentation.

r? @Mark-Simulacrum
cc @jyn514
