### PR TITLE
remove unused const_fn feature

### DIFF
--- a/collector/benchmarks/ctfe-stress-4/src/lib.rs
+++ b/collector/benchmarks/ctfe-stress-4/src/lib.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)]
-#![feature(const_fn, const_fn_trait_bound, const_fn_unsize, const_eval_limit)]
+#![feature(const_fn_trait_bound, const_fn_unsize, const_eval_limit)]
 #![const_eval_limit = "10000000"]
 use std::mem::MaybeUninit;
 

--- a/collector/benchmarks/packed-simd/src/lib.rs
+++ b/collector/benchmarks/packed-simd/src/lib.rs
@@ -201,7 +201,6 @@
 
 #![feature(
     repr_simd,
-    const_fn,
     platform_intrinsics,
     stdsimd,
     aarch64_target_feature,


### PR DESCRIPTION
I verified that `packed-simd` still builds with a recent nightly.

I think the `const_fn` feature in `style-servo` is probably also unused (and should be removed since we plan to remove that feature flag), but I can't build-test that: it fails to build even on rustc-perf master.