### PR TITLE
escape query name to prevent rendering it as html

### DIFF
--- a/site/static/detailed-query.html
+++ b/site/static/detailed-query.html
@@ -273,7 +273,8 @@
         function to_object(element) {
             if (!element.length) {
                 element = [
-                    element.label,
+                    // escape html, to prevent rendering queries like <unknown> as tags
+                    escapeHtml(element.label),
                     [ element.self_time.secs, element.self_time.nanos ],
                     element.percent_total_time,
                     element.number_of_cache_misses,

--- a/site/static/shared.js
+++ b/site/static/shared.js
@@ -252,3 +252,13 @@ function make_request(path, body) {
         console.log("error fetching ", path, ": ", err);
     });
 }
+
+// https://stackoverflow.com/questions/6234773
+function escapeHtml(unsafe) {
+    return unsafe
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#039;");
+}


### PR DESCRIPTION
This fixes issue with `<unknown>` query name will rendered as tag and became invisible.

For example see https://perf.rust-lang.org/detailed-query.html?sort_idx=1&commit=4bc7477fe1c867c78f756dbad76db4ea55c7eebf&base_commit=c5fbcd35a8217a17f6b63a22217ace06cf8f5f02&benchmark=coercions-debug&run_name=incr-unchanged (first string in table)