### PR TITLE
Simplify query interface

### DIFF
--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -247,7 +247,7 @@ async fn compare_given_commits(
 
     // `responses` contains series iterators. The first element in the iterator is the data
     // for `a` and the second is the data for `b`
-    let mut responses = ctxt.query::<Option<f64>>(query.clone(), aids).await?;
+    let mut responses = ctxt.statistic_series(query.clone(), aids).await?;
 
     let conn = ctxt.conn().await;
     Ok(Some(Comparison {
@@ -492,7 +492,7 @@ impl BenchmarkVariances {
             master_commits,
         ));
         let mut previous_commit_series = ctxt
-            .query::<Option<f64>>(query, previous_commits.clone())
+            .statistic_series(query, previous_commits.clone())
             .await?;
 
         let mut variance_data: HashMap<String, BenchmarkVariance> = HashMap::new();

--- a/site/src/selector.rs
+++ b/site/src/selector.rs
@@ -268,13 +268,6 @@ impl<T> SeriesResponse<T> {
     }
 }
 
-pub trait Series: Sized
-where
-    Self: Iterator<Item = (ArtifactId, <Self as Series>::Element)>,
-{
-    type Element: Sized;
-}
-
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Path {
     path: Vec<PathComponent>,
@@ -544,10 +537,6 @@ pub struct StatisticSeries {
     points: std::vec::IntoIter<Option<f64>>,
 }
 
-impl Series for StatisticSeries {
-    type Element = Option<f64>;
-}
-
 impl StatisticSeries {
     async fn expand_query(
         artifact_ids: Arc<Vec<ArtifactId>>,
@@ -723,10 +712,6 @@ impl Iterator for SelfProfile {
     }
 }
 
-impl Series for SelfProfile {
-    type Element = Option<SelfProfileData>;
-}
-
 impl SelfProfile {
     async fn expand_query(
         artifact_ids: Arc<Vec<ArtifactId>>,
@@ -813,10 +798,6 @@ impl Iterator for SelfProfileQueryTime {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.artifact_ids.size_hint()
     }
-}
-
-impl Series for SelfProfileQueryTime {
-    type Element = Option<f64>;
 }
 
 impl SelfProfileQueryTime {

--- a/site/src/selector.rs
+++ b/site/src/selector.rs
@@ -412,7 +412,7 @@ impl SiteCtxt {
         query: Query,
         artifact_ids: Arc<Vec<ArtifactId>>,
     ) -> Result<Vec<SeriesResponse<StatisticSeries>>, String> {
-        StatisticSeries::expand_query(artifact_ids.clone(), self, query.clone()).await
+        StatisticSeries::execute_query(artifact_ids.clone(), self, query.clone()).await
     }
 
     pub async fn self_profile(
@@ -420,7 +420,7 @@ impl SiteCtxt {
         query: Query,
         artifact_ids: Arc<Vec<ArtifactId>>,
     ) -> Result<Vec<SeriesResponse<SelfProfile>>, String> {
-        SelfProfile::expand_query(artifact_ids, self, query.clone()).await
+        SelfProfile::execute_query(artifact_ids, self, query.clone()).await
     }
 
     pub async fn self_profile_query_time(
@@ -428,7 +428,7 @@ impl SiteCtxt {
         query: Query,
         artifact_ids: Arc<Vec<ArtifactId>>,
     ) -> Result<Vec<SeriesResponse<SelfProfileQueryTime>>, String> {
-        SelfProfileQueryTime::expand_query(artifact_ids, self, query.clone()).await
+        SelfProfileQueryTime::execute_query(artifact_ids, self, query.clone()).await
     }
 }
 
@@ -438,7 +438,7 @@ pub struct StatisticSeries {
 }
 
 impl StatisticSeries {
-    async fn expand_query(
+    async fn execute_query(
         artifact_ids: Arc<Vec<ArtifactId>>,
         ctxt: &SiteCtxt,
         mut query: Query,
@@ -600,7 +600,7 @@ impl SelfProfile {
         }
     }
 
-    async fn expand_query(
+    async fn execute_query(
         artifact_ids: Arc<Vec<ArtifactId>>,
         ctxt: &SiteCtxt,
         mut query: Query,
@@ -686,7 +686,7 @@ impl SelfProfileQueryTime {
         }
     }
 
-    async fn expand_query(
+    async fn execute_query(
         artifact_ids: Arc<Vec<ArtifactId>>,
         ctxt: &SiteCtxt,
         mut query: Query,

--- a/site/src/selector.rs
+++ b/site/src/selector.rs
@@ -700,33 +700,22 @@ impl SelfProfileQueryTime {
         let index = ctxt.index.load();
         let mut series = index
             .all_query_series()
-            .filter(|tup| {
-                benchmark.matches(tup.0)
-                    && profile.matches(tup.1)
-                    && scenario.matches(tup.2)
-                    && ql.matches(tup.3)
+            .filter(|&&(b, p, s, q)| {
+                benchmark.matches(b) && profile.matches(p) && scenario.matches(s) && ql.matches(q)
             })
             .collect::<Vec<_>>();
 
         series.sort_unstable();
 
         let mut res = Vec::with_capacity(series.len());
-        for path in series {
+        for &(b, p, s, q) in series {
             res.push(SeriesResponse {
-                series: SelfProfileQueryTime::new(
-                    artifact_ids.clone(),
-                    ctxt,
-                    path.0,
-                    path.1,
-                    path.2,
-                    path.3,
-                )
-                .await,
+                series: SelfProfileQueryTime::new(artifact_ids.clone(), ctxt, b, p, s, q).await,
                 path: Path::new()
-                    .set(PathComponent::Benchmark(path.0))
-                    .set(PathComponent::Profile(path.1))
-                    .set(PathComponent::Scenario(path.2))
-                    .set(PathComponent::QueryLabel(path.3)),
+                    .set(PathComponent::Benchmark(b))
+                    .set(PathComponent::Profile(p))
+                    .set(PathComponent::Scenario(s))
+                    .set(PathComponent::QueryLabel(q)),
             });
         }
         Ok(res)


### PR DESCRIPTION
This removes a few traits in favor of direct method invocation for clarity:
* Series (which was never actually used)
* SeriesElement

Previously we've wanted to support querying of statistic series independent of the actual query (mostly for graphing support). We don't really take advantage of this functionality currently. Furthermore, often times we don't need this flexibility as we know what type of series data we want (statistic series or  self profile query time series). This removes this generic functionality and replaces it with direct named method calls. 

When querying for statistic series we go from using the previously highly generic (and pretty opaque) `SiteCtxt::query::<Option<f64>>` to non-generic and fairly transparent `SiteCtxt::statistic_series`. 