### PR TITLE
Remove incorrect and redundant options from git apply command line

### DIFF
--- a/collector/src/execute.rs
+++ b/collector/src/execute.rs
@@ -1550,7 +1550,7 @@ impl Patch {
         log::debug!("applying {} to {:?}", self.name, dir);
 
         let mut cmd = Command::new("git");
-        cmd.current_dir(dir).args(&["apply"]).args(&["-Np1"]).arg(&*self.path);
+        cmd.current_dir(dir).args(&["apply"]).arg(&*self.path);
 
         command_output(&mut cmd)?;
 


### PR DESCRIPTION
In d0712f6094b6f12de7674ed5559edf7b3c0aac5b `patch -Np1 -i` was replaced
with `git apply -Np1`, but `-N` flag has a different meaning in git:

> mark new files with `git add --intent-to-add`

Additionally the flag was added in v2.19.0, while git version used on
perf.rust-lang.org is apparently older and execution fails with error:

> unknown switch `N'

The default behaviour of git apply should be sufficient to match the
original one. Remove all flags from the command line.