### PR TITLE
fix timings order across browsers

### DIFF
--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -246,7 +246,7 @@ input[type="checkbox"] {
             ...bootstrap_names
                 .map(name => name)
                 .map(name => ({name, is_bootstrap: true, fields: to_fields_bootstrap(name)})),
-            ...test_names.map(name => ({name, fields: to_fields(name)})),
+            ...test_names.map(name => ({name, is_bootstrap: false, fields: to_fields(name)})),
         ];
 
         function to_fields_bootstrap(name) {
@@ -335,10 +335,16 @@ input[type="checkbox"] {
         }
 
         fields.sort((a, b) => {
-            if (a.is_bootstrap != b.is_bootstrap) {
-                return 1;
-            } else {
+            if (a.is_bootstrap == b.is_bootstrap){
                 return b.farthest_pct - a.farthest_pct;
+            }
+            else{
+                if (a.is_bootstrap){
+                    return 0;
+                }
+                else{
+                    return 1;
+                }
             }
         });
 


### PR DESCRIPTION
Currently order if timing differs in different browsers. For example, check this page in chrome and firefox https://perf.rust-lang.org/compare.html?start=15598a83db88ec7a32ea18a44dd6309f32edc07e&end=f288a8e816163b97425adb1baca86b573395e3ec , you can see that in chrome, bootstrap timings goes first, but in firefox - last.

Fixes by setting `is_bootstrap=false` for non bootstrap, and then sorting (as `is_bootstrap` became `true\false` always, instead being none sometimes).