### PR TITLE
Update comparison page top UI

### DIFF
--- a/site/static/bootstrap.html
+++ b/site/static/bootstrap.html
@@ -281,7 +281,7 @@
             window.location.search = params.toString();
         }
 
-        load_state(state => {
+        loadState(state => {
             let values = Object.assign({}, {
                 start: "",
                 end: "",

--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -10,21 +10,18 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
     <style>
         ul li {
-            position: relative;
-            padding-top: 0.5em;
+            margin: 0;
         }
 
-        input[type="checkbox"] {
-            position: absolute;
-            top: 0.25em;
-            left: -2em;
+        ul li input {
+            vertical-align: middle;
+            margin: 0 2px;
+
         }
 
-        #settings {
-            border: 2px black;
-            border-style: solid;
-            padding: 14px;
-            border-radius: 10px;
+        .section {
+            display: flex;
+            margin: 4px 0;
         }
 
         #commits {
@@ -35,23 +32,26 @@
 
         .commit-input {
             width: 270px;
-            margin: 10px;
             display: flex;
             flex-direction: column;
         }
 
         .commit-input label {
-            font-size: 18px;
+            font-size: 12px;
             font-weight: bold;
             margin-bottom: 6px;
         }
 
+        #metric {
+            position: relative;
+            height: 40px;
+        }
+
         #stats {
             border-radius: 5px;
-            width: 132px;
-            font-size: 16px;
-            margin: 10px;
-            padding: 3px;
+            width: 200px;
+            font-size: 14px;
+            margin-left: 52px;
         }
 
         #filters-toggle {
@@ -59,37 +59,39 @@
         }
 
         .section-heading {
-            font-size: 22px;
+            font-size: 16px;
         }
 
-        #search-content {
-            margin-top: 16px;
+        .section .section-heading {
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
         }
 
         #filters-content .section-heading {
-            font-size: 18px;
-        }
-
-        #filters-content {
-            margin-top: 16px;
+            font-size: 16px;
         }
 
         #filters {
-            padding: 10px;
             border: 1px black;
             border-style: dotted;
             margin: 16px 0px;
             border-radius: 10px;
         }
 
-        #settings input {
-            border-radius: 5px;
-            padding: 10px;
-            font-size: 14px;
+        #filter {
+            margin-left: 52px;
         }
 
-        #filter {
-            margin: 10px 0;
+        input {
+            border-radius: 5px;
+            padding: 4px;
+            font-size: 12px;
+            height: 100%;
+        }
+
+        input[type="checkbox"] {
+            height: auto;
         }
 
         #settings input[type=submit] {
@@ -103,9 +105,20 @@
             font-weight: bold;
         }
 
+        #states-list {
+            display: flex;
+            justify-content: space-around;
+            align-items: center;
+            width: 80%;
+            list-style: none;
+            margin: 0;
+        }
+
         .tooltip {
             position: relative;
             border-radius: 50%;
+            font-size: 12px;
+            margin: 0 -6px;
             border: 1px solid #7d6969;
             width: 16px;
             text-align: center;
@@ -147,44 +160,50 @@
     <br />
     <h1>Comparing <span id="stat-header">instructions:u</span> between <span id="before">???</span> and <span
             id="after">???</span></h1>
-    <form id="settings" action="">
-        <div id="search-toggle" class="section-heading">Compare Other Commits<span id="search-toggle-indicator"></span>
-        </div>
+    <fieldset id="settings">
+        <legend id="search-toggle" class="section-heading">Compare other commits<span
+                id="search-toggle-indicator"></span></legend>
         <div id="search-content">
-            <fieldset id="commits">
-                <legend class="section-heading">Commits</legend>
+            <div id="commits" class="section">
+                <div class="section-heading">Commits</div>
                 <div style="display: flex; width: 100%; justify-content: space-around;">
                     <div class="commit-input">
                         <label for="start-bound">Before</label>
-                        <input width="100em" placeholder="YYYY-MM-DD or Commit SHA" id="start-bound" /><br>
+                        <input width="100em" placeholder="YYYY-MM-DD or Commit SHA" id="start-bound" />
                     </div>
                     <div class="commit-input">
                         <label for="end-bound">After</label>
-                        <input width="100em" placeholder="YYYY-MM-DD or Commit SHA" id="end-bound" /><br>
+                        <input width="100em" placeholder="YYYY-MM-DD or Commit SHA" id="end-bound" />
                     </div>
                 </div>
-            </fieldset>
-            <div id="metric" style="position: relative;height: 60px;">
-                <label class="section-heading" for="stats">Metric</label>
-                <div style="width: 100%; position: absolute; top:0; display: flex; justify-content: center;">
+            </div>
+            <div id="metric" class="section">
+                <div class="section-heading" for="stats">Metric</div>
+                <div style="display: flex; flex-direction: column; justify-content: center;">
                     <select id='stats' name="stat"></select>
                 </div>
             </div>
             <input id="submit" type="submit" value="Submit" onclick="submit_settings(); return false;">
-        </div>
-    </form>
-    <div id="filters">
-        <div id="filters-toggle" class="section-heading">Filters<span id="filters-toggle-indicator"></span></div>
+    </fieldset>
+    </div>
+    <fieldset id="filters">
+        <legend id="filters-toggle" class="section-heading">Filters<span id="filters-toggle-indicator"></span></legend>
         <div id="filters-content" style="display: none;">
-            <div>
+            <div class="section">
                 <div class="section-heading">Filter by benchmark
                 </div>
                 <input id="filter" type="text" /> </p>
             </div>
-            <div>
-                <div class="section-heading">Cache states</div>
-                <p>Most benchmarks have at least 4 cache states for which we collect data:</p>
-                <ul style="display: flex; justify-content: space-around; list-style:none;">
+            <div class="section">
+                <div class="section-heading">
+                    <div>
+                        <span>Cache states</span>
+                        <div class="tooltip">?<span class="tooltiptext">
+                                Most benchmarks have at least 4 cache states for which we collect data
+                        </div>
+                    </div>
+                </div>
+                <ul id="states-list">
                     <li><input type="checkbox" id="build-full" checked /><span class="cache-label">full</span>
                         <div class="tooltip">?<span class="tooltiptext">A
                                 non-incremental full build starting with empty cache</span></div>
@@ -216,7 +235,7 @@
                 </ul>
             </div>
         </div>
-    </div>
+    </fieldset>
     <div id="content" style="display: none; margin-top: 15px"></div>
     <br>
     <div id="as-of"></div>
@@ -229,7 +248,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/msgpack-lite/0.1.26/msgpack.min.js"></script>
     <script src="shared.js"></script>
     <script>
-        function toggle_filters(id, toggle) {
+        function toggleFilters(id, toggle) {
             let styles = document.getElementById(id).style;
             let indicator = document.getElementById(toggle);
             if (styles.display != "none") {
@@ -240,14 +259,14 @@
                 styles.display = "block";
             }
         }
-        toggle_filters("filters-content", "filters-toggle-indicator");
-        toggle_filters("search-content", "search-toggle-indicator");
+        toggleFilters("filters-content", "filters-toggle-indicator");
+        toggleFilters("search-content", "search-toggle-indicator");
 
         document.getElementById("filters-toggle").onclick = (e) => {
-            toggle_filters("filters-content", "filters-toggle-indicator");
+            toggleFilters("filters-content", "filters-toggle-indicator");
         };
         document.getElementById("search-toggle").onclick = (e) => {
-            toggle_filters("search-content", "search-toggle-indicator");
+            toggleFilters("search-content", "search-toggle-indicator");
         };
 
 

--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -68,7 +68,6 @@
 
         #filters-content {
             margin-top: 16px;
-
         }
 
         #filters {
@@ -97,6 +96,40 @@
 
         .cache-label {
             font-weight: bold;
+        }
+
+        .tooltip {
+            position: relative;
+            border-radius: 50%;
+            border: 1px solid #7d6969;
+            width: 16px;
+            text-align: center;
+            font-weight: bold;
+            background: #d6d3d3;
+            cursor: pointer;
+            display: inline-block;
+        }
+
+        .tooltip .tooltiptext {
+            width: 180px;
+            visibility: hidden;
+            color: white;
+            background-color: #524d4d;
+            text-align: center;
+            padding: 5px;
+            border-radius: 6px;
+
+            position: absolute;
+            bottom: 125%;
+            margin-left: -60px;
+
+            opacity: 0;
+            transition: opacity 0.3s;
+        }
+
+        .tooltip:hover .tooltiptext {
+            visibility: visible;
+            opacity: 1;
         }
     </style>
     <script src="https://cdn.jsdelivr.net/npm/vue@2/dist/vue.js"></script>
@@ -132,7 +165,7 @@
     </form>
     <div id="filters">
         <div id="filters-toggle" class="section-heading">Filters<span id="filters-toggle-indicator"></span></div>
-        <div id="filters-content">
+        <div id="filters-content" style="display: none;">
             <div>
                 <div class="section-heading">Filter by benchmark
                 </div>
@@ -141,25 +174,35 @@
             <div>
                 <div class="section-heading">Cache states</div>
                 <p>Most benchmarks have at least 4 cache states for which we collect data:</p>
-                <ul style="list-style:none;">
-                    <li><input type="checkbox" id="build-full" checked /><span class="cache-label">full</span>: a
-                        non-incremental full build starting with empty cache</li>
+                <ul style="display: flex; justify-content: space-around; list-style:none;">
+                    <li><input type="checkbox" id="build-full" checked /><span class="cache-label">full</span>
+                        <div class="tooltip">?<span class="tooltiptext">A
+                                non-incremental full build starting with empty cache</span></div>
+                    </li>
                     <li><input type="checkbox" id="build-incremental-full" checked /> <span
-                            class="cache-label">incr-full</span>: an incremental build
-                        starting
-                        with empty cache</li>
+                            class="cache-label">incr-full</span>
+                        <div class="tooltip">?<span class="tooltiptext">An incremental build
+                                starting
+                                with empty cache
+                            </span></div>
+                    </li>
                     <li><input type="checkbox" id="build-incremental-unchanged" checked /> <span
-                            class="cache-label">incr-unchanged</span>: an
-                        incremental
-                        build
-                        starting with complete
-                        cache, and unchanged source directory -- the "perfect" scenario for incremental.</li>
+                            class="cache-label">incr-unchanged</span>
+                        <div class="tooltip">?<span class="tooltiptext">An
+                                incremental
+                                build
+                                starting with complete
+                                cache, and unchanged source directory -- the "perfect" scenario for incremental.</span>
+                        </div>
+                    </li>
                     <li><input type="checkbox" id="build-incremental-patched" checked /><span
-                            class="cache-label">incr-patched</span> : an incremental
-                        build
-                        starting with complete cache, and an
-                        altered source directory. The typical variant of this is "println" which represents
-                        the addition of a `println!` macro somewhere in the source code.</li>
+                            class="cache-label">incr-patched</span>
+                        <div class="tooltip">?<span class="tooltiptext">An incremental
+                                build
+                                starting with complete cache, and an
+                                altered source directory. The typical variant of this is "println" which represents
+                                the addition of a `println!` macro somewhere in the source code.</span></div>
+                    </li>
                 </ul>
             </div>
         </div>

--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -20,20 +20,83 @@
             left: -2em;
         }
 
-        #filters-toggle {
-            margin: 10px 0px;
-            background: #add8e6;
-            width: 70px;
-            padding: 5px;
-            border-radius: 15px;
+        #settings {
+            border: 2px black;
+            border-style: solid;
+            padding: 14px;
+            border-radius: 10px;
+        }
+
+        #commits {
+            border: none;
+            display: flex;
+            padding: 0px;
+        }
+
+        .commit-input {
+            width: 270px;
+            margin: 10px;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .commit-input label {
+            font-size: 18px;
             font-weight: bold;
-            text-align: center;
+            margin-bottom: 6px;
+        }
+
+        #stats {
+            border-radius: 5px;
+            width: 132px;
+            font-size: 16px;
+            margin: 10px;
+            padding: 3px;
+        }
+
+        #filters-toggle {
+            cursor: pointer;
+        }
+
+        .section-heading {
+            font-size: 22px;
+        }
+
+        #filters-content .section-heading {
+            font-size: 18px;
+        }
+
+        #filters-content {
+            margin-top: 16px;
+
         }
 
         #filters {
             padding: 10px;
-            border: 2px black;
-            border-style: solid;
+            border: 1px black;
+            border-style: dotted;
+            margin: 16px 0px;
+        }
+
+        #settings input {
+            border-radius: 5px;
+            padding: 10px;
+            font-size: 14px;
+        }
+
+        #filter {
+            margin: 10px 0;
+        }
+
+        #settings input[type=submit] {
+            width: 100%;
+            font-weight: bold;
+            background: #ADD8E6;
+            margin: 10px 0;
+        }
+
+        .cache-label {
+            font-weight: bold;
         }
     </style>
     <script src="https://cdn.jsdelivr.net/npm/vue@2/dist/vue.js"></script>
@@ -47,40 +110,56 @@
     <br />
     <form id="settings" action="">
         <fieldset id="commits">
-            <legend>Commits</legend>
-            <label for="start-bound">Commit/Date A:</label>
-            <input width="100em" placeholder="YYYY-MM-DD or SHA" id="start-bound" /><br>
-            <label for="end-bound">Commit/Date B:</label>
-            <input width="100em" placeholder="YYYY-MM-DD or SHA" id="end-bound" /><br>
+            <legend class="section-heading">Commits</legend>
+            <div style="display: flex; width: 100%; justify-content: space-around;">
+                <div class="commit-input">
+                    <label for="start-bound">Before</label>
+                    <input width="100em" placeholder="YYYY-MM-DD or Commit SHA" id="start-bound" /><br>
+                </div>
+                <div class="commit-input">
+                    <label for="end-bound">After</label>
+                    <input width="100em" placeholder="YYYY-MM-DD or Commit SHA" id="end-bound" /><br>
+                </div>
+            </div>
         </fieldset>
