### PR TITLE
Fix invocation of `curl` in README to actually post the data for query

### DIFF
--- a/triage/README.md
+++ b/triage/README.md
@@ -28,7 +28,7 @@ be the parent commit that we use for the current round of triage.
 Use the API endpoint to automate building the file:
 
 ```
-% curl https://perf.rust-lang.org/perf/triage '{"start":"$PARENT","stat":"instructions:u"}' > YYYY-MM-DD.md
+% curl https://perf.rust-lang.org/perf/triage -d "{\"start\": \"$PARENT\"}" > YYYY-MM-DD.md
 ```
 
 ## Analysis


### PR DESCRIPTION
 Fix invocation of `curl` in README to actually post the data for query

And, as a drive-by, removed use of single quotes in the command line, so that when I set `PARENT` in my environment, a la `( PARENT=5aff6dd07a562a2cba3c57fc3460a72acb6bef46 ; curl https://perf.rust-lang.org/perf/triage -d "{\"start\": \"$PARENT\"}" > 2021-07-20.md )`, it will actually do the right thing.