### PR TITLE
Keep usage of aid and cid straight

### DIFF
--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -75,11 +75,11 @@ pub trait Connection: Send + Sync {
     async fn get_pstats(
         &self,
         series: &[u32],
-        cid: &[Option<ArtifactIdNumber>],
+        artifact_row_id: &[Option<ArtifactIdNumber>],
     ) -> Vec<Vec<Option<f64>>>;
     async fn get_self_profile(
         &self,
-        cid: ArtifactIdNumber,
+        artifact_row_id: ArtifactIdNumber,
         crate_: &str,
         profile: &str,
         cache: &str,
@@ -87,9 +87,10 @@ pub trait Connection: Send + Sync {
     async fn get_self_profile_query(
         &self,
         series: u32,
-        cid: ArtifactIdNumber,
+        artifact_row_id: ArtifactIdNumber,
     ) -> Option<QueryDatum>;
-    async fn get_error(&self, cid: ArtifactIdNumber) -> HashMap<String, Option<String>>;
+    async fn get_error(&self, artifact_row_id: ArtifactIdNumber)
+        -> HashMap<String, Option<String>>;
 
     async fn queue_pr(
         &self,

--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -584,16 +584,16 @@ where
     async fn get_pstats(
         &self,
         series: &[u32],
-        cids: &[Option<crate::ArtifactIdNumber>],
+        artifact_row_ids: &[Option<crate::ArtifactIdNumber>],
     ) -> Vec<Vec<Option<f64>>> {
         let series = series.iter().map(|sid| *sid as i32).collect::<Vec<_>>();
-        let cids = cids
+        let artifact_row_ids = artifact_row_ids
             .iter()
             .map(|id| id.map(|id| id.0 as i32))
             .collect::<Vec<_>>();
         let rows = self
             .conn()
-            .query(&self.statements().get_pstat, &[&series, &cids])
+            .query(&self.statements().get_pstat, &[&series, &artifact_row_ids])
             .await
             .unwrap();
         rows.into_iter()
@@ -603,13 +603,13 @@ where
     async fn get_self_profile_query(
         &self,
         series: u32,
-        cid: crate::ArtifactIdNumber,
+        artifact_row_id: crate::ArtifactIdNumber,
     ) -> Option<crate::QueryDatum> {
         let row = self
             .conn()
             .query_opt(
                 &self.statements().get_self_profile_query,
-                &[&(series as i32), &(cid.0 as i32)],
+                &[&(series as i32), &(artifact_row_id.0 as i32)],
             )
             .await
             .unwrap()?;
@@ -626,7 +626,7 @@ where
     }
     async fn get_self_profile(
         &self,
-        cid: ArtifactIdNumber,
+        artifact_row_id: ArtifactIdNumber,
         crate_: &str,
         profile: &str,
         cache: &str,
@@ -635,7 +635,7 @@ where
             .conn()
             .query(
                 &self.statements().get_self_profile,
-                &[&crate_, &profile, &cache, &(cid.0 as i32)],
+                &[&crate_, &profile, &cache, &(artifact_row_id.0 as i32)],
             )
             .await
             .unwrap();
@@ -658,10 +658,13 @@ where
             })
             .collect()
     }
-    async fn get_error(&self, cid: crate::ArtifactIdNumber) -> HashMap<String, Option<String>> {
+    async fn get_error(
+        &self,
+        artifact_row_id: crate::ArtifactIdNumber,
+    ) -> HashMap<String, Option<String>> {
         let rows = self
             .conn()
-            .query(&self.statements().get_error, &[&(cid.0 as i32)])
+            .query(&self.statements().get_error, &[&(artifact_row_id.0 as i32)])
             .await
             .unwrap();
         rows.into_iter()

--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -236,7 +236,7 @@ pub async fn compare_given_commits(
         Some(b) => b,
         None => return Ok(None),
     };
-    let cids = Arc::new(vec![a.clone(), b.clone()]);
+    let aids = Arc::new(vec![a.clone(), b.clone()]);
 
     // get all crates, cache, and profile combinations for the given stat
     let query = selector::Query::new()
@@ -247,7 +247,7 @@ pub async fn compare_given_commits(
 
     // `responses` contains series iterators. The first element in the iterator is the data
     // for `a` and the second is the data for `b`
-    let mut responses = ctxt.query::<Option<f64>>(query, cids).await?;
+    let mut responses = ctxt.query::<Option<f64>>(query, aids).await?;
 
     let conn = ctxt.conn().await;
 

--- a/site/src/server.rs
+++ b/site/src/server.rs
@@ -141,7 +141,7 @@ pub async fn handle_dashboard(ctxt: Arc<SiteCtxt>) -> ServerResult<dashboard::Re
         versions.drain(first_beta..last_beta);
     }
 
-    let cids = Arc::new(
+    let artifact_ids = Arc::new(
         versions
             .into_iter()
             .map(|v| ArtifactId::Artifact(v.to_string()))
@@ -176,7 +176,7 @@ pub async fn handle_dashboard(ctxt: Arc<SiteCtxt>) -> ServerResult<dashboard::Re
         let summary_patches = &summary_patches;
         let ctxt = &ctxt;
         let query = &query;
-        let cids = &cids;
+        let aids = &artifact_ids;
         async move {
             let mut cases = dashboard::Cases::default();
             for patch in summary_patches.iter() {
@@ -186,7 +186,7 @@ pub async fn handle_dashboard(ctxt: Arc<SiteCtxt>) -> ServerResult<dashboard::Re
                             .clone()
                             .set(Tag::Profile, selector::Selector::One(profile))
                             .set(Tag::Cache, selector::Selector::One(patch)),
-                        cids.clone(),
+                        aids.clone(),
                     )
                     .await?;
 
@@ -216,9 +216,9 @@ pub async fn handle_dashboard(ctxt: Arc<SiteCtxt>) -> ServerResult<dashboard::Re
     .unwrap();
 
     Ok(dashboard::Response {
-        versions: cids
+        versions: artifact_ids
             .iter()
-            .map(|cid| match cid {
+            .map(|aid| match aid {
                 ArtifactId::Commit(c) => format!("master: {}", &c.sha.to_string()[0..8]),
                 ArtifactId::Artifact(aid) => aid.clone(),
             })
@@ -374,8 +374,8 @@ fn to_graph_data<'a>(
     points: impl Iterator<Item = ((ArtifactId, Option<f64>), Interpolated)> + 'a,
 ) -> impl Iterator<Item = graph::GraphData> + 'a {
     let mut first = None;
-    points.map(move |((cid, point), interpolated)| {
-        let commit = if let ArtifactId::Commit(commit) = cid {
+    points.map(move |((aid, point), interpolated)| {
+        let commit = if let ArtifactId::Commit(commit) = aid {
             commit
         } else {
             unimplemented!()


### PR DESCRIPTION
The code base uses `cid` or `collection_id` for two different things. This PR makes a clear distinction between `artifact_id` (sometimes `aid`) which are ids for artifacts and `collection_id` (sometimes cid) which are ids for collections. Additionally, this PR attempts to differentiate between `artifact_id` which are string representations of artifacts and `artifact_row_id` which is the database row number for a specific artifact record. 

This PR does nothing but rename variables and fields. 