### PR TITLE
Triage report 2021-07-13

### DIFF
--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -561,8 +561,7 @@ TODO: Summary
 Triage done by **@???**.
 Revision range: [{first_commit}..{last_commit}](https://perf.rust-lang.org/?start={first_commit}&end={last_commit}&absolute=false&stat=instructions%3Au)
 
-{num_regressions} Regressions, {num_improvements} Improvements, {num_mixed} Mixed
-??? of them in rollups
+{num_regressions} Regressions, {num_improvements} Improvements, {num_mixed} Mixed; ??? of them in rollups
 
 #### Regressions
 

--- a/triage/2021-07-13.md
+++ b/triage/2021-07-13.md
@@ -1,0 +1,41 @@
+# 2021-07-13 Triage Log
+
+Mostly quiet week; improvements outweighed regressions.
+
+Triage done by **@simulacrum**.
+Revision range: [9a27044f42ace9eb652781b53f598e25d4e7e918..5aff6dd07a562a2cba3c57fc3460a72acb6bef46](https://perf.rust-lang.org/?start=9a27044f42ace9eb652781b53f598e25d4e7e918&end=5aff6dd07a562a2cba3c57fc3460a72acb6bef46&absolute=false&stat=instructions%3Au)
+
+1 Regressions, 4 Improvements, 0 Mixed; 0 of them in rollups
+
+#### Regressions
+
+Support forwarding caller location through trait object method call [#81360](https://github.com/rust-lang/rust/issues/81360)
+- Moderate regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=a84d1b21aea9863f0fc5f436b4982d145dade646&end=3982eb35cabe3a99194d768d34a92347967c3fa2&stat=instructions:u) (up to 1.5% on `incr-full` builds of `unused-warnings-check`)
+- Largely due to increased number of calls to the newly-made query
+  should_inherit_track_caller. Mostly higher regressions on smaller benchmarks.
+
+#### Improvements
+
+Reland "Merge CrateDisambiguator into StableCrateId" [#86143](https://github.com/rust-lang/rust/issues/86143)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=d7901f37bb74ee677ff939c324d49a9a0a5b4aca&end=d04ec4735810553224eb5eaf948ec78f84eac06c&stat=instructions:u) (up to -2.5% on `full` builds of `html5ever-opt`)
+
+
+Stop generating `alloca`s & `memcmp` for simple short array equality [#85828](https://github.com/rust-lang/rust/issues/85828)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=95fb1315217976ff4c268bb03c9b4132f0dfa9fd&end=ee86f96ba176f598d64dc9f3bb7e074d5b8b86b6&stat=instructions:u) (up to -2.2% on `incr-patched: b9b3e592dd cherry picked` builds of `style-servo-debug`)
+
+
+Add support for raw-dylib with stdcall, fastcall functions [#86419](https://github.com/rust-lang/rust/issues/86419)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=240ff4c4a0d0936c9eeb783fa9ff5c0507a6ffb4&end=8d9d4c87d677552ae52e2d58034e4be199b5a6d2&stat=instructions:u) (up to -1.2% on `incr-unchanged` builds of `externs-opt`)
+
+
+Use clang 12.0.1 on dist-x86_64/i686-linux [#87019](https://github.com/rust-lang/rust/issues/87019)
+- Moderate improvement in [instruction counts](https://perf.rust-lang.org/compare.html?start=394804bb23bf0889c135a21f945b2fe44881ada8&end=5aff6dd07a562a2cba3c57fc3460a72acb6bef46&stat=instructions:u) (up to -2.3% on `full` builds of `regression-31157-opt`)
+
+
+#### Nags requiring follow up
+
+- There are a number of [untriaged regressions](https://github.com/rust-lang/rust/issues?q=is%3Amerged+label%3Aperf-regression+-label%3Aperf-regression-triaged); as of this writing:
+    - Include terminators in instance size estimate [#86777](https://github.com/rust-lang/rust/issues/86777)
+    - Rollup of 8 pull requests [#86588](https://github.com/rust-lang/rust/issues/86588)
+    - Change entry point to 🛡️ against 💥 💥-payloads [#86034](https://github.com/rust-lang/rust/issues/86034)
+    - Inline Iterator as IntoIterator. [#84560](https://github.com/rust-lang/rust/issues/84560)


### PR DESCRIPTION
Also includes a minor adjustment to the script, since markdown doesn't preserve adjacent linebreaks.