-        <label for="stats">Choose a comparison method:</label>
-        <select id='stats' name="stat">
-        </select><br>
-        <input type="submit" value="Submit" onclick="submit_settings(); return false;">
-    </form>
-    <div id="filters-toggle">Filters <span id="filters-toggle-indicator"></span></div>
-    <div id="filters">
-        <div>
-            <p>Filter benchmark builds: <input id="filter" type="text" /> </p>
+        <label class="section-heading" for="stats">Metric</label>
+        <div id="metric" style="display: flex; justify-content: center;">
+            <select id='stats' name="stat"></select>
         </div>
-        <div>
-            <h3>Cache states</h3>
-            <p>Most benchmarks have at least 4 cache states for which we collect data:</p>
-            <ul style="list-style:none;">
-                <li><input type="checkbox" id="build-full" checked /> full: a
-                    non-incremental full build starting with empty cache</li>
-                <li><input type="checkbox" id="build-incremental-full" checked /> incr-full: an incremental build
-                    starting
-                    with empty cache</li>
-                <li><input type="checkbox" id="build-incremental-unchanged" checked /> incr-unchanged: an incremental
-                    build
-                    starting with complete
-                    cache, and unchanged source directory -- the "perfect" scenario for incremental.</li>
-                <li><input type="checkbox" id="build-incremental-patched" checked /> incr-patched: an incremental build
-                    starting with complete cache, and an
-                    altered source directory. The typical variant of this is "println" which represents
-                    the addition of a `println!` macro somewhere in the source code.</li>
-            </ul>
+        <input id="submit" type="submit" value="Submit" onclick="submit_settings(); return false;">
+    </form>
+    <div id="filters">
+        <div id="filters-toggle" class="section-heading">Filters<span id="filters-toggle-indicator"></span></div>
+        <div id="filters-content">
+            <div>
+                <div class="section-heading">Filter by benchmark
+                </div>
+                <input id="filter" type="text" /> </p>
+            </div>
+            <div>
+                <div class="section-heading">Cache states</div>
+                <p>Most benchmarks have at least 4 cache states for which we collect data:</p>
+                <ul style="list-style:none;">
+                    <li><input type="checkbox" id="build-full" checked /><span class="cache-label">full</span>: a
+                        non-incremental full build starting with empty cache</li>
+                    <li><input type="checkbox" id="build-incremental-full" checked /> <span
+                            class="cache-label">incr-full</span>: an incremental build
+                        starting
+                        with empty cache</li>
+                    <li><input type="checkbox" id="build-incremental-unchanged" checked /> <span
+                            class="cache-label">incr-unchanged</span>: an
+                        incremental
+                        build
+                        starting with complete
+                        cache, and unchanged source directory -- the "perfect" scenario for incremental.</li>
+                    <li><input type="checkbox" id="build-incremental-patched" checked /><span
+                            class="cache-label">incr-patched</span> : an incremental
+                        build
+                        starting with complete cache, and an
+                        altered source directory. The typical variant of this is "println" which represents
+                        the addition of a `println!` macro somewhere in the source code.</li>
+                </ul>
+            </div>
         </div>
     </div>
     <div id="content" style="display: none; margin-top: 15px"></div>
@@ -96,7 +175,7 @@
     <script src="shared.js"></script>
     <script>
         function toggle_filters() {
-            let styles = document.getElementById("filters").style;
+            let styles = document.getElementById("filters-content").style;
             let indicator = document.getElementById("filters-toggle-indicator");
             if (styles.display != "none") {
                 indicator.innerHTML = "⯈"

--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -122,9 +122,11 @@
                 </div>
             </div>
         </fieldset>
-        <label class="section-heading" for="stats">Metric</label>
-        <div id="metric" style="display: flex; justify-content: center;">
-            <select id='stats' name="stat"></select>
+        <div id="metric" style="position: relative;height: 60px;">
+            <label class="section-heading" for="stats">Metric</label>
+            <div style="width: 100%; position: absolute; top:0; display: flex; justify-content: center;">
+                <select id='stats' name="stat"></select>
+            </div>
         </div>
         <input id="submit" type="submit" value="Submit" onclick="submit_settings(); return false;">
     </form>

--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -118,7 +118,7 @@
             position: relative;
             border-radius: 50%;
             font-size: 12px;
-            margin: 0 -6px;
+            margin: 0 -4px;
             border: 1px solid #7d6969;
             width: 16px;
             text-align: center;
@@ -161,7 +161,7 @@
     <h1>Comparing <span id="stat-header">instructions:u</span> between <span id="before">???</span> and <span
             id="after">???</span></h1>
     <fieldset id="settings">
-        <legend id="search-toggle" class="section-heading">Compare other commits<span
+        <legend id="search-toggle" class="section-heading">Do another comparison<span
                 id="search-toggle-indicator"></span></legend>
         <div id="search-content">
             <div id="commits" class="section">

--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -19,7 +19,24 @@
             top: 0.25em;
             left: -2em;
         }
+
+        #filters-toggle {
+            margin: 10px 0px;
+            background: #add8e6;
+            width: 70px;
+            padding: 5px;
+            border-radius: 15px;
+            font-weight: bold;
+            text-align: center;
+        }
+
+        #filters {
+            padding: 10px;
+            border: 2px black;
+            border-style: solid;
+        }
     </style>
+    <script src="https://cdn.jsdelivr.net/npm/vue@2/dist/vue.js"></script>
 </head>
 
 <body class="container" style="max-width:800px">
@@ -27,33 +44,7 @@
         <a href="dashboard.html">dashboard</a>, <a href="bootstrap.html">bootstrap</a>,
         <a href="status.html">status</a>, <a href="help.html">help</a>.
     </div>
-    <div>
-        <p>Warning: although measurements known to have high variation are marked with
-            '?'/'??', this does not mean that unmarked measurements are guaranteed to have
-            low variation. Verify the measurement against the
-            <a
-                href="compare.html?start=3158857297417566824631a85c4cb3c0615ec6c2&end=7e0241c63755ea28045d512b742f50b307874419&stat=instructions:u">
-                last "noise run"</a> which shows the perf difference of a non-functional change.
-        </p>
-    </div>
-    Filter benchmark builds: <input id="filter" type="text" /><br>
-    <div>
-        <h3>Cache states</h3>
-        <p>Most benchmarks have at least 4 cache states for which we collect data:</p>
-        <ul style="list-style:none;">
-            <li><input type="checkbox" id="build-full" checked /> full: a
-                non-incremental full build starting with empty cache</li>
-            <li><input type="checkbox" id="build-incremental-full" checked /> incr-full: an incremental build starting
-                with empty cache</li>
-            <li><input type="checkbox" id="build-incremental-unchanged" checked /> incr-unchanged: an incremental build
-                starting with complete
-                cache, and unchanged source directory -- the "perfect" scenario for incremental.</li>
-            <li><input type="checkbox" id="build-incremental-patched" checked /> incr-patched: an incremental build
-                starting with complete cache, and an
-                altered source directory. The typical variant of this is "println" which represents
-                the addition of a `println!` macro somewhere in the source code.</li>
-        </ul>
-    </div>
+    <br />
     <form id="settings" action="">
         <fieldset id="commits">
             <legend>Commits</legend>
@@ -67,6 +58,31 @@
         </select><br>
         <input type="submit" value="Submit" onclick="submit_settings(); return false;">
     </form>
+    <div id="filters-toggle">Filters <span id="filters-toggle-indicator"></span></div>
+    <div id="filters">
+        <div>
+            <p>Filter benchmark builds: <input id="filter" type="text" /> </p>
+        </div>
+        <div>
+            <h3>Cache states</h3>
+            <p>Most benchmarks have at least 4 cache states for which we collect data:</p>
+            <ul style="list-style:none;">
+                <li><input type="checkbox" id="build-full" checked /> full: a
+                    non-incremental full build starting with empty cache</li>
+                <li><input type="checkbox" id="build-incremental-full" checked /> incr-full: an incremental build
+                    starting
+                    with empty cache</li>
+                <li><input type="checkbox" id="build-incremental-unchanged" checked /> incr-unchanged: an incremental
+                    build
+                    starting with complete
+                    cache, and unchanged source directory -- the "perfect" scenario for incremental.</li>
+                <li><input type="checkbox" id="build-incremental-patched" checked /> incr-patched: an incremental build
+                    starting with complete cache, and an
+                    altered source directory. The typical variant of this is "println" which represents
+                    the addition of a `println!` macro somewhere in the source code.</li>
+            </ul>
+        </div>
+    </div>
     <div id="content" style="display: none; margin-top: 15px"></div>
     <br>
     <div id="as-of"></div>
@@ -79,6 +95,24 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/msgpack-lite/0.1.26/msgpack.min.js"></script>
     <script src="shared.js"></script>
     <script>
+        function toggle_filters() {
+            let styles = document.getElementById("filters").style;
+            let indicator = document.getElementById("filters-toggle-indicator");
+            if (styles.display != "none") {
+                indicator.innerHTML = "⯈"
+                styles.display = "none";
+            } else {
+                indicator.innerHTML = "▼"
+                styles.display = "block";
+            }
+        }
+        toggle_filters();
+
+        document.getElementById("filters-toggle").onclick = (e) => {
+            toggle_filters();
+        };
+
+
         function print_date(date) {
             function pad_str(i) {
                 return (i < 10) ? "0" + i : "" + i;

--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -175,9 +175,6 @@
     </div>
     <br />
     <div id="app">
-        <h1>Comparing <span id="stat-header">{{stat}}</span> between <span id="before">{{before}}</span> and
-            <span id="after">{{after}}</span>
-        </h1>
         <fieldset id="settings">
             <legend id="search-toggle" class="section-heading">Do another comparison<span
                     id="search-toggle-indicator"></span></legend>
@@ -203,13 +200,16 @@
                 </div>
                 <input id="submit" type="submit" value="Submit" onclick="submitSettings(); return false;">
         </fieldset>
+        <h1>Comparing <span id="stat-header">{{stat}}</span> between <span id="before">{{before}}</span> and
+            <span id="after">{{after}}</span>
+        </h1>
         <div v-if="data" style="margin: 12px 0;">
             <div style="display: flex;justify-content: center;">
                 <div class="description-box">
                     <div class="description-arrow"><a v-if="data.prev" v-bind:href="prevLink">&larr;</a></div>
                     <div style="padding: 10px;">
                         <a v-if="data.a.pr" v-bind:href="prLink(data.a.pr)">#{{data.a.pr}}</a>
-                        <span>{{formatDate(data.a.date)}}</span>
+                        <span v-if="data.a.date">{{formatDate(data.a.date)}}</span>
                         (<a v-bind:href="commitLink(data.a.commit)">{{short(data.a)}}</a>)
                     </div>
                 </div>
@@ -218,7 +218,7 @@
                 <div class="description-box">
                     <div style="padding: 10px;">
                         <a v-if="data.b.pr" v-bind:href="prLink(data.b.pr)">#{{data.b.pr}}</a>
-                        <span>{{formatDate(data.b.date)}}</span>
+                        <span v-if="data.b.date">{{formatDate(data.b.date)}}</span>
                         (<a v-bind:href="commitLink(data.b.commit)">{{short(data.b)}}</a>)
                     </div>
                     <div class="description-arrow"><a v-if="data.next" v-bind:href="nextLink">&rarr;</a></div>

--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -206,7 +206,7 @@
         <div v-if="data" style="margin: 12px 0;">
             <div style="display: flex;justify-content: center;">
                 <div class="description-box">
-                    <div class="description-arrow"><a v-if="data.prev" v-bind:href="prevLink">&larr;</a></div>
+                    <div v-if="data.prev" class="description-arrow"><a v-bind:href="prevLink">&larr;</a></div>
                     <div style="padding: 10px;">
                         <a v-if="data.a.pr" v-bind:href="prLink(data.a.pr)">#{{data.a.pr}}</a>
                         <span v-if="data.a.date">{{formatDate(data.a.date)}}</span>
@@ -221,7 +221,7 @@
                         <span v-if="data.b.date">{{formatDate(data.b.date)}}</span>
                         (<a v-bind:href="commitLink(data.b.commit)">{{short(data.b)}}</a>)
                     </div>
-                    <div class="description-arrow"><a v-if="data.next" v-bind:href="nextLink">&rarr;</a></div>
+                    <div v-if="data.next" class="description-arrow"><a v-bind:href="nextLink">&rarr;</a></div>
                 </div>
             </div>
             <div style="display: flex; justify-content: center;">

--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -69,7 +69,7 @@
         #filters {
             border: 1px black;
             border-style: dotted;
-            margin: 16px 0px;
+            margin: 12px 0px;
             border-radius: 10px;
         }
 
@@ -141,6 +141,29 @@
             visibility: visible;
             opacity: 1;
         }
+
+        .description-box {
+            border: 1px solid;
+            display: flex;
+        }
+
+        .description-arrow {
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            background: #8dcc8d;
+            padding: 5px;
+        }
+
+        #not-continuous {
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            text-align: center;
+            background: #cc3300;
+            border: 1px solid;
+            cursor: help;
+        }
     </style>
     <script src="https://cdn.jsdelivr.net/npm/vue@2/dist/vue.js"></script>
 </head>
@@ -180,6 +203,31 @@
                 </div>
                 <input id="submit" type="submit" value="Submit" onclick="submitSettings(); return false;">
         </fieldset>
