### PR TITLE
add feature gate for const_fn splitting

### DIFF
--- a/collector/benchmarks/ctfe-stress-4/src/lib.rs
+++ b/collector/benchmarks/ctfe-stress-4/src/lib.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)]
-#![feature(const_fn, const_eval_limit)]
+#![feature(const_fn, const_fn_trait_bound, const_fn_unsize, const_eval_limit)]
 #![const_eval_limit = "10000000"]
 use std::mem::MaybeUninit;
 


### PR DESCRIPTION
Cc https://github.com/rust-lang/rust/pull/84310
I have no idea if this will even build without that PR landing first, though... but that PR cannot land until the perf test suite is fixed...