### PR TITLE
Use default branch for rustc if the chosen ref doesn't exist

### DIFF
--- a/collector/src/execute/rustc.rs
+++ b/collector/src/execute/rustc.rs
@@ -37,7 +37,7 @@ fn record(
     aid: database::ArtifactIdNumber,
 ) -> anyhow::Result<()> {
     let checkout = Path::new("rust");
-    let status = Command::new("git")
+    let mut status = Command::new("git")
         .current_dir("rust")
         .arg("reset")
         .arg("--hard")
@@ -48,17 +48,17 @@ fn record(
         .status()
         .context("git reset --hard")?;
 
-    if !status.success() {
+    if !status.success() && matches!(artifact, ArtifactId::Artifact(_)) {
         log::warn!("git reset --hard {} failed - trying default branch", artifact);
-        let status = Command::new("git")
+        status = Command::new("git")
             .current_dir("rust")
             .arg("reset")
             .arg("--hard")
             .arg("origin/HEAD")
             .status()
             .context("git reset --hard")?;
-        assert!(status.success(), "git reset --hard successful");
     }
+    assert!(status.success(), "git reset --hard successful");
 
     let status = Command::new("git")
         .current_dir("rust")
@@ -156,7 +156,7 @@ fn record(
 
 fn checkout(artifact: &ArtifactId) -> anyhow::Result<()> {
     if Path::new("rust").exists() {
-        let status = Command::new("git")
+        let mut status = Command::new("git")
             .current_dir("rust")
             .arg("fetch")
             .arg("origin")
@@ -167,18 +167,17 @@ fn checkout(artifact: &ArtifactId) -> anyhow::Result<()> {
             .status()
             .context("git fetch origin")?;
 
-        if !status.success() {
+        if !status.success() && matches!(artifact, ArtifactId::Artifact(_)) {
             log::warn!("git fetch origin {} failed - trying default branch", artifact);
-            let status = Command::new("git")
+            status = Command::new("git")
                 .current_dir("rust")
                 .arg("fetch")
                 .arg("origin")
                 .arg("HEAD")
                 .status()
                 .context("git fetch origin HEAD")?;
-
-            assert!(status.success(), "git fetch successful");
         }
+        assert!(status.success(), "git fetch successful");
 
     } else {
         let status = Command::new("git")

--- a/collector/src/execute/rustc.rs
+++ b/collector/src/execute/rustc.rs
@@ -47,7 +47,19 @@ fn record(
         })
         .status()
         .context("git reset --hard")?;
-    assert!(status.success(), "git reset --hard successful");
+
+    if !status.success() {
+        log::warn!("git reset --hard {} failed - trying default branch", artifact);
+        let status = Command::new("git")
+            .current_dir("rust")
+            .arg("reset")
+            .arg("--hard")
+            .arg("origin/HEAD")
+            .status()
+            .context("git reset --hard")?;
+        assert!(status.success(), "git reset --hard successful");
+    }
+
     let status = Command::new("git")
         .current_dir("rust")
         .arg("clean")
@@ -154,7 +166,20 @@ fn checkout(artifact: &ArtifactId) -> anyhow::Result<()> {
             })
             .status()
             .context("git fetch origin")?;
-        assert!(status.success(), "git fetch successful");
+
+        if !status.success() {
+            log::warn!("git fetch origin {} failed - trying default branch", artifact);
+            let status = Command::new("git")
+                .current_dir("rust")
+                .arg("fetch")
+                .arg("origin")
+                .arg("HEAD")
+                .status()
+                .context("git fetch origin HEAD")?;
+
+            assert!(status.success(), "git fetch successful");
+        }
+
     } else {
         let status = Command::new("git")
             .arg("clone")


### PR DESCRIPTION
A small fix to default to `rust/origin/HEAD` if checking out a specific ref fails. Previously this would halt the whole collector run. This allows easier comparing of bench_local runs as you can freely choose the run ID.

If the chosen ref (whatever it is) fails to compile then the benchmark is recorded as an error and the run continues. No changes needed here in my opinion.

See https://github.com/rust-lang/rustc-perf/issues/837