+        <div v-if="data" style="margin: 12px 0;">
+            <div style="display: flex;justify-content: center;">
+                <div class="description-box">
+                    <div class="description-arrow"><a v-if="data.prev" v-bind:href="prevLink">&larr;</a></div>
+                    <div style="padding: 10px;">
+                        <a v-if="data.a.pr" v-bind:href="prLink(data.a.pr)">#{{data.a.pr}}</a>
+                        <span>{{formatDate(data.a.date)}}</span>
+                        (<a v-bind:href="commitLink(data.a.commit)">{{short(data.a)}}</a>)
+                    </div>
+                </div>
+                <div v-if="notContinuous" id="not-continuous" title="WARNING! The commits are not continuous.">...
+                </div>
+                <div class="description-box">
+                    <div style="padding: 10px;">
+                        <a v-if="data.b.pr" v-bind:href="prLink(data.b.pr)">#{{data.b.pr}}</a>
+                        <span>{{formatDate(data.b.date)}}</span>
+                        (<a v-bind:href="commitLink(data.b.commit)">{{short(data.b)}}</a>)
+                    </div>
+                    <div class="description-arrow"><a v-if="data.next" v-bind:href="nextLink">&rarr;</a></div>
+                </div>
+            </div>
+            <div style="display: flex; justify-content: center;">
+                <a v-bind:href="compareLink">🔎 compare commits</a>
+            </div>
+        </div>
         <fieldset id="filters">
             <legend id="filters-toggle" class="section-heading">Filters<span id="filters-toggle-indicator"></span>
             </legend>
@@ -234,40 +282,8 @@
                 </div>
             </div>
         </fieldset>
-        <div id="content" style="margin-top: 15px">
-            <table v-if="data" class="compare" style="font-size: medium !important;">
-                <thead>
-                    <tr>
-                        <td v-if="notContinuous" colspan="4" style="text-align:center;"><b>Warning</b>: The start and
-                            end
-                            are not adjacent!</td>
-                    </tr>
-                    <tr>
-                        <th>
-                            <a v-bind:href="compareLink">compare</a>
-                        </th>
-                        <th>
-                            <a v-if="data.prev" v-bind:href="prevLink">&larr;</a>
-                            {{formatDate(data.a.date)}}
-                            (<a>{{short(data.a)}}</a>)
-                        </th>
-                        <th>
-                            {{formatDate(data.b.date)}}
-                            (<a>{{short(data.b)}}</a>)
-                            <a v-if="data.next" v-bind:href="nextLink">&rarr;</a>
-                        </th>
-                        <th>% change</th>
-                    </tr>
-                    <tr>
-                        <th></th>
-                        <th style="text-align: left;"><a v-if="data.a.pr"
-                                v-bind:href="prLink(data.a.pr)">#{{data.a.pr}}</a>
-                        </th>
-                        <th style="text-align: left;"><a v-if="data.b.pr"
-                                v-bind:href="prLink(data.b.pr)">#{{data.b.pr}}</a>
-                        </th>
-                    </tr>
-                </thead>
+        <div v-if="data" id="content" style="margin-top: 15px">
+            <table class="compare" style="width: 80%; margin: 0 auto; font-size: medium !important;">
                 <tbody>
                     <template v-for="bench in benches">
                         <tr data-field-start="true">
@@ -503,6 +519,9 @@
                 },
                 percentLink(commit, baseCommit, bench, run) {
                     return `/detailed-query.html?commit=${commit}&base_commit=${baseCommit}&benchmark=${bench}&run_name=${run}`;
+                },
+                commitLink(commit) {
+                    return `https://github.com/rust-lang/rust/commit/${commit}`;
                 },
                 benchGroupToggle(e) {
                     const element = e.target;

--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -21,7 +21,7 @@
 
         .section {
             display: flex;
-            margin: 4px 0;
+            margin: 10px 0;
         }
 
         #commits {
@@ -62,12 +62,6 @@
             font-size: 16px;
         }
 
-        .section .section-heading {
-            display: flex;
-            flex-direction: column;
-            justify-content: center;
-        }
-
         #filters-content .section-heading {
             font-size: 16px;
         }
@@ -85,7 +79,6 @@
 
         input {
             border-radius: 5px;
-            padding: 4px;
             font-size: 12px;
             height: 100%;
         }
@@ -98,7 +91,6 @@
             width: 100%;
             font-weight: bold;
             background: #ADD8E6;
-            margin: 10px 0;
         }
 
         .cache-label {
@@ -195,15 +187,15 @@
                 <div class="section">
                     <div class="section-heading">Filter by benchmark
                     </div>
-                    <input id="filter" type="text" v-model="filter.name" /> </p>
+                    <input id="filter" type="text" v-model="filter.name" />
                 </div>
                 <div class=" section">
                     <div class="section-heading">
-                        <div>
+                        <div style="width: 160px;">
                             <span>Cache states</span>
-                            <div class="tooltip">?<span class="tooltiptext">
-                                    Most benchmarks have at least 4 cache states for which we collect data
-                            </div>
+                            <span class="tooltip">?<span class="tooltiptext">
+                                    Most benchmarks have at least 4 cache states for which we collect data</span>
+                            </span>
                         </div>
                     </div>
                     <ul id="states-list">
@@ -317,7 +309,7 @@
                 </tbody>
             </table>
             <br />
-            <table class="compare" v-if="data && data.a.bootstrap">
+            <table class="compare" v-if="data && data.a.bootstrap.length > 0">
                 <tr>
                     <td colspan="4">bootstrap timings; variance is 1-3% on smaller benchmarks! Values in seconds.</td>
                 </tr>

--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -304,9 +304,7 @@
                                 </details>
                             </th>
                             <td>min: <span v-bind:class="percentClass(bench.minPct)">{{bench.minPct}}%</span></td>
-                            <td>max: <span
-                                    v-bind:class="percentClass(bench.maxPct)">{{bench.maxPct}}%{{isDodgyBench(bench)
-                                    ? "?" : ""}}</span></td>
+                            <td>max: <span v-bind:class="percentClass(bench.maxPct)">{{bench.maxPct}}%</span></td>
                             <td></td>
                         </tr>
                         <template v-for="run in bench.variants">

--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -240,43 +240,51 @@
                 <div class=" section">
                     <div class="section-heading">
                         <div style="width: 160px;">
-                            <span>Cache states</span>
-                            <span class="tooltip">?<span class="tooltiptext">
-                                    Most benchmarks have at least 4 cache states for which we collect data</span>
+                            <span>Build types</span>
+                            <span class="tooltip">?
+                                <span class="tooltiptext">
+                                    The different types of builds based on their incremental compilation cache state and
+                                    what has changed since the last build.
+                                </span>
                             </span>
                         </div>
                     </div>
                     <ul id="states-list">
                         <li><input type="checkbox" id="build-full" v-model="filter.cache.full" /><span
                                 class="cache-label">full</span>
-                            <div class="tooltip">?<span class="tooltiptext">A
-                                    non-incremental full build starting with empty cache</span></div>
+                            <div class="tooltip">?
+                                <span class="tooltiptext">
+                                    A non-incremental full build starting with empty cache.
+                                </span>
+                            </div>
                         </li>
                         <li><input type="checkbox" id="build-incremental-full" v-model="filter.cache.incrFull" /> <span
                                 class="cache-label">incr-full</span>
-                            <div class="tooltip">?<span class="tooltiptext">An incremental build
-                                    starting
-                                    with empty cache
-                                </span></div>
+                            <div class="tooltip">?
+                                <span class="tooltiptext">
+                                    An incremental build starting with empty cache.
+                                </span>
+                            </div>
                         </li>
                         <li><input type="checkbox" id="build-incremental-unchanged"
                                 v-model="filter.cache.incrUnchanged" />
                             <span class="cache-label">incr-unchanged</span>
-                            <div class="tooltip">?<span class="tooltiptext">An
-                                    incremental
-                                    build
-                                    starting with complete
-                                    cache, and unchanged source directory -- the "perfect" scenario for
-                                    incremental.</span>
+                            <div class="tooltip">?
+                                <span class="tooltiptext">
+                                    An incremental build starting with complete cache, and unchanged source directory --
+                                    the "perfect" scenario for incremental.
+                                </span>
                             </div>
                         </li>
                         <li><input type="checkbox" id="build-incremental-patched"
                                 v-model="filter.cache.incrPatched" /><span class="cache-label">incr-patched</span>
-                            <div class="tooltip">?<span class="tooltiptext">An incremental
-                                    build
-                                    starting with complete cache, and an
-                                    altered source directory. The typical variant of this is "println" which represents
-                                    the addition of a `println!` macro somewhere in the source code.</span></div>
+                            <div class="tooltip">?
+                                <span class="tooltiptext">
+                                    An incremental build starting with complete cache, and an altered source directory.
+                                    The typical variant of this is "println" which represents the addition of a
+                                    `println!` macro somewhere in the source code.
+                                </span>
+                            </div>
                         </li>
                     </ul>
                 </div>

--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -62,6 +62,10 @@
             font-size: 22px;
         }
 
+        #search-content {
+            margin-top: 16px;
+        }
+
         #filters-content .section-heading {
             font-size: 18px;
         }
@@ -75,6 +79,7 @@
             border: 1px black;
             border-style: dotted;
             margin: 16px 0px;
+            border-radius: 10px;
         }
 
         #settings input {
@@ -132,7 +137,6 @@
             opacity: 1;
         }
     </style>
-    <script src="https://cdn.jsdelivr.net/npm/vue@2/dist/vue.js"></script>
 </head>
 
 <body class="container" style="max-width:800px">
@@ -141,27 +145,33 @@
         <a href="status.html">status</a>, <a href="help.html">help</a>.
     </div>
     <br />
+    <h1>Comparing <span id="stat-header">instructions:u</span> between <span id="before">???</span> and <span
+            id="after">???</span></h1>
     <form id="settings" action="">
-        <fieldset id="commits">
-            <legend class="section-heading">Commits</legend>
-            <div style="display: flex; width: 100%; justify-content: space-around;">
-                <div class="commit-input">
-                    <label for="start-bound">Before</label>
-                    <input width="100em" placeholder="YYYY-MM-DD or Commit SHA" id="start-bound" /><br>
-                </div>
-                <div class="commit-input">
-                    <label for="end-bound">After</label>
-                    <input width="100em" placeholder="YYYY-MM-DD or Commit SHA" id="end-bound" /><br>
-                </div>
-            </div>
-        </fieldset>
-        <div id="metric" style="position: relative;height: 60px;">
-            <label class="section-heading" for="stats">Metric</label>
-            <div style="width: 100%; position: absolute; top:0; display: flex; justify-content: center;">
-                <select id='stats' name="stat"></select>
-            </div>
+        <div id="search-toggle" class="section-heading">Compare Other Commits<span id="search-toggle-indicator"></span>
         </div>
-        <input id="submit" type="submit" value="Submit" onclick="submit_settings(); return false;">
+        <div id="search-content">
+            <fieldset id="commits">
+                <legend class="section-heading">Commits</legend>
+                <div style="display: flex; width: 100%; justify-content: space-around;">
+                    <div class="commit-input">
+                        <label for="start-bound">Before</label>
+                        <input width="100em" placeholder="YYYY-MM-DD or Commit SHA" id="start-bound" /><br>
+                    </div>
+                    <div class="commit-input">
+                        <label for="end-bound">After</label>
+                        <input width="100em" placeholder="YYYY-MM-DD or Commit SHA" id="end-bound" /><br>
+                    </div>
+                </div>
+            </fieldset>
+            <div id="metric" style="position: relative;height: 60px;">
+                <label class="section-heading" for="stats">Metric</label>
+                <div style="width: 100%; position: absolute; top:0; display: flex; justify-content: center;">
+                    <select id='stats' name="stat"></select>
+                </div>
+            </div>
+            <input id="submit" type="submit" value="Submit" onclick="submit_settings(); return false;">
+        </div>
     </form>
     <div id="filters">
         <div id="filters-toggle" class="section-heading">Filters<span id="filters-toggle-indicator"></span></div>
@@ -219,9 +229,9 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/msgpack-lite/0.1.26/msgpack.min.js"></script>
     <script src="shared.js"></script>
     <script>
-        function toggle_filters() {
-            let styles = document.getElementById("filters-content").style;
-            let indicator = document.getElementById("filters-toggle-indicator");
+        function toggle_filters(id, toggle) {
+            let styles = document.getElementById(id).style;
+            let indicator = document.getElementById(toggle);
             if (styles.display != "none") {
                 indicator.innerHTML = "⯈"
                 styles.display = "none";
@@ -230,10 +240,14 @@
                 styles.display = "block";
             }
         }
-        toggle_filters();
+        toggle_filters("filters-content", "filters-toggle-indicator");
+        toggle_filters("search-content", "search-toggle-indicator");
 
         document.getElementById("filters-toggle").onclick = (e) => {
-            toggle_filters();
+            toggle_filters("filters-content", "filters-toggle-indicator");
+        };
+        document.getElementById("search-toggle").onclick = (e) => {
+            toggle_filters("search-content", "search-toggle-indicator");
         };
 
 
@@ -641,9 +655,30 @@
             }, state);
             make_request("/get", values).then(function (data) {
                 DATA = data;
+                update_header(data.a.commit, data.b.commit);
                 populate_data(data);
             });
         }
