### PR TITLE
Filter results by end date correctly on graphs and bootstrap pages

### DIFF
--- a/site/src/selector.rs
+++ b/site/src/selector.rs
@@ -66,7 +66,7 @@ pub fn range_subset(data: Vec<Commit>, range: RangeInclusive<Bound>) -> Vec<Comm
     let (a, b) = range.into_inner();
 
     let left_idx = data.iter().position(|commit| a.left_match(commit));
-    let right_idx = data.iter().rposition(|commit| b.left_match(commit));
+    let right_idx = data.iter().rposition(|commit| b.right_match(commit));
 
     if let (Some(left), Some(right)) = (left_idx, right_idx) {
         data.get(left..=right)


### PR DESCRIPTION
Select as the upper end of the commit range the most recent commit
less than or equal to the specified end date, rather than the most
recent commit greater than or equal to the specified end date.

Fixes #833