### PR TITLE
Consistent terminology

### DIFF
--- a/collector/src/execute.rs
+++ b/collector/src/execute.rs
@@ -605,7 +605,7 @@ impl<'a> MeasureProcessor<'a> {
 
     fn insert_stats(
         &mut self,
-        cache: database::Cache,
+        cache: database::Scenario,
         build_kind: BuildKind,
         stats: (Stats, Option<SelfProfile>, Option<SelfProfileFiles>),
     ) {
@@ -822,18 +822,26 @@ impl<'a> Processor for MeasureProcessor<'a> {
             Ok(res) => {
                 match data.run_kind {
                     RunKind::Full => {
-                        self.insert_stats(database::Cache::Empty, data.build_kind, res);
+                        self.insert_stats(database::Scenario::Empty, data.build_kind, res);
                     }
                     RunKind::IncrFull => {
-                        self.insert_stats(database::Cache::IncrementalEmpty, data.build_kind, res);
+                        self.insert_stats(
+                            database::Scenario::IncrementalEmpty,
+                            data.build_kind,
+                            res,
+                        );
                     }
                     RunKind::IncrUnchanged => {
-                        self.insert_stats(database::Cache::IncrementalFresh, data.build_kind, res);
+                        self.insert_stats(
+                            database::Scenario::IncrementalFresh,
+                            data.build_kind,
+                            res,
+                        );
                     }
                     RunKind::IncrPatched => {
                         let patch = data.patch.unwrap();
                         self.insert_stats(
-                            database::Cache::IncrementalPatch(patch.name),
+                            database::Scenario::IncrementalPatch(patch.name),
                             data.build_kind,
                             res,
                         );

--- a/collector/src/execute/rustc.rs
+++ b/collector/src/execute/rustc.rs
@@ -43,12 +43,12 @@ fn record(
         .arg("--hard")
         .arg(match artifact {
             ArtifactId::Commit(c) => c.sha.as_str(),
-            ArtifactId::Artifact(id) => id.as_str(),
+            ArtifactId::Tag(id) => id.as_str(),
         })
         .status()
         .context("git reset --hard")?;
 
-    if !status.success() && matches!(artifact, ArtifactId::Artifact(_)) {
+    if !status.success() && matches!(artifact, ArtifactId::Tag(_)) {
         log::warn!(
             "git reset --hard {} failed - trying default branch",
             artifact
@@ -165,12 +165,12 @@ fn checkout(artifact: &ArtifactId) -> anyhow::Result<()> {
             .arg("origin")
             .arg(match artifact {
                 ArtifactId::Commit(c) => c.sha.as_str(),
-                ArtifactId::Artifact(id) => id.as_str(),
+                ArtifactId::Tag(id) => id.as_str(),
             })
             .status()
             .context("git fetch origin")?;
 
-        if !status.success() && matches!(artifact, ArtifactId::Artifact(_)) {
+        if !status.success() && matches!(artifact, ArtifactId::Tag(_)) {
             log::warn!(
                 "git fetch origin {} failed - trying default branch",
                 artifact

--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -606,7 +606,7 @@ fn main_result() -> anyhow::Result<i32> {
             let res = bench(
                 &mut rt,
                 pool,
-                &ArtifactId::Artifact(id.to_string()),
+                &ArtifactId::Tag(id.to_string()),
                 &build_kinds,
                 &run_kinds,
                 Compiler {
@@ -731,7 +731,7 @@ fn main_result() -> anyhow::Result<i32> {
             let res = bench(
                 &mut rt,
                 pool,
-                &ArtifactId::Artifact(toolchain.to_string()),
+                &ArtifactId::Tag(toolchain.to_string()),
                 &build_kinds,
                 &run_kinds,
                 Compiler {

--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -67,28 +67,28 @@ impl BuildKind {
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub enum RunKind {
+pub enum ScenarioKind {
     Full,
     IncrFull,
     IncrUnchanged,
     IncrPatched,
 }
 
-impl RunKind {
-    fn all() -> Vec<RunKind> {
+impl ScenarioKind {
+    fn all() -> Vec<ScenarioKind> {
         vec![
-            RunKind::Full,
-            RunKind::IncrFull,
-            RunKind::IncrUnchanged,
-            RunKind::IncrPatched,
+            ScenarioKind::Full,
+            ScenarioKind::IncrFull,
+            ScenarioKind::IncrUnchanged,
+            ScenarioKind::IncrPatched,
         ]
     }
 
-    fn all_non_incr() -> Vec<RunKind> {
-        vec![RunKind::Full]
+    fn all_non_incr() -> Vec<ScenarioKind> {
+        vec![ScenarioKind::Full]
     }
 
-    fn default() -> Vec<RunKind> {
+    fn default() -> Vec<ScenarioKind> {
         Self::all()
     }
 }
@@ -101,12 +101,12 @@ const STRINGS_AND_BUILD_KINDS: &[(&str, BuildKind)] = &[
     ("Opt", BuildKind::Opt),
 ];
 
-// How the --runs arg maps to RunKinds.
-const STRINGS_AND_RUN_KINDS: &[(&str, RunKind)] = &[
-    ("Full", RunKind::Full),
-    ("IncrFull", RunKind::IncrFull),
-    ("IncrUnchanged", RunKind::IncrUnchanged),
-    ("IncrPatched", RunKind::IncrPatched),
+// How the --runs arg maps to ScenarioKinds.
+const STRINGS_AND_SCENARIO_KINDS: &[(&str, ScenarioKind)] = &[
+    ("Full", ScenarioKind::Full),
+    ("IncrFull", ScenarioKind::IncrFull),
+    ("IncrUnchanged", ScenarioKind::IncrUnchanged),
+    ("IncrPatched", ScenarioKind::IncrPatched),
 ];
 
 fn build_kinds_from_arg(arg: &Option<&str>) -> anyhow::Result<Vec<BuildKind>> {
@@ -117,11 +117,11 @@ fn build_kinds_from_arg(arg: &Option<&str>) -> anyhow::Result<Vec<BuildKind>> {
     }
 }
 
-fn run_kinds_from_arg(arg: Option<&str>) -> anyhow::Result<Vec<RunKind>> {
+fn scenario_kinds_from_arg(arg: Option<&str>) -> anyhow::Result<Vec<ScenarioKind>> {
     if let Some(arg) = arg {
-        kinds_from_arg("run", STRINGS_AND_RUN_KINDS, arg)
+        kinds_from_arg("run", STRINGS_AND_SCENARIO_KINDS, arg)
     } else {
-        Ok(RunKind::default())
+        Ok(ScenarioKind::default())
     }
 }
 
@@ -203,7 +203,7 @@ fn bench(
     pool: database::Pool,
     artifact_id: &ArtifactId,
     build_kinds: &[BuildKind],
-    run_kinds: &[RunKind],
+    scenario_kinds: &[ScenarioKind],
     compiler: Compiler<'_>,
     benchmarks: &[Benchmark],
     iterations: Option<usize>,
@@ -269,8 +269,13 @@ fn bench(
             artifact_row_id,
             is_self_profile,
         );
-        let result =
-            benchmark.measure(&mut processor, build_kinds, run_kinds, compiler, iterations);
+        let result = benchmark.measure(
+            &mut processor,
+            build_kinds,
+            scenario_kinds,
+            compiler,
+            iterations,
+        );
         if let Err(s) = result {
             eprintln!(
                 "collector error: Failed to benchmark '{}', recorded: {:#}",
@@ -592,7 +597,7 @@ fn main_result() -> anyhow::Result<i32> {
             let db = sub_m.value_of("DB").unwrap_or(default_db);
             let exclude = sub_m.value_of("EXCLUDE");
             let include = sub_m.value_of("INCLUDE");
-            let run_kinds = run_kinds_from_arg(sub_m.value_of("RUNS"))?;
+            let scenario_kinds = scenario_kinds_from_arg(sub_m.value_of("RUNS"))?;
             let iterations = iterations_from_arg(sub_m.value_of("ITERATIONS"))?;
             let rustdoc = sub_m.value_of("RUSTDOC");
             let is_self_profile = sub_m.is_present("SELF_PROFILE");
@@ -608,7 +613,7 @@ fn main_result() -> anyhow::Result<i32> {
                 pool,
                 &ArtifactId::Tag(id.to_string()),
                 &build_kinds,
-                &run_kinds,
+                &scenario_kinds,
                 Compiler {
                     rustc: &rustc,
                     rustdoc: rustdoc.as_deref(),
@@ -663,7 +668,7 @@ fn main_result() -> anyhow::Result<i32> {
                 pool,
                 &ArtifactId::Commit(commit),
                 &BuildKind::all(),
-                &RunKind::all(),
+                &ScenarioKind::all(),
                 Compiler::from_sysroot(&sysroot),
                 &benchmarks,
                 next.runs.map(|v| v as usize),
@@ -693,10 +698,10 @@ fn main_result() -> anyhow::Result<i32> {
 
             let pool = database::Pool::open(db);
 
-            let run_kinds = if collector::version_supports_incremental(toolchain) {
-                RunKind::all()
+            let scenario_kinds = if collector::version_supports_incremental(toolchain) {
+                ScenarioKind::all()
             } else {
-                RunKind::all_non_incr()
+                ScenarioKind::all_non_incr()
             };
             let build_kinds = if collector::version_supports_doc(toolchain) {
                 BuildKind::all()
@@ -733,7 +738,7 @@ fn main_result() -> anyhow::Result<i32> {
                 pool,
                 &ArtifactId::Tag(toolchain.to_string()),
                 &build_kinds,
-                &run_kinds,
+                &scenario_kinds,
                 Compiler {
                     rustc: Path::new(rustc.trim()),
                     rustdoc: Some(Path::new(rustdoc.trim())),
@@ -761,7 +766,7 @@ fn main_result() -> anyhow::Result<i32> {
             let exclude = sub_m.value_of("EXCLUDE");
             let include = sub_m.value_of("INCLUDE");
             let out_dir = PathBuf::from(sub_m.value_of_os("OUT_DIR").unwrap_or(default_out_dir));
-            let run_kinds = run_kinds_from_arg(sub_m.value_of("RUNS"))?;
+            let scenario_kinds = scenario_kinds_from_arg(sub_m.value_of("RUNS"))?;
             let rustdoc = sub_m.value_of("RUSTDOC");
 
             let (rustc, rustdoc, cargo) = get_local_toolchain(&build_kinds, rustc, rustdoc, cargo)?;
@@ -782,8 +787,13 @@ fn main_result() -> anyhow::Result<i32> {
             for (i, benchmark) in benchmarks.iter().enumerate() {
                 eprintln!("{}", n_benchmarks_remaining(benchmarks.len() - i));
                 let mut processor = execute::ProfileProcessor::new(profiler, &out_dir, &id);
-                let result =
-                    benchmark.measure(&mut processor, &build_kinds, &run_kinds, compiler, Some(1));
+                let result = benchmark.measure(
+                    &mut processor,
+                    &build_kinds,
+                    &scenario_kinds,
+                    compiler,
+                    Some(1),
+                );
                 if let Err(ref s) = result {
                     errors.incr();
                     eprintln!(

--- a/database/src/bin/import-sqlite.rs
+++ b/database/src/bin/import-sqlite.rs
@@ -38,12 +38,12 @@ async fn main() {
         let sqlite_aid = sqlite_conn.artifact_id(&aid).await;
         let postgres_aid = postgres_conn.artifact_id(&aid).await;
 
-        for &(krate, profile, cache, stat) in sqlite_idx.all_pstat_series() {
+        for &(krate, profile, cache, stat) in sqlite_idx.all_test_case_metrics() {
             if benchmarks.insert(krate) {
                 postgres_conn.record_benchmark(krate.as_str(), None).await;
             }
 
-            let id = database::DbLabel::ProcessStat {
+            let id = database::DbLabel::TestCaseMetric {
                 benchmark: krate,
                 profile,
                 scenario: cache,

--- a/database/src/bin/import-sqlite.rs
+++ b/database/src/bin/import-sqlite.rs
@@ -38,37 +38,39 @@ async fn main() {
         let sqlite_aid = sqlite_conn.artifact_id(&aid).await;
         let postgres_aid = postgres_conn.artifact_id(&aid).await;
 
-        for &(krate, profile, cache, stat) in sqlite_idx.all_test_case_metrics() {
-            if benchmarks.insert(krate) {
-                postgres_conn.record_benchmark(krate.as_str(), None).await;
+        for &(benchmark, profile, scenario, metric) in sqlite_idx.all_statistic_descriptions() {
+            if benchmarks.insert(benchmark) {
+                postgres_conn
+                    .record_benchmark(benchmark.as_str(), None)
+                    .await;
             }
 
-            let id = database::DbLabel::TestCaseMetric {
-                benchmark: krate,
+            let id = database::DbLabel::StatisticDescription {
+                benchmark,
                 profile,
-                scenario: cache,
-                metric: stat,
+                scenario,
+                metric,
             }
             .lookup(&sqlite_idx)
             .unwrap();
 
-            let value = sqlite_conn
+            let stat = sqlite_conn
                 .get_pstats(&[id], &[Some(sqlite_aid)])
                 .await
                 .pop()
                 .unwrap()
                 .pop()
                 .unwrap();
-            if let Some(value) = value {
+            if let Some(stat) = stat {
                 postgres_conn
                     .record_statistic(
                         cid,
                         postgres_aid,
-                        &krate.to_string(),
+                        &benchmark.to_string(),
                         profile,
-                        cache,
-                        stat.as_str(),
-                        value,
+                        scenario,
+                        metric.as_str(),
+                        stat,
                     )
                     .await;
             }

--- a/database/src/bin/import-sqlite.rs
+++ b/database/src/bin/import-sqlite.rs
@@ -44,10 +44,10 @@ async fn main() {
             }
 
             let id = database::DbLabel::ProcessStat {
-                krate,
+                benchmark: krate,
                 profile,
-                cache,
-                stat,
+                scenario: cache,
+                metric: stat,
             }
             .lookup(&sqlite_idx)
             .unwrap();

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -599,7 +599,7 @@ pub enum DbLabel {
     Errors {
         benchmark: Benchmark,
     },
-    TestCaseMetric {
+    StatisticDescription {
         benchmark: Benchmark,
         profile: Profile,
         scenario: Scenario,
@@ -623,7 +623,7 @@ impl Lookup for DbLabel {
     fn lookup(&self, index: &Index) -> Option<Self::Id> {
         match self {
             DbLabel::Errors { benchmark } => index.errors.get(benchmark),
-            DbLabel::TestCaseMetric {
+            DbLabel::StatisticDescription {
                 benchmark,
                 profile,
                 scenario,
@@ -711,7 +711,7 @@ impl Index {
     // millions of queries and labels and iterating all of them is eventually
     // going to be impractical. But for now it performs quite well, so we'll go
     // for it as keeping indices around would be annoying.
-    pub fn all_test_case_metrics(
+    pub fn all_statistic_descriptions(
         &self,
     ) -> impl Iterator<Item = &'_ (Benchmark, Profile, Scenario, Metric)> + '_ {
         self.pstat_series.map.keys()

--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -1,5 +1,5 @@
 use crate::{ArtifactId, ArtifactIdNumber};
-use crate::{Cache, CollectionId, Index, Profile, QueryDatum, QueuedCommit, Step};
+use crate::{CollectionId, Index, Profile, QueryDatum, QueuedCommit, Scenario, Step};
 use chrono::{DateTime, Utc};
 use hashbrown::HashMap;
 use std::sync::{Arc, Mutex};
@@ -33,7 +33,7 @@ pub trait Connection: Send + Sync {
         artifact: ArtifactIdNumber,
         krate: &str,
         profile: Profile,
-        cache: Cache,
+        cache: Scenario,
         statistic: &str,
         value: f64,
     );
@@ -47,7 +47,7 @@ pub trait Connection: Send + Sync {
         artifact: ArtifactIdNumber,
         krate: &str,
         profile: Profile,
-        cache: Cache,
+        cache: Scenario,
     );
     async fn record_self_profile_query(
         &self,
@@ -55,7 +55,7 @@ pub trait Connection: Send + Sync {
         artifact: ArtifactIdNumber,
         krate: &str,
         profile: Profile,
-        cache: Cache,
+        cache: Scenario,
         query: &str,
         qd: QueryDatum,
     );

--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -74,7 +74,7 @@ pub trait Connection: Send + Sync {
     ) -> HashMap<String, Vec<Option<Duration>>>;
     async fn get_pstats(
         &self,
-        series: &[u32],
+        pstat_series_row_ids: &[u32],
         artifact_row_id: &[Option<ArtifactIdNumber>],
     ) -> Vec<Vec<Option<f64>>>;
     async fn get_self_profile(

--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -31,10 +31,10 @@ pub trait Connection: Send + Sync {
         &self,
         collection: CollectionId,
         artifact: ArtifactIdNumber,
-        krate: &str,
+        benchmark: &str,
         profile: Profile,
-        cache: Scenario,
-        statistic: &str,
+        scenario: Scenario,
+        metric: &str,
         value: f64,
     );
     /// Records a self-profile artifact in S3.
@@ -45,17 +45,17 @@ pub trait Connection: Send + Sync {
         &self,
         collection: CollectionId,
         artifact: ArtifactIdNumber,
-        krate: &str,
+        benchmark: &str,
         profile: Profile,
-        cache: Scenario,
+        scenario: Scenario,
     );
     async fn record_self_profile_query(
         &self,
         collection: CollectionId,
         artifact: ArtifactIdNumber,
-        krate: &str,
+        benchmark: &str,
         profile: Profile,
-        cache: Scenario,
+        scenario: Scenario,
         query: &str,
         qd: QueryDatum,
     );

--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -525,7 +525,7 @@ where
                     )
                 })
                 .collect(),
-            pstats: self
+            pstat_series: self
                 .conn()
                 .query(
                     "select id, crate, profile, cache, statistic from pstat_series;",
@@ -583,17 +583,23 @@ where
     }
     async fn get_pstats(
         &self,
-        series: &[u32],
+        pstat_series_row_ids: &[u32],
         artifact_row_ids: &[Option<crate::ArtifactIdNumber>],
     ) -> Vec<Vec<Option<f64>>> {
-        let series = series.iter().map(|sid| *sid as i32).collect::<Vec<_>>();
+        let pstat_series_row_ids = pstat_series_row_ids
+            .iter()
+            .map(|sid| *sid as i32)
+            .collect::<Vec<_>>();
         let artifact_row_ids = artifact_row_ids
             .iter()
             .map(|id| id.map(|id| id.0 as i32))
             .collect::<Vec<_>>();
         let rows = self
             .conn()
-            .query(&self.statements().get_pstat, &[&series, &artifact_row_ids])
+            .query(
+                &self.statements().get_pstat,
+                &[&pstat_series_row_ids, &artifact_row_ids],
+            )
             .await
             .unwrap();
         rows.into_iter()
@@ -602,14 +608,14 @@ where
     }
     async fn get_self_profile_query(
         &self,
-        series: u32,
+        pstat_series_row_id: u32,
         artifact_row_id: crate::ArtifactIdNumber,
     ) -> Option<crate::QueryDatum> {
         let row = self
             .conn()
             .query_opt(
                 &self.statements().get_self_profile_query,
-                &[&(series as i32), &(artifact_row_id.0 as i32)],
+                &[&(pstat_series_row_id as i32), &(artifact_row_id.0 as i32)],
             )
             .await
             .unwrap()?;

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -325,7 +325,7 @@ impl Connection for SqliteConnection {
             commits,
             artifacts,
             errors,
-            pstats: self
+            pstat_series: self
                 .raw()
                 .prepare("select id, crate, profile, cache, statistic from pstat_series;")
                 .unwrap()

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -1,5 +1,5 @@
 use crate::pool::{Connection, ConnectionManager, ManagedConnection, Transaction};
-use crate::{ArtifactId, CollectionId, Commit, Crate, Date, Profile};
+use crate::{ArtifactId, Benchmark, CollectionId, Commit, Date, Profile};
 use crate::{ArtifactIdNumber, Index, QueryDatum, QueuedCommit};
 use chrono::{DateTime, TimeZone, Utc};
 use hashbrown::HashMap;
@@ -292,7 +292,7 @@ impl Connection for SqliteConnection {
                 Ok((
                     row.get::<_, i32>(0)? as u32,
                     (
-                        Crate::from(row.get::<_, String>(1)?.as_str()),
+                        Benchmark::from(row.get::<_, String>(1)?.as_str()),
                         match row.get::<_, String>(2)?.as_str() {
                             "check" => Profile::Check,
                             "opt" => Profile::Opt,
@@ -333,7 +333,7 @@ impl Connection for SqliteConnection {
                     Ok((
                         row.get::<_, i32>(0)? as u32,
                         (
-                            Crate::from(row.get::<_, String>(1)?.as_str()),
+                            Benchmark::from(row.get::<_, String>(1)?.as_str()),
                             match row.get::<_, String>(2)?.as_str() {
                                 "check" => Profile::Check,
                                 "opt" => Profile::Opt,
@@ -564,7 +564,7 @@ impl Connection for SqliteConnection {
         artifact: ArtifactIdNumber,
         krate: &str,
         profile: Profile,
-        cache: crate::Cache,
+        cache: crate::Scenario,
         statistic: &str,
         value: f64,
     ) {
@@ -621,7 +621,7 @@ impl Connection for SqliteConnection {
                 },
                 if commit.is_try() { "try" } else { "master" },
             ),
-            crate::ArtifactId::Artifact(a) => (a.clone(), None, "release"),
+            crate::ArtifactId::Tag(a) => (a.clone(), None, "release"),
         };
 
         self.raw_ref()
@@ -647,7 +647,7 @@ impl Connection for SqliteConnection {
         artifact: ArtifactIdNumber,
         krate: &str,
         profile: Profile,
-        cache: crate::Cache,
+        cache: crate::Scenario,
         query: &str,
         qd: QueryDatum,
     ) {
@@ -808,7 +808,7 @@ impl Connection for SqliteConnection {
                         .map(Date)
                         .unwrap_or_else(|| Date::ymd_hms(2001, 01, 01, 0, 0, 0)),
                 }),
-                "release" => ArtifactId::Artifact(name),
+                "release" => ArtifactId::Tag(name),
                 _ => {
                     log::error!("unknown ty {:?}", ty);
                     continue;
@@ -893,7 +893,7 @@ impl Connection for SqliteConnection {
         _artifact: ArtifactIdNumber,
         _krate: &str,
         _profile: Profile,
-        _cache: crate::Cache,
+        _cache: crate::Scenario,
     ) {
         // FIXME: this is left for the future, if we ever need to support it. It
         // shouldn't be too hard, but we may also want to just intern the raw
@@ -965,7 +965,7 @@ impl Connection for SqliteConnection {
                 sha: artifact.to_owned(),
                 date: Date::ymd_hms(2000, 1, 1, 0, 0, 0),
             })),
-            "release" => Some(ArtifactId::Artifact(artifact.to_owned())),
+            "release" => Some(ArtifactId::Tag(artifact.to_owned())),
             _ => panic!("unknown artifact type: {:?}", ty),
         }
     }

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,37 @@
+# Glossary
+
+The following is a glossary of domain specific terminology. Although benchmarks are a seemingly simple domain, they have a surprising amount of complexity. It is therefore useful to ensure that the vocabulary used to describe the domain is consistent and precise to avoid confusion. 
+
+## Basic terms
+
+* **benchmark**: the source of a crate which will be used to benchmark rustc. For example, ["hello world"](https://github.com/rust-lang/rustc-perf/tree/master/collector/benchmarks/helloworld).
+* **profile**: a [cargo profile](https://doc.rust-lang.org/cargo/reference/profiles.html). Note: the database uses "opt" whereas cargo uses "release". 
+* **scenario**: The scenario under which a user is compiling their code. Currently, this is the incremental cache state and a change in the source since last compilation (e.g., full incremental cache and a `println!` statement is added).  
+* **metric**: a name of quantifiable metric being measured (e.g., instruction count)
+* **artifact**: a specific version of rustc (usually a commit sha or some sort of human readable "tag" like 1.51.0)
+
+## Testing 
+
+* **test case**: a combination of a benchmark, a profile, and a scenario.
+* **test**: the act of running an artifact under a test case. Each test result is composed of many iterations.
+* **test iteration**: a single iteration that makes up a test. Note: we currently normally run 2 test iterations for each test. 
+* **test result**: the collection of all metrics as a result of running a test. 
+* **statistic**: a single value of a metric in a test result
+* **run**: a collection of test results for all currently available test cases run on a given artifact. 
+* **test result delta**: the delta between two test results for the same test case but (optionally) different artifacts. The [comparison page](https://perf.rust-lang.org/compare.html) lists all the test result deltas as percentages comparing two runs.  
+
+## Benchmarks
+
+* **stress test benchmark**: a benchmark that is specifically designed to stress a certain part of the compiler (e.g., [deeply-nested-async](https://github.com/rust-lang/rustc-perf/tree/master/collector/benchmarks/deeply-nested-async) is meant to stress parts of the compiler used in async code)
+* **real world benchmark**: a benchmark based on a real world crate. These are typically copied as-is from crates.io. (e.g., [serde](https://github.com/rust-lang/rustc-perf/tree/master/collector/benchmarks/serde) is a popular crate and the benchmark has not been altered from a release of serde on crates.io). 
+
+## Analysis
+
+* **significant test result delta**: a test result delta that is above some threshold that we have determined to be an actual change in performance and not noise. 
+* **highly sensitive benchmark**: a benchmark that tends to produce large (over some threshold) significant test result deltas. For example, some of the stress tests are highly sensitive; when they do produce significant test result deltas, the percentage change is typically quite large. 
+* **highly variable benchmark**: a benchmark that frequently produces (over some threshold) significant test result deltas. This differs from sensitive benchmarks in that the deltas aren't necessarily large, they just happen more frequently than one would expect.  Note: highly variable benchmarks can be classified as noisy. They are different from classically noisy benchmarks in that they often have produce deltas that are above the significance threshold. We cannot therefore be 100% if they are variable because they are noisy or because parts of the compiler being exercised by these benchmarks are just being changed very often. 
+
+## Other 
+
+* **bootstrap**: the process of building the compiler from a previous version of the compiler
+* **query**: a query used inside the [compiler query system](https://rustc-dev-guide.rust-lang.org/overview.html#queries).

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -6,14 +6,14 @@ The following is a glossary of domain specific terminology. Although benchmarks 
 
 * **benchmark**: the source of a crate which will be used to benchmark rustc. For example, ["hello world"](https://github.com/rust-lang/rustc-perf/tree/master/collector/benchmarks/helloworld).
 * **profile**: a [cargo profile](https://doc.rust-lang.org/cargo/reference/profiles.html). Note: the database uses "opt" whereas cargo uses "release". 
-* **scenario**: The scenario under which a user is compiling their code. Currently, this is the incremental cache state and a change in the source since last compilation (e.g., full incremental cache and a `println!` statement is added).  
-* **metric**: a name of quantifiable metric being measured (e.g., instruction count)
+* **scenario**: The scenario under which a user is compiling their code. Currently, this is the incremental cache state and an optional change in the source since last compilation (e.g., full incremental cache and a `println!` statement is added).  
+* **metric**: a name of a quantifiable metric being measured (e.g., instruction count)
 * **artifact**: a specific version of rustc (usually a commit sha or some sort of human readable "tag" like 1.51.0)
 
 ## Benchmarks
 
-* **stress test benchmark**: a benchmark that is specifically designed to stress a certain part of the compiler (e.g., [deeply-nested-async](https://github.com/rust-lang/rustc-perf/tree/master/collector/benchmarks/deeply-nested-async) is meant to stress parts of the compiler used in async code)
-* **real world benchmark**: a benchmark based on a real world crate. These are typically copied as-is from crates.io. (e.g., [serde](https://github.com/rust-lang/rustc-perf/tree/master/collector/benchmarks/serde) is a popular crate and the benchmark has not been altered from a release of serde on crates.io). 
+* **stress test benchmark**: a benchmark that is specifically designed to stress a certain part of the compiler. For example, [deeply-nested-async](https://github.com/rust-lang/rustc-perf/tree/master/collector/benchmarks/deeply-nested-async) is meant to stress parts of the compiler used in async code.
+* **real world benchmark**: a benchmark based on a real world crate. These are typically copied as-is from crates.io. For example, [serde](https://github.com/rust-lang/rustc-perf/tree/master/collector/benchmarks/serde) is a popular crate and the benchmark has not been altered from a release of serde on crates.io. 
 
 ## Artifacts
 
@@ -24,19 +24,20 @@ The following is a glossary of domain specific terminology. Although benchmarks 
 * **test case**: a combination of a benchmark, a profile, and a scenario.
 * **test**: the act of running an artifact under a test case. Each test result is composed of many iterations.
 * **test iteration**: a single iteration that makes up a test. Note: we currently normally run 2 test iterations for each test. 
-* **test result**: the collection of all metrics as a result of running a test. 
-* **test case metric**: the combination of a test case and a particular metric.
+* **test result**: the result of the collection of all statistics from running a test. Currently the minimum of the statistics.
 * **statistic**: a single value of a metric in a test result
-* **statistic description**: the combination of a metric and a test result which describes a statistic.
+* **statistic description**: the combination of a metric and a test case which describes a statistic.
 * **statistic series**: statistics for the same statistic description over time.
 * **run**: a collection of test results for all currently available test cases run on a given artifact. 
 * **test result delta**: the delta between two test results for the same test case but (optionally) different artifacts. The [comparison page](https://perf.rust-lang.org/compare.html) lists all the test result deltas as percentages comparing two runs.  
 
 ## Analysis
 
+* **test result delta**: the difference between two test results for the same metric and test case.
 * **significant test result delta**: a test result delta that is above some threshold that we have determined to be an actual change in performance and not noise. 
-* **highly sensitive benchmark**: a benchmark that tends to produce large (over some threshold) significant test result deltas. For example, some of the stress tests are highly sensitive; when they do produce significant test result deltas, the percentage change is typically quite large. 
-* **highly variable benchmark**: a benchmark that frequently produces (over some threshold) significant test result deltas. This differs from sensitive benchmarks in that the deltas aren't necessarily large, they just happen more frequently than one would expect.  Note: highly variable benchmarks can be classified as noisy. They are different from classically noisy benchmarks in that they often have produce deltas that are above the significance threshold. We cannot therefore be 100% if they are variable because they are noisy or because parts of the compiler being exercised by these benchmarks are just being changed very often. 
+* **noisy test case**: a test case for which the non-significant test result deltas are on average above some threshold. Non-noisy data tends to be very close to zero, and so a test case that produces non-significant test result deltas that are not close enough to zero on average are classified as noisy.
+* **highly variable test case**: a test case that frequently produces (over some threshold) significant test result deltas. This differs from sensitive benchmarks in that the deltas aren't necessarily large, they just happen more frequently than one would expect, and it is unclear why the significant deltas are happening. Note: highly variable test cases can be classified as noisy. They are different from classically noisy benchmarks in that they often produce deltas that are above the significance threshold. We cannot therefore be 100% if they are variable because they are noisy or because parts of the compiler being exercised by these benchmarks are just being changed very often. 
+* **highly sensitive benchmark**: a test case that tends to produce large (over some threshold) significant test result deltas. This differs from highly variable test cases in that it is usually clear what type of changes tend to result in significant test result deltas. For example, some of the stress tests are highly sensitive; they produce significant test result deltas when parts of the compiler that they are stressing change and the percentage change is typically quite large. 
 
 ## Other 
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -27,6 +27,8 @@ The following is a glossary of domain specific terminology. Although benchmarks 
 * **test result**: the collection of all metrics as a result of running a test. 
 * **test case metric**: the combination of a test case and a particular metric.
 * **statistic**: a single value of a metric in a test result
+* **statistic description**: the combination of a metric and a test result which describes a statistic.
+* **statistic series**: statistics for the same statistic description over time.
 * **run**: a collection of test results for all currently available test cases run on a given artifact. 
 * **test result delta**: the delta between two test results for the same test case but (optionally) different artifacts. The [comparison page](https://perf.rust-lang.org/compare.html) lists all the test result deltas as percentages comparing two runs.  
 
@@ -39,4 +41,4 @@ The following is a glossary of domain specific terminology. Although benchmarks 
 ## Other 
 
 * **bootstrap**: the process of building the compiler from a previous version of the compiler
-* **query**: a query used inside the [compiler query system](https://rustc-dev-guide.rust-lang.org/overview.html#queries).
+* **compiler query**: a query used inside the [compiler query system](https://rustc-dev-guide.rust-lang.org/overview.html#queries).

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -25,6 +25,7 @@ The following is a glossary of domain specific terminology. Although benchmarks 
 * **test**: the act of running an artifact under a test case. Each test result is composed of many iterations.
 * **test iteration**: a single iteration that makes up a test. Note: we currently normally run 2 test iterations for each test. 
 * **test result**: the collection of all metrics as a result of running a test. 
+* **test case metric**: the combination of a test case and a particular metric.
 * **statistic**: a single value of a metric in a test result
 * **run**: a collection of test results for all currently available test cases run on a given artifact. 
 * **test result delta**: the delta between two test results for the same test case but (optionally) different artifacts. The [comparison page](https://perf.rust-lang.org/compare.html) lists all the test result deltas as percentages comparing two runs.  

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -10,6 +10,15 @@ The following is a glossary of domain specific terminology. Although benchmarks 
 * **metric**: a name of quantifiable metric being measured (e.g., instruction count)
 * **artifact**: a specific version of rustc (usually a commit sha or some sort of human readable "tag" like 1.51.0)
 
+## Benchmarks
+
+* **stress test benchmark**: a benchmark that is specifically designed to stress a certain part of the compiler (e.g., [deeply-nested-async](https://github.com/rust-lang/rustc-perf/tree/master/collector/benchmarks/deeply-nested-async) is meant to stress parts of the compiler used in async code)
+* **real world benchmark**: a benchmark based on a real world crate. These are typically copied as-is from crates.io. (e.g., [serde](https://github.com/rust-lang/rustc-perf/tree/master/collector/benchmarks/serde) is a popular crate and the benchmark has not been altered from a release of serde on crates.io). 
+
+## Artifacts
+
+* **artifact tag**: an identifier for a particular artifact (e.g., the tag "1.51.0" would presumably point to the 1.51.0 release of rustc).
+
 ## Testing 
 
 * **test case**: a combination of a benchmark, a profile, and a scenario.
@@ -19,11 +28,6 @@ The following is a glossary of domain specific terminology. Although benchmarks 
 * **statistic**: a single value of a metric in a test result
 * **run**: a collection of test results for all currently available test cases run on a given artifact. 
 * **test result delta**: the delta between two test results for the same test case but (optionally) different artifacts. The [comparison page](https://perf.rust-lang.org/compare.html) lists all the test result deltas as percentages comparing two runs.  
-
-## Benchmarks
-
-* **stress test benchmark**: a benchmark that is specifically designed to stress a certain part of the compiler (e.g., [deeply-nested-async](https://github.com/rust-lang/rustc-perf/tree/master/collector/benchmarks/deeply-nested-async) is meant to stress parts of the compiler used in async code)
-* **real world benchmark**: a benchmark based on a real world crate. These are typically copied as-is from crates.io. (e.g., [serde](https://github.com/rust-lang/rustc-perf/tree/master/collector/benchmarks/serde) is a popular crate and the benchmark has not been altered from a release of serde on crates.io). 
 
 ## Analysis
 

--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -4,14 +4,14 @@
 //!
 //! The responses are calculated in the server.rs file.
 
-use database::Crate;
+use database::Benchmark;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::result::Result as StdResult;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct StyledBenchmarkName {
-    pub name: Crate,
+    pub name: Benchmark,
     pub profile: crate::db::Profile,
 }
 

--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -619,7 +619,7 @@ pub async fn post_finished(ctxt: &SiteCtxt) {
             ArtifactId::Commit(c) => {
                 commits.remove(&c.sha);
             }
-            ArtifactId::Artifact(_) => {
+            ArtifactId::Tag(_) => {
                 // do nothing, for now, though eventually we'll want an artifact
                 // queue
             }

--- a/site/src/load.rs
+++ b/site/src/load.rs
@@ -16,7 +16,7 @@ use database::Date;
 use crate::api::github;
 use collector;
 use database::Pool;
-pub use database::{ArtifactId, Commit, Crate};
+pub use database::{ArtifactId, Benchmark, Commit};
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub enum MissingReason {
@@ -86,12 +86,12 @@ pub struct SiteCtxt {
 }
 
 impl SiteCtxt {
-    pub fn summary_patches(&self) -> Vec<crate::db::Cache> {
+    pub fn summary_patches(&self) -> Vec<crate::db::Scenario> {
         vec![
-            crate::db::Cache::Empty,
-            crate::db::Cache::IncrementalEmpty,
-            crate::db::Cache::IncrementalFresh,
-            crate::db::Cache::IncrementalPatch("println".into()),
+            crate::db::Scenario::Empty,
+            crate::db::Scenario::IncrementalEmpty,
+            crate::db::Scenario::IncrementalFresh,
+            crate::db::Scenario::IncrementalPatch("println".into()),
         ]
     }
 
@@ -225,7 +225,7 @@ impl SiteCtxt {
                     have.remove(&c.sha);
                     commits.insert(0, (c, MissingReason::InProgress(previous)));
                 }
-                ArtifactId::Artifact(_) => {
+                ArtifactId::Tag(_) => {
                     // do nothing, for now, though eventually we'll want an artifact
                     // queue
                 }

--- a/site/src/load.rs
+++ b/site/src/load.rs
@@ -86,7 +86,7 @@ pub struct SiteCtxt {
 }
 
 impl SiteCtxt {
-    pub fn summary_patches(&self) -> Vec<crate::db::Scenario> {
+    pub fn summary_scenarios(&self) -> Vec<crate::db::Scenario> {
         vec![
             crate::db::Scenario::Empty,
             crate::db::Scenario::IncrementalEmpty,

--- a/site/src/server.rs
+++ b/site/src/server.rs
@@ -171,21 +171,21 @@ pub async fn handle_dashboard(ctxt: Arc<SiteCtxt>) -> ServerResult<dashboard::Re
         )
         .set(Tag::Metric, selector::Selector::One("wall-time"));
 
-    let summary_patches = ctxt.summary_patches();
+    let summary_scenarios = ctxt.summary_scenarios();
     let by_profile = ByProfile::new::<String, _, _>(|profile| {
-        let summary_patches = &summary_patches;
+        let summary_scenarios = &summary_scenarios;
         let ctxt = &ctxt;
         let query = &query;
         let aids = &artifact_ids;
         async move {
             let mut cases = dashboard::Cases::default();
-            for patch in summary_patches.iter() {
+            for scenario in summary_scenarios.iter() {
                 let responses = ctxt
                     .query::<Option<f64>>(
                         query
                             .clone()
                             .set(Tag::Profile, selector::Selector::One(profile))
-                            .set(Tag::Scenario, selector::Selector::One(patch)),
+                            .set(Tag::Scenario, selector::Selector::One(scenario)),
                         aids.clone(),
                     )
                     .await?;
@@ -201,7 +201,7 @@ pub async fn handle_dashboard(ctxt: Arc<SiteCtxt>) -> ServerResult<dashboard::Re
                 })
                 .collect::<Vec<_>>();
 
-                match patch {
+                match scenario {
                     Scenario::Empty => cases.clean_averages = points,
                     Scenario::IncrementalEmpty => cases.base_incr_averages = points,
                     Scenario::IncrementalFresh => cases.clean_incr_averages = points,
@@ -501,7 +501,7 @@ pub async fn handle_graph(
     let baselines = &mut baselines;
 
     let summary_queries = iproduct!(
-        ctxt.summary_patches(),
+        ctxt.summary_scenarios(),
         vec![Profile::Check, Profile::Debug, Profile::Opt],
         vec![body.stat.clone()]
     )


### PR DESCRIPTION
This attempts to address #938 by moving the glossary into a docs folder and renaming variables and structs in the code to reflect the names in the glossary. 

You can find a rendered version of the glossary [here](https://github.com/rylev/rustc-perf/blob/consistent-terminology/docs/glossary.md).

This is only renaming of internal variable names so nothing that gets serialized should be touched. 

This will have to be a bit messy until we can rename database columns and tables as detailed in #937.