+
+        function update_header(a, b, stat) {
+            let shorten = (text) => {
+                return text.substring(0, 7);
+            }
+            a && (document.getElementById("before").innerHTML = shorten(a));
+            b && (document.getElementById("after").innerHTML = shorten(b));
+            stat && (document.getElementById("stat-header").innerHTML = stat);
+        }
+        function findQueryParam(name) {
+            let urlParams = window.location.search.substring(1).split("&").map(x => x.split("="));
+            let pair = urlParams.find(x => x[0] === name)
+            if (pair) {
+                return unescape(pair[1]);
+            }
+        }
+        let start = findQueryParam("start");
+        let end = findQueryParam("end");
+        let stat = findQueryParam("stat")
+        update_header(start, end, stat);
 
         function submit_settings() {
             let start = document.getElementById("start-bound").value;

--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -280,6 +280,17 @@
                         </li>
                     </ul>
                 </div>
+                <div class="section">
+                    <div class="section-heading"><span>Show only significant changes</span>
+                        <span class="tooltip">?
+                            <span class="tooltiptext">
+                                Whether to filter out all benchmarks that do not show significant changes. A significant
+                                change is any change above 0.2% for non-noisy benchmarks and 1.0% for noisy ones.
+                            </span>
+                        </span>
+                    </div>
+                    <input type="checkbox" v-model="filter.showOnlySignificant" style="margin-left: 20px;" />
+                </div>
             </div>
         </fieldset>
         <div v-if="data" id="content" style="margin-top: 15px">
@@ -288,15 +299,15 @@
                     <template v-for="bench in benches">
                         <tr data-field-start="true">
                             <th>
-                                <details class="toggle-table" v-on:toggle="benchGroupToggle">
+                                <details>
                                     <summary>{{ trimBenchName(bench.name) }}</summary>
                                 </details>
                             </th>
-                            <td>avg: <span v-bind:class="percentClass(bench.avgPct)">{{bench.avgPct}}%</span></td>
                             <td>min: <span v-bind:class="percentClass(bench.minPct)">{{bench.minPct}}%</span></td>
                             <td>max: <span
                                     v-bind:class="percentClass(bench.maxPct)">{{bench.maxPct}}%{{isDodgyBench(bench)
                                     ? "?" : ""}}</span></td>
+                            <td></td>
                         </tr>
                         <template v-for="run in bench.variants">
                             <tr>
@@ -314,9 +325,9 @@
                                 <td>
                                     <a
                                         v-bind:href="percentLink(data.b.commit, data.a.commit, bench.name, run.casename)">
-                                        <span v-bind:class="percentClass(run.percent)">{{ run.percent }}%{{run.isDodgy ?
-                                            "?"
-                                            : ""}}</span>
+                                        <span v-bind:class="percentClass(run.percent)">
+                                            {{ run.percent }}%{{run.isDodgy ? "?" : ""}}
+                                        </span>
                                     </a>
                                 </td>
                             </tr>
@@ -373,6 +384,7 @@
             data: {
                 filter: {
                     name: null,
+                    showOnlySignificant: true,
                     cache: {
                         full: true,
                         incrFull: true,
@@ -419,6 +431,10 @@
                             const key = d[0];
                             const datumA = d[1];
                             const datumB = data.b.data[name].find(x => x[0] == key)[1];
+                            let percent = (100 * (datumB - datumA) / datumA).toFixed(1);
+                            if (percent === "-0.0") {
+                                percent = "0.0";
+                            }
 
                             let isDodgy = false;
                             if (data.variance) {
@@ -430,7 +446,7 @@
                                     casename: key,
                                     datumA,
                                     datumB,
-                                    percent: (100 * (datumB - datumA) / datumA).toFixed(1),
+                                    percent,
                                     isDodgy,
                                 });
                             }
@@ -442,19 +458,23 @@
                     let benches =
                         Object.keys(data.a.data).
                             filter(n => filter.name && filter.name.trim() ? n.includes(filter.name.trim()) : true).
-                            map(name => { return { name, variants: toVariants(name) } }).filter(b => b.variants.length > 0);
+                            map(name => {
+                                const variants = toVariants(name).filter(v => filter.showOnlySignificant ? isSignificant(v) : true);
+                                const pcts = variants.map(field => parseFloat(field.percent));
+                                const maxPct = Math.max(...pcts).toFixed(1);
+                                const minPct = Math.min(...pcts).toFixed(1);
+                                const maxCasenameLen = Math.max(...variants.map(f => f.casename.length));
+                                return {
+                                    name,
+                                    variants,
+                                    maxPct,
+                                    minPct,
+                                    maxCasenameLen,
+                                };
+                            }).
+                            filter(b => b.variants.length > 0);
 
-                    for (let bench of benches) {
-                        let pcts = bench.variants.map(field => parseFloat(field.percent))
-                            .filter(p => p != undefined && p != null);
-                        bench.maxPct = Math.max(...pcts).toFixed(1);
-                        bench.minPct = Math.min(...pcts).toFixed(1);
-                        let sum = pcts.reduce((a, b) => a + b, 0);
-                        bench.avgPct = (sum / pcts.length).toFixed(1);
-                        bench.maxCasenameLen = Math.max(...bench.variants.map(f => f.casename.length));
-                    }
                     const largestChange = a => Math.max(Math.abs(a.minPct), Math.abs(a.maxPct));
-
                     benches.sort((a, b) => largestChange(b) - largestChange(a));
 
                     return benches;
@@ -543,10 +563,6 @@
                 commitLink(commit) {
                     return `https://github.com/rust-lang/rust/commit/${commit}`;
                 },
-                benchGroupToggle(e) {
-                    const element = e.target;
-                    toggleBenchGroup(element);
-                },
                 formatDate(date) {
                     date = new Date(date);
                     function padStr(i) {
@@ -563,34 +579,17 @@
                     }
                     return result;
                 },
-                isDodgyBench(bench) {
-                    return bench.variants.some(f => f.isDodgy);
-                },
             },
-            watch: {
-                data(newVal, oldVal) {
-                    if (newVal && !oldVal) {
-                        this.$nextTick(() => {
-                            for (let element of document.querySelectorAll(".toggle-table")) {
-                                toggleBenchGroup(element);
-                            }
-                        });
-                    }
-                }
-            }
         });
 
