### PR TITLE
Categorize perf runs when posting to GitHub

### DIFF
--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -151,12 +151,11 @@ impl ComparisonSummary<'_> {
             .map(|(i, _)| i);
         let hi = hi.map(|hi| benchmarks.remove(hi));
 
-        benchmarks.clear();
-
         Some(ComparisonSummary { hi, lo })
     }
+
     /// The direction of the changes
-    fn direction(&self) -> Option<Direction> {
+    pub fn direction(&self) -> Option<Direction> {
         let d = match (&self.hi, &self.lo) {
             (None, None) => return None,
             (Some(b), None) => b.direction(),
@@ -497,7 +496,7 @@ impl BenchmarkComparison<'_> {
 
 // The direction of a performance change
 #[derive(PartialEq, Eq, Hash)]
-enum Direction {
+pub enum Direction {
     Improvement,
     Regression,
     Mixed,


### PR DESCRIPTION
When the triage bot posts the results of running a performance run, it now provides a summary of the performance run. It should look something like this:

*****
Finished benchmarking try commit (ab345): [comparison url]().
 
**Summary**:  This change led to significant regressions 😿 in compiler performance.
- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=5b638c1d3751b7ab31cac9739add516bdf39e10a&end=35fff69d043b1c0f5c29894e7f4b0da8b039c131&stat=instructions:u) (up to 4.3% on `full` builds of `wg-grammar-check`)
