### PR TITLE
Change perf-regression-justified to perf-regression-triaged

### DIFF
--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -647,7 +647,7 @@ pub async fn post_finished(data: &InputData) {
                             Direction::Regression | Direction::Mixed =>
                                 "\n\n**Next Steps**: If you can justify the \
                 regressions found in this perf run, please indicate this with \
-                `@rustbot label: +perf-regression-justified` along with \
+                `@rustbot label: +perf-regression-triaged` along with \
                 sufficient written justification. If you cannot justify the regressions \
                 please fix the regressions and do another perf run. If the next run shows \
                 neutral or positive results, the label will be automatically removed.",


### PR DESCRIPTION
The label must indicate "this perf regression has been triaged" which can mean many things:
* the regression was justified (i.e., the compiler got slower, but it's worth it for some reason)
* the regression was deemed to be a false positive
* the regression is fixed in another PR
* the regression won't be fixed now, but we have an issue open that when addressed will fix the perf issue
* the regression needs to be reverted

While I'm unsure if perf-regression-triaged is the best name to capture this, I believe it to be much better than using the word "justified". 