-        function toggleBenchGroup(element) {
-            let next = element.parentElement.parentElement.nextElementSibling;
-            let inBody = []
-            while (next && next.getAttribute("data-field-start") !== "true") {
-                if (element.open) {
-                    next.style.display = "";
-                } else {
-                    next.style.display = "none";
-                }
-                next = next.nextElementSibling;
+        function isSignificant(variant) {
+            const percent = Math.abs(variant.percent);
+            if (variant.isDodgy) {
+                return percent > 1.0;
+            } else {
+                return percent > 0.2;
             }
+
         }
 
         function toggleFilters(id, toggle) {

--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -150,6 +150,7 @@
             opacity: 1;
         }
     </style>
+    <script src="https://cdn.jsdelivr.net/npm/vue@2/dist/vue.js"></script>
 </head>
 
 <body class="container" style="max-width:800px">
@@ -158,85 +159,185 @@
         <a href="status.html">status</a>, <a href="help.html">help</a>.
     </div>
     <br />
-    <h1>Comparing <span id="stat-header">instructions:u</span> between <span id="before">???</span> and <span
-            id="after">???</span></h1>
-    <fieldset id="settings">
-        <legend id="search-toggle" class="section-heading">Do another comparison<span
-                id="search-toggle-indicator"></span></legend>
-        <div id="search-content">
-            <div id="commits" class="section">
-                <div class="section-heading">Commits</div>
-                <div style="display: flex; width: 100%; justify-content: space-around;">
-                    <div class="commit-input">
-                        <label for="start-bound">Before</label>
-                        <input width="100em" placeholder="YYYY-MM-DD or Commit SHA" id="start-bound" />
-                    </div>
-                    <div class="commit-input">
-                        <label for="end-bound">After</label>
-                        <input width="100em" placeholder="YYYY-MM-DD or Commit SHA" id="end-bound" />
-                    </div>
-                </div>
-            </div>
-            <div id="metric" class="section">
-                <div class="section-heading" for="stats">Metric</div>
-                <div style="display: flex; flex-direction: column; justify-content: center;">
-                    <select id='stats' name="stat"></select>
-                </div>
-            </div>
-            <input id="submit" type="submit" value="Submit" onclick="submit_settings(); return false;">
-    </fieldset>
-    </div>
-    <fieldset id="filters">
-        <legend id="filters-toggle" class="section-heading">Filters<span id="filters-toggle-indicator"></span></legend>
-        <div id="filters-content" style="display: none;">
-            <div class="section">
-                <div class="section-heading">Filter by benchmark
-                </div>
-                <input id="filter" type="text" /> </p>
-            </div>
-            <div class="section">
-                <div class="section-heading">
-                    <div>
-                        <span>Cache states</span>
-                        <div class="tooltip">?<span class="tooltiptext">
-                                Most benchmarks have at least 4 cache states for which we collect data
+    <div id="app">
+        <h1>Comparing <span id="stat-header">instructions:u</span> between <span id="before">???</span> and <span
+                id="after">???</span></h1>
+        <fieldset id="settings">
+            <legend id="search-toggle" class="section-heading">Do another comparison<span
+                    id="search-toggle-indicator"></span></legend>
+            <div id="search-content">
+                <div id="commits" class="section">
+                    <div class="section-heading">Commits</div>
+                    <div style="display: flex; width: 100%; justify-content: space-around;">
+                        <div class="commit-input">
+                            <label for="start-bound">Before</label>
+                            <input width="100em" placeholder="YYYY-MM-DD or Commit SHA" id="start-bound" />
+                        </div>
+                        <div class="commit-input">
+                            <label for="end-bound">After</label>
+                            <input width="100em" placeholder="YYYY-MM-DD or Commit SHA" id="end-bound" />
                         </div>
                     </div>
                 </div>
-                <ul id="states-list">
-                    <li><input type="checkbox" id="build-full" checked /><span class="cache-label">full</span>
-                        <div class="tooltip">?<span class="tooltiptext">A
-                                non-incremental full build starting with empty cache</span></div>
-                    </li>
-                    <li><input type="checkbox" id="build-incremental-full" checked /> <span
-                            class="cache-label">incr-full</span>
-                        <div class="tooltip">?<span class="tooltiptext">An incremental build
-                                starting
-                                with empty cache
-                            </span></div>
-                    </li>
-                    <li><input type="checkbox" id="build-incremental-unchanged" checked /> <span
-                            class="cache-label">incr-unchanged</span>
-                        <div class="tooltip">?<span class="tooltiptext">An
-                                incremental
-                                build
-                                starting with complete
-                                cache, and unchanged source directory -- the "perfect" scenario for incremental.</span>
+                <div id="metric" class="section">
+                    <div class="section-heading" for="stats">Metric</div>
+                    <div style="display: flex; flex-direction: column; justify-content: center;">
+                        <select id='stats' name="stat"></select>
+                    </div>
+                </div>
+                <input id="submit" type="submit" value="Submit" onclick="submitSettings(); return false;">
+        </fieldset>
+        <fieldset id="filters">
+            <legend id="filters-toggle" class="section-heading">Filters<span id="filters-toggle-indicator"></span>
+            </legend>
+            <div id="filters-content" style="display: none;">
+                <div class="section">
+                    <div class="section-heading">Filter by benchmark
+                    </div>
+                    <input id="filter" type="text" v-model="filter.name" /> </p>
+                </div>
+                <div class=" section">
+                    <div class="section-heading">
+                        <div>
+                            <span>Cache states</span>
+                            <div class="tooltip">?<span class="tooltiptext">
+                                    Most benchmarks have at least 4 cache states for which we collect data
+                            </div>
                         </div>
-                    </li>
-                    <li><input type="checkbox" id="build-incremental-patched" checked /><span
-                            class="cache-label">incr-patched</span>
-                        <div class="tooltip">?<span class="tooltiptext">An incremental
-                                build
-                                starting with complete cache, and an
-                                altered source directory. The typical variant of this is "println" which represents
-                                the addition of a `println!` macro somewhere in the source code.</span></div>
-                    </li>
-                </ul>
+                    </div>
+                    <ul id="states-list">
+                        <li><input type="checkbox" id="build-full" v-model="filter.cache.full" /><span
+                                class="cache-label">full</span>
+                            <div class="tooltip">?<span class="tooltiptext">A
+                                    non-incremental full build starting with empty cache</span></div>
+                        </li>
+                        <li><input type="checkbox" id="build-incremental-full" v-model="filter.cache.incrFull" /> <span
+                                class="cache-label">incr-full</span>
+                            <div class="tooltip">?<span class="tooltiptext">An incremental build
+                                    starting
+                                    with empty cache
+                                </span></div>
+                        </li>
+                        <li><input type="checkbox" id="build-incremental-unchanged"
+                                v-model="filter.cache.incrUnchanged" />
+                            <span class="cache-label">incr-unchanged</span>
+                            <div class="tooltip">?<span class="tooltiptext">An
+                                    incremental
+                                    build
+                                    starting with complete
+                                    cache, and unchanged source directory -- the "perfect" scenario for
+                                    incremental.</span>
+                            </div>
+                        </li>
+                        <li><input type="checkbox" id="build-incremental-patched"
+                                v-model="filter.cache.incrPatched" /><span class="cache-label">incr-patched</span>
+                            <div class="tooltip">?<span class="tooltiptext">An incremental
+                                    build
+                                    starting with complete cache, and an
+                                    altered source directory. The typical variant of this is "println" which represents
+                                    the addition of a `println!` macro somewhere in the source code.</span></div>
+                        </li>
+                    </ul>
+                </div>
             </div>
+        </fieldset>
+        <div id="content" style="margin-top: 15px">
+            <table v-if="data" class="compare" style="font-size: medium !important;">
+                <thead>
+                    <tr>
+                        <td v-if="notContinuous" colspan="4" style="text-align:center;"><b>Warning</b>: The start and
+                            end
+                            are not adjacent!</td>
+                    </tr>
+                    <tr>
+                        <th>
+                            <a v-bind:href="compareLink">compare</a>
+                        </th>
+                        <th>
+                            <a v-if="data.prev" v-bind:href="prevLink">&larr;</a>
+                            {{formatDate(data.a.date)}}
+                            (<a>{{short(data.a)}}</a>)
+                        </th>
+                        <th>
+                            {{formatDate(data.b.date)}}
+                            (<a>{{short(data.b)}}</a>)
+                            <a v-if="data.next" v-bind:href="nextLink">&rarr;</a>
+                        </th>
+                        <th>% change</th>
+                    </tr>
+                    <tr>
+                        <th></th>
+                        <th style="text-align: left;"><a v-if="data.a.pr"
+                                v-bind:href="prLink(data.a.pr)">#{{data.a.pr}}</a>
+                        </th>
+                        <th style="text-align: left;"><a v-if="data.b.pr"
+                                v-bind:href="prLink(data.b.pr)">#{{data.b.pr}}</a>
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <template v-for="bench in benches">
+                        <tr data-field-start="true">
+                            <th>
+                                <details class="toggle-table" v-on:toggle="benchGroupToggle">
+                                    <summary>{{ trimBenchName(bench.name) }}</summary>
+                                </details>
+                            </th>
+                            <td>avg: <span v-bind:class="percentClass(bench.avgPct)">{{bench.avgPct}}</span></td>
+                            <td>min: <span v-bind:class="percentClass(bench.minPct)">{{bench.minPct}}</span></td>
+                            <td>max: <span
+                                    v-bind:class="percentClass(bench.maxPct)">{{bench.maxPct}}%{{isDodgyBench(bench)
+                                    ? "?" : ""}}</span></td>
+                        </tr>
+                        <template v-for="run in bench.variants">
+                            <tr>
+                                <td>{{ run.casename }}</td>
+                                <td>
+                                    <a v-bind:href="detailedQueryLink(data.a.commit, bench.name, run.casename)">
+                                        {{ run.datumA }}
+                                    </a>
+                                </td>
+                                <td>
+                                    <a v-bind:href="detailedQueryLink(data.b.commit, bench.name, run.casename)">
+                                        {{ run.datumB }}
+                                    </a>
+                                </td>
+                                <td>
+                                    <a
+                                        v-bind:href="percentLink(data.b.commit, data.a.commit, bench.name, run.casename)">
+                                        <span v-bind:class="percentClass(run.percent)">{{ run.percent }}%{{run.isDodgy ?
+                                            "?"
+                                            : ""}}</span>
+                                    </a>
+                                </td>
+                            </tr>
+                        </template>
+                    </template>
+                </tbody>
+            </table>
+            <br />
+            <table class="compare" v-if="data && data.a.bootstrap">
+                <tr>
+                    <td colspan="4">bootstrap timings; variance is 1-3% on smaller benchmarks! Values in seconds.</td>
+                </tr>
+                <tr>
+                    <th>total</th>
+                    <th>{{bootstrapTotals.a.toFixed(3)}}</th>
+                    <th>{{bootstrapTotals.b.toFixed(3)}}</th>
+                </tr>
+                <template v-for="bootstrap in bootstraps">
+                    <tr data-field-start="true">
+                        <th style="width: 19em;">{{bootstrap.name}}</th>
+                        <td>{{bootstrap.a}}</td>
+                        <td>{{bootstrap.b}}</td>
+                        <td><span
+                                v-bind:class="percentClass(bootstrap.percent)">{{bootstrap.percent.toFixed(1)}}%</span>
+                        </td>
+                    </tr>
+                </template>
+            </table>
         </div>
-    </fieldset>
-    <div id="content" style="display: none; margin-top: 15px"></div>
+    </div>
     <br>
     <div id="as-of"></div>
     <a href="https://github.com/rust-lang-nursery/rustc-perf">
@@ -248,6 +349,196 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/msgpack-lite/0.1.26/msgpack.min.js"></script>
     <script src="shared.js"></script>
     <script>
+        let app = new Vue({
+            el: '#app',
+            data: {
+                filter: {
+                    name: null,
+                    cache: {
+                        full: true,
+                        incrFull: true,
+                        incrUnchanged: true,
+                        incrPatched: true
+                    }
+                },
+                data: null
+            },
+            computed: {
+                notContinuous() {
+                    return !this.data.is_contiguous;
+                },
+                prevLink() {
+                    return `/compare.html?start=${this.data.prev}&end=${this.data.a.commit}`;
+                },
+                nextLink() {
+                    return `/compare.html?start=${this.data.b.commit}&end=${this.data.next}`;
+                },
+                compareLink() {
+                    return `https://github.com/rust-lang/rust/compare/${this.data.a.commit}...${this.data.b.commit}`;
+                },
+                benches() {
+                    let data = this.data;
+                    const filter = this.filter;
+
+                    function shouldShowBuild(name) {
+                        if (name === "full") {
+                            return filter.cache.full;
+                        } else if (name === "incr-full") {
+                            return filter.cache.incrFull;
+                        } else if (name === "incr-unchanged") {
+                            return filter.cache.incrUnchanged;
+                        } else if (name.startsWith("incr-patched")) {
+                            return filter.cache.incrPatched;
+                        } else {
+                            // Unknown, but by default we should show things
+                            return true;
+                        }
+                    }
+                    function toVariants(name) {
+                        let variants = [];
+                        for (let d of data.a.data[name]) {
+                            const key = d[0];
+                            const datumA = d[1];
+                            const datumB = data.b.data[name].find(x => x[0] == key)[1];
+
+                            let isDodgy = false;
+                            if (data.variance) {
+                                let variance = data.variance[name + "-" + key];
+                                isDodgy = !!(variance && variance.description && variance.description.type != "Normal");
+                            }
+                            if (shouldShowBuild(key)) {
+                                variants.push({
+                                    casename: key,
+                                    datumA,
+                                    datumB,
+                                    percent: (100 * (datumB - datumA) / datumA).toFixed(1),
+                                    isDodgy,
+                                });
+                            }
+                        }
+
+                        return variants;
+                    }
+
+                    let benches =
+                        Object.keys(data.a.data).
+                            filter(n => filter.name && filter.name.trim() ? n.includes(filter.name.trim()) : true).
+                            map(name => { return { name, variants: toVariants(name) } }).filter(b => b.variants.length > 0);
+
+                    for (let bench of benches) {
+                        let pcts = bench.variants.map(field => parseFloat(field.percent))
+                            .filter(p => p != undefined && p != null);
+                        bench.maxPct = Math.max(...pcts).toFixed(1);
+                        bench.minPct = Math.min(...pcts).toFixed(1);
+                        let sum = pcts.reduce((a, b) => a + b, 0);
+                        bench.avgPct = (sum / pcts.length).toFixed(1);
+                        bench.maxCasenameLen = Math.max(...bench.variants.map(f => f.casename.length));
+                    }
+                    const largestChange = a => Math.max(Math.abs(a.minPct), Math.abs(a.maxPct));
+
+                    benches.sort((a, b) => largestChange(b) - largestChange(a));
+
+                    return benches;
+                },
+                bootstrapTotals() {
+                    const sum = bootstrap => Object.entries(bootstrap).map(e => e[1] / 1e9).reduce((sum, next) => sum + next, 0);
+                    const a = sum(this.data.a.bootstrap);
+                    const b = sum(this.data.b.bootstrap);
+                    return { a, b };
+                },
+                bootstraps() {
+                    return Object.entries(this.data.a.bootstrap).map(e => {
+                        const name = e[0];
+
+                        const format = datum => datum.toLocaleString('en-US', { minimumFractionDigits: 3, maximumFractionDigits: 3 });
+                        const a = format(e[1] / 1e9);
+                        const b = format(this.data.b.bootstrap[name] / 1e9);
+                        return {
+                            name,
+                            a,
+                            b,
+                            percent: 100 * (b - a) / a
+                        };
+                    }).sort((a, b) => Math.abs(b.percent) - Math.abs(a.percent));
+                },
+            },
+            methods: {
+                short(comparison) {
+                    return shortCommit(comparison.commit);
+                },
+                prLink(pr) {
+                    return `https://github.com/rust-lang/rust/pull/${pr}`;
+                },
+                percentClass(pct) {
+                    let klass = "";
+                    if (pct > 1) {
+                        klass = 'positive';
+                    } else if (pct > 0.1) {
+                        klass = 'slightly-positive';
+                    } else if (pct < -1) {
+                        klass = 'negative';
+                    } else if (pct < -0.1) {
+                        klass = 'slightly-negative';
+                    }
+                    return klass;
+
+                },
+                detailedQueryLink(commit, bench, run) {
+                    return `/detailed-query.html?commit=${commit}&benchmark=${bench}&run_name=${run}`;
+                },
+                percentLink(commit, baseCommit, bench, run) {
+                    return `/detailed-query.html?commit=${commit}&base_commit=${baseCommit}&benchmark=${bench}&run_name=${run}`;
+                },
+                benchGroupToggle(e) {
+                    const element = e.target;
+                    toggleBenchGroup(element);
+                },
+                formatDate(date) {
+                    date = new Date(date);
+                    function padStr(i) {
+                        return (i < 10) ? "0" + i : "" + i;
+                    }
+
+                    return `${date.getUTCFullYear()}-${padStr(date.getUTCMonth() + 1)}-${padStr(date.getUTCDate())} `;
+                },
+                trimBenchName(name) {
+                    let result = name.substring(0, 25)
+                    if (result != name) {
+                        result = result + "...";
+
+                    }
+                    return result;
+                },
+                isDodgyBench(bench) {
+                    return bench.variants.some(f => f.isDodgy);
+                },
+            },
+            watch: {
+                data(newVal, oldVal) {
+                    if (newVal && !oldVal) {
+                        this.$nextTick(() => {
+                            for (let element of document.querySelectorAll(".toggle-table")) {
+                                toggleBenchGroup(element);
+                            }
+                        });
+                    }
+                }
+            }
+        });
+
+        function toggleBenchGroup(element) {
+            let next = element.parentElement.parentElement.nextElementSibling;
+            let inBody = []
+            while (next && next.getAttribute("data-field-start") !== "true") {
+                if (element.open) {
+                    next.style.display = "";
+                } else {
+                    next.style.display = "none";
+                }
+                next = next.nextElementSibling;
+            }
+        }
+
         function toggleFilters(id, toggle) {
             let styles = document.getElementById(id).style;
             let indicator = document.getElementById(toggle);
@@ -269,417 +560,27 @@
             toggleFilters("search-content", "search-toggle-indicator");
         };
 
-
-        function print_date(date) {
-            function pad_str(i) {
-                return (i < 10) ? "0" + i : "" + i;
-            }
-
-            return `${date.getUTCFullYear()}-${pad_str(date.getUTCMonth() + 1)}-${pad_str(date.getUTCDate())}`;
-        }
-
         function unique(arr) {
             return arr.filter((value, idx) => arr.indexOf(value) == idx);
         }
 
-        function add_datum_fields(datum, sha, bench, run, selfProfileAvailable) {
-            let html = "";
-            if (datum) {
-                html += "<td>";
-                let txt = "";
-                if (Number.isInteger(datum)) {
-                    txt = datum + "";
-                } else {
-                    txt = datum.toLocaleString('en-US', { minimumFractionDigits: 3, maximumFractionDigits: 3 });
-                }
-                if (selfProfileAvailable) {
-                    html += `<a href="/detailed-query.html?commit=${sha}&benchmark=${bench}&run_name=${run}">${txt}</a>`;
-                } else {
-                    html += txt;
-                }
-                html += "</td>";
-            } else {
-                html += "<td>-</td>";
-            }
-            return html;
+        function shortCommit(commit) {
+            return commit.substring(0, 8);
         }
 
-        function percent_chg(a, b) {
-            if (a && b) {
-                return 100 * (b - a) / a;
-            } else {
-                return null;
-            }
-        }
-
-        function add_percent(pct, dodgy, dodgy_marker) {
-            if (pct != null && pct != Infinity && pct != -Infinity) {
-                let klass = "";
-                if (pct > 1) {
-                    klass = 'class="positive"';
-                } else if (pct > 0.1) {
-                    klass = 'class="slightly-positive"';
-                } else if (pct < -1) {
-                    klass = 'class="negative"';
-                } else if (pct < -0.1) {
-                    klass = 'class="slightly-negative"';
-                }
-                let title = "";
-                let marker = "";
-                if (dodgy) {
-                    title = `title="${dodgy}"`;
-                    marker = dodgy_marker;
-                }
-                return `<span ${klass} ${title}>${pct.toFixed(1)}%${marker}</span>`;
-            } else {
-                return "<span>-</span>"
-            }
-        }
-
-        function populate_data(data) {
-            {
-                let filter = document.querySelector("#filter").value;
-                let test_names = unique([
-                    ...Object.keys(data.a.data),
-                    ...Object.keys(data.b.data),
-                    ...Object.keys(data.a.bootstrap),
-                    ...Object.keys(data.b.bootstrap),
-                ]);
-                let is_copied = false;
-                for (let name of test_names) {
-                    if (!name.includes(filter)) {
-                        if (!is_copied) {
-                            // Copying data is very expensive
-                            // This branch ensures that we avoid copying
-                            // if there are no filters (which is the most common case)
-                            data = JSON.parse(JSON.stringify(DATA)); // deep copy
-                            is_copied = true;
-                        }
-                        if (data.a.data[name]) delete data.a.data[name];
-                        if (data.b.data[name]) delete data.b.data[name];
-                        if (data.a.bootstrap[name]) delete data.a.bootstrap[name];
-                        if (data.b.bootstrap[name]) delete data.b.bootstrap[name];
-                    }
-                }
-            }
-
-            function shouldShowBuild(name) {
-                if (name == "full") {
-                    return document.querySelector("#build-full").checked;
-                } else if (name == "incr-full") {
-                    return document.querySelector("#build-incremental-full").checked;
-                } else if (name == "incr-unchanged") {
-                    return document.querySelector("#build-incremental-unchanged").checked;
-                } else if (name.startsWith("incr-patched")) {
-                    return document.querySelector("#build-incremental-patched").checked;
-                } else {
-                    // Unknown, but by default we should show things
-                    return true;
-                }
-            }
-
-            let html = "";
-
-            html += `<table class="compare" style="font-size: medium !important;">`;
-            html += "<thead>";
-
-            if (!data.is_contiguous) {
-                html += `<tr><td colspan=4 style="text-align:center;">`;
-                html += `<b>Warning</b>: The start and end are not adjacent!`;
-                html += `</td></tr>`;
-            }
-
-            // Heading: the two dates, and the time and rss percent changes.
-            html += "<tr>";
-
-            html += "<th>" + "<a href=\"" +
-                "https://github.com/rust-lang/rust/compare/" + data.a.commit + "..." +
-                data.b.commit +
-                "\">compare</a>" + "</th>";
-
-            let prev_link = "";
-            if (data.prev) {
-                let params = new URLSearchParams(window.location.search);
-                params.set("end", params.get("start"));
-                params.set("start", data.prev);
-                prev_link = `<a href="/compare.html?${params.toString()}">&larr;</a> `;
-            }
-            let next_link = "";
-            if (data.next) {
-                let params = new URLSearchParams(window.location.search);
-                params.set("start", params.get("end"));
-                params.set("end", data.next);
-                next_link = ` <a href="/compare.html?${params.toString()}">&rarr;</a>`;
-            }
-            html += "<th>"
-                + prev_link + ""
-                + print_date(new Date(data.a.date))
-                + ` (<a href="https://github.com/rust-lang/rust/commit/${data.a.commit}"
-                >${data.a.commit.substring(0, 8)}</a>)` + "</th>";
-            html += "<th>" + print_date(new Date(data.b.date))
-                + ` (<a href="https://github.com/rust-lang/rust/commit/${data.b.commit}"
-                >${data.b.commit.substring(0, 8)}</a>)`
-                + next_link
-                + "</th>";
-
-            html += "<th>" + "% change" + "</th>";
-            html += "</tr>";
-
-            html += "<tr>";
-            html += "<th></th>";
-            html += `<th style="text-align:left;">${data.a.pr ? `<a
-            href="https://github.com/rust-lang/rust/pull/${data.a.pr}">#${data.a.pr}</a>` : ""}</th>`;
-            html += `<th style="text-align:left;">${data.b.pr ? `<a
-            href="https://github.com/rust-lang/rust/pull/${data.b.pr}">#${data.b.pr}</a>` : ""}</th>`;
-            html += "</tr>";
-
-            html += "</thead>";
-
-            let test_names = unique([
-                ...Object.keys(data.a.data),
-                ...Object.keys(data.b.data),
-            ]);
-            let bootstrap_names = unique([
-                ...Object.keys(data.a.bootstrap),
-                ...Object.keys(data.b.bootstrap),
-            ]);
-
-            let fields = [
-                ...bootstrap_names
-                    .map(name => name)
-                    .map(name => ({ name, is_bootstrap: true, fields: to_fields_bootstrap(name) })),
-                ...test_names.map(name => ({ name, is_bootstrap: false, fields: to_fields(name) })),
-            ];
-
-            function to_fields_bootstrap(name) {
-                let datum_a = data.a.bootstrap[name] || null;
-                let datum_b = data.b.bootstrap[name] || null;
-                datum_a = datum_a ? datum_a / 1e9 : null;
-                datum_b = datum_b ? datum_b / 1e9 : null;
-
-                return [
-                    {
-                        casename: name,
-                        datum_a,
-                        datum_b,
-                        percent: percent_chg(datum_a, datum_b),
-                    }
-                ];
-            }
-
-            function to_fields(name) {
-                let source = data.a.data[name] || data.b.data[name];
-                let max_length = 0;
-                if (data.a.data[name]) {
-                    max_length = data.a.data[name].length;
-                }
-                if (data.b.data[name] && data.b.data[name].length > max_length) {
-                    max_length = data.b.data[name].length;
-                }
-
-                let keys = {};
-                if (data.a.data[name]) {
-                    for (let i = 0; i < data.a.data[name].length; i++) {
-                        if (!keys[data.a.data[name][i][0]]) {
-                            keys[data.a.data[name][i][0]] = {};
-                        }
-                        keys[data.a.data[name][i][0]].a_idx = i;
-                    }
-                }
-                if (data.b.data[name]) {
-                    for (let i = 0; i < data.b.data[name].length; i++) {
-                        if (!keys[data.b.data[name][i][0]]) {
-                            keys[data.b.data[name][i][0]] = {};
-                        }
-                        keys[data.b.data[name][i][0]].b_idx = i;
-                    }
-                }
-
-                let fields = [];
-                for (let key in keys) {
-                    let a_idx = keys[key].a_idx;
-                    let b_idx = keys[key].b_idx;
-                    let datum_a = null;
-                    let datum_b = null;
-                    if (a_idx != undefined && b_idx != undefined) {
-                        datum_a = data.a.data[name][a_idx][1];
-                        datum_b = data.b.data[name][b_idx][1];
-                    } else if (a_idx != undefined) {
-                        datum_a = data.a.data[name][a_idx][1];
-                    } else if (b_idx != undefined) {
-                        datum_b = data.b.data[name][b_idx][1];
-                    } else {
-                        // should be unreachable
-                    }
-                    if (shouldShowBuild(key)) {
-                        fields.push({
-                            casename: key,
-                            datum_a,
-                            datum_b,
-                            percent: percent_chg(datum_a, datum_b),
-                        });
-                    }
-                }
-
-                return fields;
-            }
-
-            for (let field of fields) {
-                let pcts = field.fields.map(field => field.percent)
-                    .filter(p => p != undefined && p != null);
-                field.max_pct = Math.max(...pcts);
-                field.min_pct = Math.min(...pcts);
-                field.farthest_pct = Math.max(...pcts.map(p => Math.abs(p)));
-                let sum = pcts.reduce((a, b) => a + b, 0);
-                let avg = sum / pcts.length;
-                field.avg_pct = avg;
-                field.max_casename_len = Math.max(...field.fields.map(f => f.casename.length));
-            }
-
-            fields.sort((a, b) => {
-                if (a.is_bootstrap == b.is_bootstrap) {
-                    return b.farthest_pct - a.farthest_pct;
-                }
-                else {
-                    if (a.is_bootstrap) {
-                        return 1;
-                    }
-                    else {
-                        return -1;
-                    }
-                }
-            });
-
-            let max_name_width = Math.max(...fields.map(f => f.max_casename_len));
-
-            function dodgy_name_title() {
-                return "One or more of this benchmark's runs have high measurement variation. " +
-                    "Treat this value with caution. And see the warning at the bottom of " +
-                    "the table.";
-            }
-
-            function dodgy_casename_title(name, casename, variance) {
-                if (!variance) {
-                    return "";
-                }
-
-                if (variance.type == "HighlyVariable") {
-                    return `This measurement varies a lot. Do not trust it!`
-                }
-                if (variance.type == "Noisy") {
-                    return `This measurement is noisy. Do not trust it!`
-                }
-                return "";
-            }
-
-            let is_first_bootstrap = true;
-            for (let field of fields) {
-                let is_dodgy = Object.keys(data.variance || {}).some(k => {
-                    let variance = data.variance[k];
-                    return k.startsWith(field.name) && variance && variance.description.type != "Normal";
-                });
-                let dodgy = is_dodgy ? dodgy_name_title() : "";
-                if (field.is_bootstrap) {
-                    if (is_first_bootstrap) {
-                        html += "<tr data-field-start=true><td>&nbsp;</td></tr>";
-                        html += "<tr data-field-start=true><td colspan=4>bootstrap timings; variance is 1-3% on smaller benchmarks! Values in seconds.</td></tr>";
-                        is_first_bootstrap = false;
-
-                        html += "<tr data-field-start=true>";
-                        html += `<th style="width: ${max_name_width / 2}em;" data-js-name=Total>` + truncate_name("total") + "</th>";
-                        let sum = (acc, value) => acc + value;
-                        let a_total = fields.filter(f => f.is_bootstrap).map(f => f.fields[0].datum_a).reduce(sum);
-                        let b_total = fields.filter(f => f.is_bootstrap).map(f => f.fields[0].datum_b).reduce(sum);
-                        html += add_datum_fields(a_total, data.a.commit, "Total", "", false);
-                        html += add_datum_fields(b_total, data.b.commit, "Total", "", false);
-                        let pct = add_percent(percent_chg(a_total, b_total), dodgy, "??");
-                        html += `<td>${pct}</td>`;
-                        html += "</tr>";
-                    }
-                    html += "<tr data-field-start=true>";
-                    html += `<th style="width: ${max_name_width / 2}em;" data-js-name=${field.name}>` + truncate_name(field.name) + "</th>";
-                    let entry = field.fields[0];
-                    html += add_datum_fields(entry.datum_a, data.a.commit,
-                        field.name, entry.casename, false);
-                    html += add_datum_fields(entry.datum_b, data.b.commit,
-                        field.name, entry.casename, false);
-                    let pct = add_percent(entry.percent, dodgy, "??");
-                    html += `<td>${pct}</td>`;
-                    html += "</tr>";
-                } else {
-                    html += "<tr><td>&nbsp;</td></tr>";
-                    html += "<tr data-field-start=true>";
-                    html += `<th style="width: ${max_name_width / 2}em;" data-js-name=${field.name}>` +
-                        `<details class=toggle-table><summary>` +
-                        truncate_name(field.name) + "</summary></details></th>";
-                    html += "<td> avg: " + add_percent(field.avg_pct, dodgy, "?") + "</td>";
-                    html += "<td text-align=center> min: " + add_percent(field.min_pct, dodgy, "?") +
-                        "</td>";
-                    html += "<td> max: " + add_percent(field.max_pct, dodgy, "?") + "</td>";
-                    html += "</tr>";
-                    for (let i = 0; i < field.fields.length; i++) {
-                        let entry = field.fields[i];
-                        const varianceKey = field.name + "-" + entry.casename;
-                        const variance = data.variance && data.variance[varianceKey] && data.variance[varianceKey].description;
-                        let dodgy = dodgy_casename_title(field.name, entry.casename, variance);
-                        html += "<tr>";
-                        html += "<td>" + entry.casename + "</td>";
-                        // No base comparison commit for the first datum
-                        html += add_datum_fields(entry.datum_a, data.a.commit,
-                            field.name, entry.casename, true);
-                        html += add_datum_fields(entry.datum_b, data.b.commit,
-                            field.name, entry.casename, true);
-                        let pct = add_percent(entry.percent, dodgy, "??");
-                        let diff_href =
-                            `/detailed-query.html?commit=${data.b.commit}&base_commit=${data.a.commit}&benchmark=${field.name}&run_name=${entry.casename}`;
-                        html += `<td><a href="${diff_href}">${pct}</a></td>`;
-                        html += "</tr>";
-                    }
-                }
-            }
-
-            html += "</table>";
-
-            document.getElementById("content").innerHTML = html;
-            document.getElementById("content").style.display = "block";
-            for (let element of document.querySelectorAll(".toggle-table")) {
-                let name = element.parentElement.getAttribute("data-js-name");
-                let in_body = [];
-                let next = element.parentElement.parentElement.nextElementSibling;
-                while (next && next.getAttribute("data-field-start") !== "true") {
-                    in_body.push(next);
-                    next = next.nextElementSibling;
-                }
-                for (let detail of in_body) {
-                    detail.style.display = "none";
-                }
-                element.addEventListener("toggle", evt => {
-                    for (let detail of in_body) {
-                        if (element.open) {
-                            detail.style.display = "";
-                        } else {
-                            detail.style.display = "none";
-                        }
-                    }
-                });
-            }
-        }
-
-        var DATA;
-        function make_data(state) {
+        function makeData(state) {
             let values = Object.assign({}, {
                 start: "",
                 end: "",
                 stat: "instructions:u",
             }, state);
-            make_request("/get", values).then(function (data) {
-                DATA = data;
-                update_header(data.a.commit, data.b.commit);
-                populate_data(data);
+            makeRequest("/get", values).then(function (data) {
+                updateHeader(data.a.commit, data.b.commit);
+                app.data = data;
             });
         }
 
-        function update_header(a, b, stat) {
+        function updateHeader(a, b, stat) {
             let shorten = (text) => {
                 return text.substring(0, 7);
             }
@@ -687,6 +588,7 @@
             b && (document.getElementById("after").innerHTML = shorten(b));
             stat && (document.getElementById("stat-header").innerHTML = stat);
         }
+
         function findQueryParam(name) {
             let urlParams = window.location.search.substring(1).split("&").map(x => x.split("="));
             let pair = urlParams.find(x => x[0] === name)
@@ -697,9 +599,9 @@
         let start = findQueryParam("start");
         let end = findQueryParam("end");
         let stat = findQueryParam("stat")
-        update_header(start, end, stat);
+        updateHeader(start, end, stat);
 
-        function submit_settings() {
+        function submitSettings() {
             let start = document.getElementById("start-bound").value;
             let end = document.getElementById("end-bound").value;
             let stat = getSelected("stats");
@@ -710,18 +612,7 @@
             window.location.search = params.toString();
         }
 
-        load_state(make_data);
-
-        function rerender() {
-            populate_data(DATA);
-        }
-
-        document.querySelector("#filter").addEventListener("change", rerender);
-        document.querySelector("#build-full").addEventListener("change", rerender);
-        document.querySelector("#build-incremental-full").addEventListener("change", rerender);
-        document.querySelector("#build-incremental-unchanged").addEventListener("change", rerender);
-        document.querySelector("#build-incremental-patched").addEventListener("change", rerender);
-
+        loadState(makeData);
     </script>
 </body>
 

--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -160,8 +160,9 @@
     </div>
     <br />
     <div id="app">
-        <h1>Comparing <span id="stat-header">instructions:u</span> between <span id="before">???</span> and <span
-                id="after">???</span></h1>
+        <h1>Comparing <span id="stat-header">{{stat}}</span> between <span id="before">{{before}}</span> and
+            <span id="after">{{after}}</span>
+        </h1>
         <fieldset id="settings">
             <legend id="search-toggle" class="section-heading">Do another comparison<span
                     id="search-toggle-indicator"></span></legend>
@@ -349,6 +350,13 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/msgpack-lite/0.1.26/msgpack.min.js"></script>
     <script src="shared.js"></script>
     <script>
+        function findQueryParam(name) {
+            let urlParams = window.location.search.substring(1).split("&").map(x => x.split("="));
+            let pair = urlParams.find(x => x[0] === name)
+            if (pair) {
+                return unescape(pair[1]);
+            }
+        }
         let app = new Vue({
             el: '#app',
             data: {
@@ -461,6 +469,21 @@
                         };
                     }).sort((a, b) => Math.abs(b.percent) - Math.abs(a.percent));
                 },
+                before() {
+                    if (!this.data) {
+                        return findQueryParam("start").substring(0, 7);
+                    }
+                    return `#${this.data.a.pr}` || this.formatDate(this.data.a.date) || this.data.a.commit.substring(0, 7);
+                },
+                after() {
+                    if (!this.data) {
+                        return findQueryParam("end").substring(0, 7);
+                    }
+                    return `#${this.data.b.pr}` || this.formatDate(this.data.b.date) || this.data.b.commit.substring(0, 7);
+                },
+                stat() {
+                    return findQueryParam("stat");
+                }
             },
             methods: {
                 short(comparison) {
@@ -575,31 +598,10 @@
                 stat: "instructions:u",
             }, state);
             makeRequest("/get", values).then(function (data) {
-                updateHeader(data.a.commit, data.b.commit);
                 app.data = data;
             });
         }
 
-        function updateHeader(a, b, stat) {
-            let shorten = (text) => {
-                return text.substring(0, 7);
-            }
-            a && (document.getElementById("before").innerHTML = shorten(a));
-            b && (document.getElementById("after").innerHTML = shorten(b));
-            stat && (document.getElementById("stat-header").innerHTML = stat);
-        }
-
-        function findQueryParam(name) {
-            let urlParams = window.location.search.substring(1).split("&").map(x => x.split("="));
-            let pair = urlParams.find(x => x[0] === name)
-            if (pair) {
-                return unescape(pair[1]);
-            }
-        }
-        let start = findQueryParam("start");
-        let end = findQueryParam("end");
-        let stat = findQueryParam("stat")
-        updateHeader(start, end, stat);
 
         function submitSettings() {
             let start = document.getElementById("start-bound").value;

--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -200,9 +200,9 @@
                 </div>
                 <input id="submit" type="submit" value="Submit" onclick="submitSettings(); return false;">
         </fieldset>
-        <h1>Comparing <span id="stat-header">{{stat}}</span> between <span id="before">{{before}}</span> and
+        <h2>Comparing <span id="stat-header">{{stat}}</span> between <span id="before">{{before}}</span> and
             <span id="after">{{after}}</span>
-        </h1>
+        </h2>
         <div v-if="data" style="margin: 12px 0;">
             <div style="display: flex;justify-content: center;">
                 <div class="description-box">
@@ -292,8 +292,8 @@
                                     <summary>{{ trimBenchName(bench.name) }}</summary>
                                 </details>
                             </th>
-                            <td>avg: <span v-bind:class="percentClass(bench.avgPct)">{{bench.avgPct}}</span></td>
-                            <td>min: <span v-bind:class="percentClass(bench.minPct)">{{bench.minPct}}</span></td>
+                            <td>avg: <span v-bind:class="percentClass(bench.avgPct)">{{bench.avgPct}}%</span></td>
+                            <td>min: <span v-bind:class="percentClass(bench.minPct)">{{bench.minPct}}%</span></td>
                             <td>max: <span
                                     v-bind:class="percentClass(bench.maxPct)">{{bench.maxPct}}%{{isDodgyBench(bench)
                                     ? "?" : ""}}</span></td>
@@ -359,6 +359,9 @@
     <script src="shared.js"></script>
     <script>
         function findQueryParam(name) {
+            if (!window.location.search) {
+                return null;
+            }
             let urlParams = window.location.search.substring(1).split("&").map(x => x.split("="));
             let pair = urlParams.find(x => x[0] === name)
             if (pair) {
@@ -479,18 +482,35 @@
                 },
                 before() {
                     if (!this.data) {
-                        return findQueryParam("start").substring(0, 7);
+                        const start = findQueryParam("start");
+                        return start ? start.substring(0, 7) : "???";
                     }
-                    return `#${this.data.a.pr}` || this.formatDate(this.data.a.date) || this.data.a.commit.substring(0, 7);
+                    if (this.data.a.pr) {
+                        return `#${this.data.a.pr}`;
+                    }
+                    if (this.data.a.date) {
+                        return this.formatDate(this.data.a.date);
+                    }
+
+                    return this.data.a.commit.substring(0, 7);
                 },
                 after() {
                     if (!this.data) {
-                        return findQueryParam("end").substring(0, 7);
+                        const end = findQueryParam("end");
+                        return end ? end.substring(0, 7) : "???";
                     }
-                    return `#${this.data.b.pr}` || this.formatDate(this.data.b.date) || this.data.b.commit.substring(0, 7);
+
+                    if (this.data.b.pr) {
+                        return `#${this.data.b.pr}`;
+                    }
+                    if (this.data.b.date) {
+                        return this.formatDate(this.data.b.date);
+                    }
+
+                    return this.data.b.commit.substring(0, 7);
                 },
                 stat() {
-                    return findQueryParam("stat");
+                    return findQueryParam("stat") || "instructions:u";
                 }
             },
             methods: {
@@ -577,10 +597,10 @@
             let styles = document.getElementById(id).style;
             let indicator = document.getElementById(toggle);
             if (styles.display != "none") {
-                indicator.innerHTML = "⯈"
+                indicator.innerHTML = " ▶"
                 styles.display = "none";
             } else {
-                indicator.innerHTML = "▼"
+                indicator.innerHTML = " ▼"
                 styles.display = "block";
             }
         }

--- a/site/static/detailed-query.html
+++ b/site/static/detailed-query.html
@@ -309,14 +309,14 @@
             let values = Object.assign({
                 sort_idx: "-2",
             }, state);
-            make_request("/self-profile", values).then(function (data) {
+            makeRequest("/self-profile", values).then(function (data) {
                 DATA = data;
                 data = JSON.parse(JSON.stringify(DATA)); // deep copy
                 populate_data(data, values);
             });
         }
 
-        load_state(make_data, true);
+        loadState(make_data, true);
     </script>
 </body>
 

--- a/site/static/index-old.html
+++ b/site/static/index-old.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html>
+
 <head>
     <meta charset="utf-8">
     <title>rustc performance data</title>
@@ -13,9 +14,11 @@
         }
     </style>
 </head>
+
 <body class="container">
     <div>&gt; <a href="index.html">graphs</a>, <a href="compare.html">compare</a>,
-        <a href="dashboard.html">dashboard</a>, <a href="status.html">status</a>.</div>
+        <a href="dashboard.html">dashboard</a>, <a href="status.html">status</a>.
+    </div>
     <div id="settings">
         start: <input placeholder="yyyy-mm-dd or commit" id="start-bound" />
         end: <input placeholder="yyyy-mm-dd or commit" id="end-bound" />
@@ -27,207 +30,216 @@
         See <a href="/compare.html">compare page</a> for descriptions of what
         the names mean.
     </div>
-    <div id="loading"><h2>Loading &amp; rendering data..</h2><h3>This may take a while!</h3></div>
+    <div id="loading">
+        <h2>Loading &amp; rendering data..</h2>
+        <h3>This may take a while!</h3>
+    </div>
     <div id="charts"></div>
     <div id="as-of"></div>
     <a href="https://github.com/rust-lang-nursery/rustc-perf">
-        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+        <img style="position: absolute; top: 0; right: 0; border: 0;"
+            src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67"
+            alt="Fork me on GitHub"
+            data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
     </a>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/msgpack-lite/0.1.26/msgpack.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highcharts/6.0.7/highcharts.js"></script>
     <script src="shared.js"></script>
 
     <script>
-    let summaryYAxis = "Multiplier of `full` builds";
-    function init_graph(response, stat, absolute) {
-        let sorted_names = Object.keys(response.benchmarks);
-        sorted_names.sort();
-        document.getElementById("charts").style.display = "none";
-        let title = "";
-        let yAxis = "Value";
-        if (stat == "instructions:u") {
-            title = "Number of CPU instructions";
-            yAxis = "Instructions";
-        } else if (stat == "cycles:u") {
-            title = "Number of CPU cycles";
-            yAxis = "Cycles";
-        } else if (stat == "cpu-clock") {
-            title = "Wall time execution";
-            yAxis = "Seconds";
-        } else if (stat == "wall-time") {
-            title = "Wall time execution";
-            yAxis = "Seconds";
-        } else if (stat == "max-rss") {
-            title = "Maximum resident set size";
-            yAxis = "Kilobytes";
-        } else if (stat == "faults") {
-            title = "Faults";
-        }
-
-        function clickHandler(event) {
-            if (this.options.prev_commit !== false) {
-                const prev_commit = this.options.commit
-                window.open("/compare.html?start=" + this.options.prev_commit +
-                    "&end=" + this.options.commit +
-                    "&stat=" + stat, "_blank");
+        let summaryYAxis = "Multiplier of `full` builds";
+        function init_graph(response, stat, absolute) {
+            let sorted_names = Object.keys(response.benchmarks);
+            sorted_names.sort();
+            document.getElementById("charts").style.display = "none";
+            let title = "";
+            let yAxis = "Value";
+            if (stat == "instructions:u") {
+                title = "Number of CPU instructions";
+                yAxis = "Instructions";
+            } else if (stat == "cycles:u") {
+                title = "Number of CPU cycles";
+                yAxis = "Cycles";
+            } else if (stat == "cpu-clock") {
+                title = "Wall time execution";
+                yAxis = "Seconds";
+            } else if (stat == "wall-time") {
+                title = "Wall time execution";
+                yAxis = "Seconds";
+            } else if (stat == "max-rss") {
+                title = "Maximum resident set size";
+                yAxis = "Kilobytes";
+            } else if (stat == "faults") {
+                title = "Faults";
             }
-            return false;
-        }
 
-        for (let crate_name of sorted_names) {
-            let wrapper = document.createElement("table");
-            let row = document.createElement("tr");
-            wrapper.appendChild(row);
-            for (let profile of ["check", "debug", "opt"]) {
-                let crate_name_with_profile = `${crate_name}-${profile}`;
-                let element = document.createElement("td");
-                let element_1 = document.createElement("div");
-                let element_2 = document.createElement("div");
-                element_1.style.position = "absolute";
-                element_1.style.width = "100%";
-                element_1.id = "chart-container-" + crate_name_with_profile;
-                element_2.style.position = "relative";
-                element_2.style.width = "100%";
-                element_2.style.height = "450px";
-                element_2.appendChild(element_1);
-                element.id = "chart-top-outer-container-" + crate_name_with_profile;
-                element.style.width = "33%";
-                element.appendChild(element_2);
-                row.appendChild(element);
+            function clickHandler(event) {
+                if (this.options.prev_commit !== false) {
+                    const prev_commit = this.options.commit
+                    window.open("/compare.html?start=" + this.options.prev_commit +
+                        "&end=" + this.options.commit +
+                        "&stat=" + stat, "_blank");
+                }
+                return false;
             }
-            row.style.width = "100%";
-            wrapper.style.width = "100%";
-            document.getElementById("charts").appendChild(wrapper);
-        }
-        let graphs = [];
-        for (let crate_name of sorted_names) {
-            for (let profile of ["check", "debug", "opt"]) {
-                graphs.push(() => {
-                    let cache_states =
-                        response.benchmarks[crate_name][profile];
-                    let datasets = [];
-                    let max = response.max[crate_name.replace("-check", "").replace("-debug", "").replace("-opt", "")];
-                    for (let state of cache_states) {
-                        let cache_name = state[0];
-                        let data = state[1];
-                        datasets.push({
-                            name: cache_name,
-                            animation: false,
-                            allowPointSelect: true,
-                            data: data.map(({commit, absolute, percent, y, x, is_interpolated}) => ({
-                                commit: response.commits[commit],
-                                prev_commit: commit == 0 ? null : response.commits[commit - 1],
-                                absolute, percent, y, x, color: response.colors[is_interpolated ? 1 : 0],
-                            })),
-                            marker: {
-                                enabled: true
-                            },
-                        });
-                    }
 
-                    let id = "chart-container-" + crate_name + "-" + profile;
-                    let element = document.getElementById(id);
-                    let chart = new Highcharts.chart(element, {
-                        chart: {
-                            zoomType: "xy",
-                            renderTo: element,
-                            type: "line",
-                        },
-                        title: {
-                            text: crate_name + "-" + profile + "<br>" + title,
-                        },
-                        rangeSelector: {
-                            selected: 1,
-                        },
-                        series: datasets,
-                        tooltip: {
-                            crosshairs: [true],
-                            formatter: function formatter() {
-                                let date = new Date(this.x);
-                                let commit = this.point.commit.substr(0, 10);
-                                let y_axis = crate_name.startsWith("Summary") ? summaryYAxis : yAxis;
-                                return "<b>" + date.toLocaleString() + " - " + commit + "</b>" +
-                                    "<br>" + this.series.name + ": " +
-                                    this.point.absolute.toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2}) +
-                                    " " + y_axis.toLowerCase() + " (" +
-                                    this.point.percent.toFixed(2) + "% from start)";
+            for (let crate_name of sorted_names) {
+                let wrapper = document.createElement("table");
+                let row = document.createElement("tr");
+                wrapper.appendChild(row);
+                for (let profile of ["check", "debug", "opt"]) {
+                    let crate_name_with_profile = `${crate_name}-${profile}`;
+                    let element = document.createElement("td");
+                    let element_1 = document.createElement("div");
+                    let element_2 = document.createElement("div");
+                    element_1.style.position = "absolute";
+                    element_1.style.width = "100%";
+                    element_1.id = "chart-container-" + crate_name_with_profile;
+                    element_2.style.position = "relative";
+                    element_2.style.width = "100%";
+                    element_2.style.height = "450px";
+                    element_2.appendChild(element_1);
+                    element.id = "chart-top-outer-container-" + crate_name_with_profile;
+                    element.style.width = "33%";
+                    element.appendChild(element_2);
+                    row.appendChild(element);
+                }
+                row.style.width = "100%";
+                wrapper.style.width = "100%";
+                document.getElementById("charts").appendChild(wrapper);
+            }
+            let graphs = [];
+            for (let crate_name of sorted_names) {
+                for (let profile of ["check", "debug", "opt"]) {
+                    graphs.push(() => {
+                        let cache_states =
+                            response.benchmarks[crate_name][profile];
+                        let datasets = [];
+                        let max = response.max[crate_name.replace("-check", "").replace("-debug", "").replace("-opt", "")];
+                        for (let state of cache_states) {
+                            let cache_name = state[0];
+                            let data = state[1];
+                            datasets.push({
+                                name: cache_name,
+                                animation: false,
+                                allowPointSelect: true,
+                                data: data.map(({ commit, absolute, percent, y, x, is_interpolated }) => ({
+                                    commit: response.commits[commit],
+                                    prev_commit: commit == 0 ? null : response.commits[commit - 1],
+                                    absolute, percent, y, x, color: response.colors[is_interpolated ? 1 : 0],
+                                })),
+                                marker: {
+                                    enabled: true
+                                },
+                            });
+                        }
+
+                        let id = "chart-container-" + crate_name + "-" + profile;
+                        let element = document.getElementById(id);
+                        let chart = new Highcharts.chart(element, {
+                            chart: {
+                                zoomType: "xy",
+                                renderTo: element,
+                                type: "line",
                             },
-                        },
-                        xAxis: {
-                            type: "datetime",
-                        },
-                        yAxis: absolute ? {
-                            // Only the leftmost one ("-check") has its y-axis titled.
-                            title: profile == "check" ?
-                                { text: crate_name.startsWith("Summary") ?
-                                    summaryYAxis : yAxis } :
-                                { text: "" },
-                            min: 0,
-                            ceiling: max * 1.05,
-                            floor: 0,
-                        } : {
-                            max: max * 1.05,
-                            softMin: -5,
-                            minRange: 0.1,
                             title: {
-                                text: "% change",
-                            }
-                        },
-                        plotOptions: {
-                            line: {
-                                point: {
-                                    events: {
-                                        click: clickHandler,
+                                text: crate_name + "-" + profile + "<br>" + title,
+                            },
+                            rangeSelector: {
+                                selected: 1,
+                            },
+                            series: datasets,
+                            tooltip: {
+                                crosshairs: [true],
+                                formatter: function formatter() {
+                                    let date = new Date(this.x);
+                                    let commit = this.point.commit.substr(0, 10);
+                                    let y_axis = crate_name.startsWith("Summary") ? summaryYAxis : yAxis;
+                                    return "<b>" + date.toLocaleString() + " - " + commit + "</b>" +
+                                        "<br>" + this.series.name + ": " +
+                                        this.point.absolute.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) +
+                                        " " + y_axis.toLowerCase() + " (" +
+                                        this.point.percent.toFixed(2) + "% from start)";
+                                },
+                            },
+                            xAxis: {
+                                type: "datetime",
+                            },
+                            yAxis: absolute ? {
+                                // Only the leftmost one ("-check") has its y-axis titled.
+                                title: profile == "check" ?
+                                    {
+                                        text: crate_name.startsWith("Summary") ?
+                                            summaryYAxis : yAxis
+                                    } :
+                                    { text: "" },
+                                min: 0,
+                                ceiling: max * 1.05,
+                                floor: 0,
+                            } : {
+                                max: max * 1.05,
+                                softMin: -5,
+                                minRange: 0.1,
+                                title: {
+                                    text: "% change",
+                                }
+                            },
+                            plotOptions: {
+                                line: {
+                                    point: {
+                                        events: {
+                                            click: clickHandler,
+                                        }
                                     }
                                 }
                             }
-                        }
+                        });
                     });
-                });
+                }
             }
+            processGraphs(graphs);
+            document.getElementById("charts").style.display = "block";
         }
-        processGraphs(graphs);
-        document.getElementById("charts").style.display = "block";
-    }
 
-    function processGraphs(graphs) {
-        requestAnimationFrame(() => {
-            graphs.shift()();
-            if (graphs.length > 0) {
-                processGraphs(graphs);
-            }
-        });
-    }
+        function processGraphs(graphs) {
+            requestAnimationFrame(() => {
+                graphs.shift()();
+                if (graphs.length > 0) {
+                    processGraphs(graphs);
+                }
+            });
+        }
 
-    function make_graph(state) {
-        // it's already visible, but if we would allow calling this more than once this makes it repeatable
-        document.getElementById("loading").style.display = "block";
-        let values = Object.assign({}, {
-            start: "",
-            end: "",
-            stat: "instructions:u",
-            absolute: true,
-        }, state);
-        make_request("/graph", values).then(function(response) {
-            init_graph(response, values.stat, values.absolute);
-            document.getElementById("loading").style.display = "none";
-        });
-    }
+        function make_graph(state) {
+            // it's already visible, but if we would allow calling this more than once this makes it repeatable
+            document.getElementById("loading").style.display = "block";
+            let values = Object.assign({}, {
+                start: "",
+                end: "",
+                stat: "instructions:u",
+                absolute: true,
+            }, state);
+            makeRequest("/graph", values).then(function (response) {
+                init_graph(response, values.stat, values.absolute);
+                document.getElementById("loading").style.display = "none";
+            });
+        }
 
-    function submit_settings() {
-        let start = document.getElementById("start-bound").value;
-        let end = document.getElementById("end-bound").value;
-        let absolute = document.getElementById("absolute").checked;
-        let stat = getSelected("stats");
-        let params = new URLSearchParams();
-        params.append("start", start);
-        params.append("end", end);
-        params.append("absolute", absolute);
-        params.append("stat", stat);
-        window.location.search = params.toString();
-    }
+        function submit_settings() {
+            let start = document.getElementById("start-bound").value;
+            let end = document.getElementById("end-bound").value;
+            let absolute = document.getElementById("absolute").checked;
+            let stat = getSelected("stats");
+            let params = new URLSearchParams();
+            params.append("start", start);
+            params.append("end", end);
+            params.append("absolute", absolute);
+            params.append("stat", stat);
+            window.location.search = params.toString();
+        }
 
-    load_state(make_graph);
+        loadState(make_graph);
     </script>
 </body>
+
 </html>

--- a/site/static/index.html
+++ b/site/static/index.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <html>
+
 <head>
     <meta charset="utf-8">
     <link rel="stylesheet" href="uPlot.min.css">
@@ -42,6 +43,7 @@
             white-space: pre;
             font-family: monospace;
         }
+
         body {
             padding: 1em;
             margin: 0;
@@ -51,10 +53,12 @@
     <script src="shared.js"></script>
     <title>rustc performance data</title>
 </head>
+
 <body>
     <div>&gt; <a href="index.html">graphs</a>, <a href="compare.html">compare</a>,
         <a href="dashboard.html">dashboard</a>, <a href="bootstrap.html">bootstrap</a>,
-        <a href="status.html">status</a>, <a href="help.html">help</a>.</div>
+        <a href="status.html">status</a>, <a href="help.html">help</a>.
+    </div>
     <div id="settings">
         start: <input placeholder="yyyy-mm-dd or commit" id="start-bound" />
         end: <input placeholder="yyyy-mm-dd or commit" id="end-bound" />
@@ -66,11 +70,17 @@
         See <a href="/compare.html">compare page</a> for descriptions of what
         the names mean.
     </div>
-    <div id="loading"><h2>Loading &amp; rendering data..</h2><h3>This may take a while!</h3></div>
+    <div id="loading">
+        <h2>Loading &amp; rendering data..</h2>
+        <h3>This may take a while!</h3>
+    </div>
     <div id="charts"></div>
     <div id="as-of"></div>
     <a href="https://github.com/rust-lang-nursery/rustc-perf">
-        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+        <img style="position: absolute; top: 0; right: 0; border: 0;"
+            src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67"
+            alt="Fork me on GitHub"
+            data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
     </a>
 
     <script>
@@ -84,7 +94,7 @@
         const otherCacheStateColors = ["#8085e9", "#f15c80", "#e4d354", "#2b908f", "#f45b5b", "#91e8e1"];
         const interpolatedColor = "#fcb0f1";
 
-        function tooltipPlugin({onclick, commits, isInterpolated, absoluteMode, shiftX = 10, shiftY = 10}) {
+        function tooltipPlugin({ onclick, commits, isInterpolated, absoluteMode, shiftX = 10, shiftY = 10 }) {
             let tooltipLeftOffset = 0;
             let tooltipTopOffset = 0;
 
@@ -120,9 +130,9 @@
                 showTooltip();
 
                 let top = u.valToPos(u.data[seriesIdx][dataIdx], 'y');
-                let lft = u.valToPos(u.data[        0][dataIdx], 'x');
+                let lft = u.valToPos(u.data[0][dataIdx], 'x');
 
-                tooltip.style.top  = (tooltipTopOffset  + top + shiftX) + "px";
+                tooltip.style.top = (tooltipTopOffset + top + shiftX) + "px";
                 tooltip.style.left = (tooltipLeftOffset + lft + shiftY) + "px";
 
                 tooltip.style.borderColor = isInterpolated(dataIdx) ?
@@ -139,7 +149,7 @@
                 }
                 tooltip.textContent = (
                     fmtDate(new Date(u.data[0][dataIdx] * 1e3)) + " - " +
-                    commits[dataIdx][1].slice(0,10) + "\n" + trailer
+                    commits[dataIdx][1].slice(0, 10) + "\n" + trailer
                 );
             }
 
@@ -199,8 +209,8 @@
             };
         }
 
-        function genPlotOpts({title, width, height, yAxisLabel, series, commits,
-            stat, isInterpolated, alpha = 0.3, prox = 5, absoluteMode}) {
+        function genPlotOpts({ title, width, height, yAxisLabel, series, commits,
+            stat, isInterpolated, alpha = 0.3, prox = 5, absoluteMode }) {
             return {
                 title,
                 width,
@@ -238,11 +248,11 @@
                         values: (self, splits) => {
                             return splits.map(v => {
                                 return (
-                                    v >= 1e12 ? v/1e12 + "T" :
-                                    v >= 1e9  ? v/1e9  + "G" :
-                                    v >= 1e6  ? v/1e6  + "M" :
-                                    v >= 1e3  ? v/1e3  + "k" :
-                                    v
+                                    v >= 1e12 ? v / 1e12 + "T" :
+                                        v >= 1e9 ? v / 1e9 + "G" :
+                                            v >= 1e6 ? v / 1e6 + "M" :
+                                                v >= 1e3 ? v / 1e3 + "k" :
+                                                    v
                                 );
                             });
                         },
@@ -261,7 +271,7 @@
                                     ctx.strokeStyle = interpolatedColorWithAlpha;
                                     ctx.beginPath();
 
-                                    let [ i0, i1 ] = u.series[0].idxs;
+                                    let [i0, i1] = u.series[0].idxs;
 
                                     for (let j = i0; j <= i1; j++) {
                                         let v = u.data[0][j];
@@ -282,7 +292,7 @@
                     tooltipPlugin({
                         onclick(u, seriesIdx, dataIdx) {
                             let thisCommit = commits[dataIdx][1];
-                            let prevCommit = (commits[dataIdx-1] || [null,null])[1];
+                            let prevCommit = (commits[dataIdx - 1] || [null, null])[1];
                             window.open(`/compare.html?start=${prevCommit}&end=${thisCommit}&stat=${stat}`);
                         },
                         commits,
@@ -393,7 +403,7 @@
                 benchmarks[name] = {
                     check: optInterpolated(Check),
                     debug: optInterpolated(Debug),
-                    opt:   optInterpolated(Opt),
+                    opt: optInterpolated(Opt),
                 }
             });
 
@@ -415,7 +425,7 @@
             window.location.search = params.toString();
         }
 
-        load_state(state => {
+        loadState(state => {
             let values = Object.assign({}, {
                 start: "",
                 end: "",
@@ -427,4 +437,5 @@
         });
     </script>
 </body>
+
 </html>

--- a/site/static/shared.js
+++ b/site/static/shared.js
@@ -186,7 +186,7 @@ function query_string_for_state(state) {
     return result;
 }
 
-function load_state(callback, skip_settings) {
+function loadState(callback, skip_settings) {
     let params = new URLSearchParams(window.location.search.slice(1));
     let state = {};
     for (let param of params) {
@@ -225,7 +225,7 @@ function load_state(callback, skip_settings) {
 }
 
 // This one is for making the request we send to the backend.
-function make_request(path, body) {
+function makeRequest(path, body) {
     if (window.msgpack === undefined) {
         alert("msgpack is not loaded, maybe allow scripts from cdnjs.cloudflare.com?");
         return Promise.reject("msgpack is not loaded");


### PR DESCRIPTION
This makes the picking of start and end bounds and metric a bit clearer. It also collapses the search functionality by default since most of the time are on the page from a direct link. Filtering can be collapsed but it's opened by default. 

## Current
![image](https://user-images.githubusercontent.com/1327285/125862149-cb73bf09-7831-408d-800a-dd56b13b67aa.png)

## New
<img width="1304" alt="Screenshot 2021-07-19 at 11 12 15" src="https://user-images.githubusercontent.com/1327285/126135105-25669e93-2b0a-4506-91c4-aa84cb49226a.png">



