### PR TITLE
Consistent significance

### DIFF
--- a/docs/comparison-analysis.md
+++ b/docs/comparison-analysis.md
@@ -22,7 +22,16 @@ At the core of comparison analysis are the collection of test results for the tw
 
 Analysis of the changes is performed in order to determine whether artifact B represents a performance change over artifact A. At a high level the analysis performed takes the following form:
 
-How many _significant_ test results indicate performance changes? If all significant test results indicate regressions (i.e., all percent relative changes are positive), then artifact B represents a performance regression over artifact A. If all significant test results indicate improvements (i.e., all percent relative changes are negative), then artifact B represents a performance improvement over artifact B. If some significant test results indicate improvement and others indicate regressions, then the performance change is mixed.
+How many _significant_ test results indicate performance changes and what is the magnitude of the changes (i.e., how large are the changes regardless of the direction of change)? 
+
+* If there are improvements and regressions with magnitude of medium or above then the comparison is mixed.
+* If there are only either improvements or regressions then the comparison is labeled with that kind.
+* If one kind of changes are of medium or above magnitude (and the other kind are not), then the comparison is mixed if 15% or more of the total changes are the other (small magnitude) kind. For example:
+  * given 20 regressions (with at least 1 of medium magnitude) and all improvements of low magnitude, the comparison is only mixed if there are 4 or more improvements.
+  * given 5 regressions (with at least 1 of medium magnitude) and all improvements of low magnitude, the comparison is only mixed if there 1 or more improvements.
+* If both kinds of changes are all low magnitude changes, then the comparison is mixed unless 90% or more of total changes are of one kind. For example:
+  * given 20 changes of different kinds all of low magnitude, the result is mixed unless only 2 or fewer of the changes are of one kind.
+  * given 5 changes of different kinds all of low magnitude, the result is always mixed.
 
 Whether we actually _report_ an analysis or not depends on the context and how _confident_ we are in the summary of the results (see below for an explanation of how confidence is derived). For example, in pull request performance "try" runs, we report a performance change if we are at least confident that the results are "probably relevant", while for the triage report, we only report if the we are confident the results are "definitely relevant".
 
@@ -48,10 +57,9 @@ A noisy test case is one where of all the non-significant relative delta changes
 
 ### How is confidence in whether a test analysis is "relevant" determined?
 
-The confidence in whether a test analysis is relevant depends on the number of significant test results. Depending on that number a confidence level is reached:
+The confidence in whether a test analysis is relevant depends on the number of significant test results and their magnitude (how large a change is regardless of the direction of the change).
 
-* Maybe relevant: 0-3 changes 
-* Probably relevant: 4-6 changes 
-* Definitely relevant: >6 changes 
-
-Note: changes can be any combination of positive or negative changes.
+The actual algorithm for determining confidence may change, but in general the following rules apply:
+* Definitely relevant: any number of very large changes, a small amount of large and/or medium changes, or a large amount of small changes.
+* Probably relevant: any number of large changes, more than 1 medium change, or smaller but still substantial amount of small changes.
+* Maybe relevant: if it doesn't fit into the above two categories, it ends in this category.

--- a/docs/comparison-analysis.md
+++ b/docs/comparison-analysis.md
@@ -22,13 +22,15 @@ At the core of comparison analysis are the collection of test results for the tw
 
 Analysis of the changes is performed in order to determine whether artifact B represents a performance change over artifact A. At a high level the analysis performed takes the following form:
 
-Are there 1 or more _significant_ test results that indicate performance changes. If all significant test results indicate regressions (i.e., all percent relative changes are positive), then artifact B represents a performance regression over artifact A. If all significant test results indicate improvements (i.e., all percent relative changes are negative), then artifact B represents a performance improvement over artifact B. If some significant test results indicate improvement and others indicate regressions, then the performance change is mixed.
+How many _significant_ test results indicate performance changes? If all significant test results indicate regressions (i.e., all percent relative changes are positive), then artifact B represents a performance regression over artifact A. If all significant test results indicate improvements (i.e., all percent relative changes are negative), then artifact B represents a performance improvement over artifact B. If some significant test results indicate improvement and others indicate regressions, then the performance change is mixed.
 
-* What makes a test result significant?
+Whether we actually _report_ an analysis or not depends on the context and how _confident_ we are in the summary of the results (see below for an explanation of how confidence is derived). For example, in pull request performance "try" runs, we report a performance change if we are at least confident that the results are "probably relevant", while for the triage report, we only report if the we are confident the results are "definitely relevant".
+
+### What makes a test result significant?
 
 A test result is significant if the relative change percentage meets some threshold. What the threshold is depends of whether the test case is "dodgy" or not (see below for an examination of "dodginess"). For dodgy test cases, the threshold is set at 1%. For non-dodgy test cases, the threshold is set to 0.1%.
 
-* What makes a test case "dodgy"?
+### What makes a test case "dodgy"?
 
 A test case is "dodgy" if it shows signs of either being noisy or highly variable.
 
@@ -43,3 +45,13 @@ Any relative delta change that is above a threshold (currently 0.1) is considere
 A highly variable test case is one where a certain percentage (currently 5%) of relative delta changes are significant. The logic being that test cases should only display significant relative delta changes a small percentage of the time.
 
 A noisy test case is one where of all the non-significant relative delta changes, the average delta change is still above some threshold (0.001). The logic being that non-significant changes should, on average, being very close to 0. If they are not close to zero, then they are noisy.
+
+### How is confidence in whether a test analysis is "relevant" determined?
+
+The confidence in whether a test analysis is relevant depends on the number of significant test results. Depending on that number a confidence level is reached:
+
+* Maybe relevant: 0-3 changes 
+* Probably relevant: 4-6 changes 
+* Definitely relevant: >6 changes 
+
+Note: changes can be any combination of positive or negative changes.

--- a/docs/comparison-analysis.md
+++ b/docs/comparison-analysis.md
@@ -1,0 +1,45 @@
+# Comparison Analysis
+
+The following is a detailed explanation of the process undertaken to automate the analysis of test results for two artifacts of interest (artifact A and B). 
+
+This analysis can be done by hand, by using the [comparison page](https://perf.rust-lang.org/compare.html) and entering the two artifacts of interest in the form at the top.
+
+## The goal
+
+The goal of the analysis is to determine whether artifact B represents a performance improvement, regression, or mixed result from artifact A. Typically artifact B will be based on artifact A with a certain pull requests changes applied to artifact A to get artifact B, but this is not required.
+
+Performance analysis is typically used to determine whether a pull request has introduced performance regressions or improvements.
+
+## What is being compared?
+
+At the core of comparison analysis are the collection of test results for the two artifacts being compared. For each test case, the statistics for the two artifacts are compared and a relative change percentage is obtained using the following formula:
+
+```
+100 * ((statisticForArtifactB - statisticForArtifactA) / statisticForArtifactA)
+```
+
+## High-level analysis description 
+
+Analysis of the changes is performed in order to determine whether artifact B represents a performance change over artifact A. At a high level the analysis performed takes the following form:
+
+Are there 1 or more _significant_ test results that indicate performance changes. If all significant test results indicate regressions (i.e., all percent relative changes are positive), then artifact B represents a performance regression over artifact A. If all significant test results indicate improvements (i.e., all percent relative changes are negative), then artifact B represents a performance improvement over artifact B. If some significant test results indicate improvement and others indicate regressions, then the performance change is mixed.
+
+* What makes a test result significant?
+
+A test result is significant if the relative change percentage meets some threshold. What the threshold is depends of whether the test case is "dodgy" or not (see below for an examination of "dodginess"). For dodgy test cases, the threshold is set at 1%. For non-dodgy test cases, the threshold is set to 0.1%.
+
+* What makes a test case "dodgy"?
+
+A test case is "dodgy" if it shows signs of either being noisy or highly variable.
+
+To determine noise and high variability, the previous 100 test results for the test case in question are examined by calculating relative delta changes between adjacent test results. This is done with the following formula (where `testResult1` is the test result immediately proceeding `testResult2`):
+
+```
+testResult2 - testResult1 / testResult1
+```
+
+Any relative delta change that is above a threshold (currently 0.1) is considered "significant" for the purposes of dodginess detection.
+
+A highly variable test case is one where a certain percentage (currently 5%) of relative delta changes are significant. The logic being that test cases should only display significant relative delta changes a small percentage of the time.
+
+A noisy test case is one where of all the non-significant relative delta changes, the average delta change is still above some threshold (0.001). The logic being that non-significant changes should, on average, being very close to 0. If they are not close to zero, then they are noisy.

--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -138,7 +138,6 @@ pub mod bootstrap {
 }
 
 pub mod comparison {
-    use crate::comparison;
     use collector::Bound;
     use database::Date;
     use serde::{Deserialize, Serialize};
@@ -153,13 +152,12 @@ pub mod comparison {
 
     #[derive(Debug, Clone, Serialize)]
     pub struct Response {
-        /// The variance data for each benchmark, if any.
-        pub variance: Option<HashMap<String, comparison::BenchmarkVariance>>,
         /// The names for the previous artifact before `a`, if any.
         pub prev: Option<String>,
 
-        pub a: ArtifactData,
-        pub b: ArtifactData,
+        pub a: ArtifactDescription,
+        pub b: ArtifactDescription,
+        pub comparisons: Vec<Comparison>,
 
         /// The names for the next artifact after `b`, if any.
         pub next: Option<String>,
@@ -169,14 +167,24 @@ pub mod comparison {
         pub is_contiguous: bool,
     }
 
-    /// A serializable wrapper for `comparison::ArtifactData`.
     #[derive(Debug, Clone, Serialize)]
-    pub struct ArtifactData {
+    pub struct ArtifactDescription {
         pub commit: String,
         pub date: Option<Date>,
         pub pr: Option<u32>,
-        pub data: HashMap<String, Vec<(String, f64)>>,
         pub bootstrap: HashMap<String, u64>,
+    }
+
+    /// A serializable wrapper for `comparison::ArtifactData`.
+    #[derive(Debug, Clone, Serialize)]
+    pub struct Comparison {
+        pub benchmark: String,
+        pub profile: String,
+        pub scenario: String,
+        pub is_significant: bool,
+        pub is_dodgy: bool,
+        pub historical_statistics: Option<Vec<f64>>,
+        pub statistics: (f64, f64),
     }
 }
 

--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -945,7 +945,9 @@ Revision range: [{first_commit}..{last_commit}](https://perf.rust-lang.org/?star
 #### Probably changed
 
 The following is a list of comparisons which *probably* represent real performance changes,
-but we're not 100% sure.
+but we're not 100% sure. Please move things from this category into the categories
+above for changes you think *are* definitely relevant and file an issue for each so that
+we can consider how to change our heuristics.
 
 {unlabeled}
 

--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -640,7 +640,7 @@ pub struct TestResultComparison {
 impl TestResultComparison {
     /// The amount of relative change considered significant when
     /// the test case is not dodgy
-    const SIGNIFICANT_RELATIVE_CHANGE_THRESHOLD: f64 = 0.01;
+    const SIGNIFICANT_RELATIVE_CHANGE_THRESHOLD: f64 = 0.001;
 
     /// The amount of relative change considered significant when
     /// the test case is dodgy

--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -641,7 +641,7 @@ pub struct BenchmarkComparison {
     results: (f64, f64),
 }
 
-const SIGNIFICANCE_THRESHOLD: f64 = 0.01;
+const SIGNIFICANCE_THRESHOLD: f64 = 0.001;
 impl BenchmarkComparison {
     fn log_change(&self) -> f64 {
         let (a, b) = self.results;

--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -630,7 +630,7 @@ async fn categorize_benchmark(
         "This change led to significant {} in compiler performance.\n",
         category
     );
-    for change in summary.largest_changes(2) {
+    for change in summary.relevant_changes().iter().filter_map(|c| *c) {
         write!(result, "- ").unwrap();
         change.summary_line(&mut result, None)
     }

--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -606,7 +606,7 @@ async fn categorize_benchmark(
     const DISAGREEMENT: &str = "If you disagree with this performance assessment, \
     please file an issue in [rust-lang/rustc-perf](https://github.com/rust-lang/rustc-perf/issues/new).";
     let (summary, direction) = match ComparisonSummary::summarize_comparison(&comparison) {
-        Some(s) if s.direction().is_some() => {
+        Some(s) if s.confidence().is_atleast_probably_relevant() => {
             let direction = s.direction().unwrap();
             (s, direction)
         }
@@ -630,7 +630,7 @@ async fn categorize_benchmark(
         "This change led to significant {} in compiler performance.\n",
         category
     );
-    for change in summary.ordered_changes() {
+    for change in summary.largest_changes(2) {
         write!(result, "- ").unwrap();
         change.summary_line(&mut result, None)
     }

--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -525,28 +525,23 @@
                             return true;
                         }
                     }
-                    function toVariants(name) {
+                    function toVariants(results) {
                         let variants = [];
-                        for (let d of data.a.data[name]) {
-                            const key = d[0];
-                            const datumA = d[1];
-                            const datumB = data.b.data[name]?.find(x => x[0] == key)?.[1];
-                            if (!datumB) {
-                                continue;
-                            }
+                        for (let r of results) {
+                            const scenarioName = r.scenario;
+                            const datumA = r.statistics[0];
+                            const datumB = r.statistics[1];
+                            const isSignificant = r.is_significant;
                             let percent = (100 * (datumB - datumA) / datumA);
-                            let isDodgy = false;
-                            if (data.variance) {
-                                let variance = data.variance[name + "-" + key];
-                                isDodgy = (variance?.description?.type ?? "Normal") != "Normal";
-                            }
-                            if (shouldShowBuild(key)) {
+                            let isDodgy = r.is_dodgy;
+                            if (shouldShowBuild(scenarioName)) {
                                 variants.push({
-                                    casename: key,
+                                    casename: scenarioName,
                                     datumA,
                                     datumB,
                                     percent,
                                     isDodgy,
+                                    isSignificant
                                 });
                             }
                         }
@@ -555,25 +550,33 @@
                     }
 
                     let benches =
-                        Object.keys(data.a.data).
-                            filter(n => filter.name && filter.name.trim() ? n.includes(filter.name.trim()) : true).
-                            map(name => {
-                                const variants = toVariants(name).filter(v => filter.showOnlySignificant ? isSignificant(v.percent, v.isDodgy) : true);
-                                const pcts = variants.map(field => parseFloat(field.percent));
-                                const maxPct = Math.max(...pcts).toFixed(1);
-                                const minPct = Math.min(...pcts).toFixed(1);
-                                if (variants.length > 0) {
-                                    variants[0].first = true;
-                                }
+                        data.comparisons.
+                            filter(n => filter.name && filter.name.trim() ? n.benchmark.includes(filter.name.trim()) : true).
+                            reduce((accum, next) => {
+                                accum[next.benchmark + "-" + next.profile] ||= [];
+                                accum[next.benchmark + "-" + next.profile].push(next);
+                                return accum;
+                            }, {});
+                    benches = Object.entries(benches).
+                        map(c => {
+                            const name = c[0];
+                            const comparison = c[1];
+                            const variants = toVariants(comparison).filter(v => filter.showOnlySignificant ? v.isSignificant : true);
+                            const pcts = variants.map(field => parseFloat(field.percent));
+                            const maxPct = Math.max(...pcts).toFixed(1);
+                            const minPct = Math.min(...pcts).toFixed(1);
+                            if (variants.length > 0) {
+                                variants[0].first = true;
+                            }
 
-                                return {
-                                    name,
-                                    variants,
-                                    maxPct,
-                                    minPct,
-                                };
-                            }).
-                            filter(b => b.variants.length > 0);
+                            return {
+                                name,
+                                variants,
+                                maxPct,
+                                minPct,
+                            };
+                        }).
+                        filter(b => b.variants.length > 0);
 
                     const largestChange = a => Math.max(Math.abs(a.minPct), Math.abs(a.maxPct));
                     benches.sort((a, b) => largestChange(b) - largestChange(a));
@@ -634,29 +637,25 @@
                     return findQueryParam("stat") || "instructions:u";
                 },
                 summary() {
-                    const filtered = Object.fromEntries(this.benches.map(b => [b.name, Object.fromEntries(b.variants.map(v => [v.casename, true]))]));
+                    // Create object with each test case that is not filtered out as a key
+                    const filtered = Object.fromEntries(this.benches.flatMap(b => b.variants.map(v => [b.name + "-" + v.casename, true])));
                     const newCount = { regressions: 0, improvements: 0, unchanged: 0 }
                     let result = { all: { ...newCount }, filtered: { ...newCount } }
-                    for (let benchmarkAndProfile of Object.keys(this.data.a.data)) {
-                        for (let d of this.data.a.data[benchmarkAndProfile]) {
-                            const scenario = d[0];
-                            const datumA = d[1];
-                            const datumB = this.data.b.data[benchmarkAndProfile]?.find(x => x[0] == scenario)?.[1];
-                            if (!datumB) {
-                                continue;
-                            }
-                            let percent = 100 * ((datumB - datumA) / datumA);
-                            const isDodgy = this.isDodgy(benchmarkAndProfile, scenario);
-                            if (percent > 0 && isSignificant(percent, isDodgy)) {
-                                result.all.regressions += 1;
-                                result.filtered.regressions += filtered[benchmarkAndProfile]?.[scenario] || 0;
-                            } else if (percent < 0 && isSignificant(percent, isDodgy)) {
-                                result.all.improvements += 1;
-                                result.filtered.improvements += filtered[benchmarkAndProfile]?.[scenario] || 0;
-                            } else {
-                                result.all.unchanged += 1;
-                                result.filtered.unchanged += filtered[benchmarkAndProfile]?.[scenario] || 0;
-                            }
+                    for (let d of this.data.comparisons) {
+                        const testCase = testCaseString(d)
+                        const scenario = d.scenario;
+                        const datumA = d.statistics[0];
+                        const datumB = d.statistics[1];
+                        let percent = 100 * ((datumB - datumA) / datumA);
+                        if (percent > 0 && d.is_significant) {
+                            result.all.regressions += 1;
+                            result.filtered.regressions += filtered[testCase] || 0;
+                        } else if (percent < 0 && d.is_significant) {
+                            result.all.improvements += 1;
+                            result.filtered.improvements += filtered[testCase] || 0;
+                        } else {
+                            result.all.unchanged += 1;
+                            result.filtered.unchanged += filtered[testCase] || 0;
                         }
                     }
                     return result;
@@ -719,25 +718,8 @@
                     }
                     return result;
                 },
-                isDodgy(benchmarkAndProfile, scenario) {
-                    let variance = this.data.variance;
-                    if (!variance) {
-                        return false;
-                    }
-                    variance = this.data.variance[benchmarkAndProfile + "-" + scenario];
-                    return (variance?.description?.type ?? "Normal") != "Normal";
-                },
             },
         });
-
-        function isSignificant(percent, isNoisy) {
-            const perAbs = Math.abs(percent);
-            if (isNoisy) {
-                return perAbs > 1.0;
-            } else {
-                return perAbs >= 0.2;
-            }
-        }
 
         function toggleFilters(id, toggle) {
             let styles = document.getElementById(id).style;
@@ -752,6 +734,10 @@
         }
         toggleFilters("filters-content", "filters-toggle-indicator");
         toggleFilters("search-content", "search-toggle-indicator");
+
+        function testCaseString(testCase) {
+            return testCase.benchmark + "-" + testCase.profile + "-" + testCase.scenario;
+        }
 
         document.getElementById("filters-toggle").onclick = (e) => {
             toggleFilters("filters-content", "filters-toggle-indicator");


### PR DESCRIPTION
This moves the definition of significance to one central place (almost) in the API instead of it be calculated on the client and in the API.

Some things to note: 
* We're now using the same significance threshold for both triage reports _and_ the comparison.html page. The threshold has been placed at 0.1% for test cases not considered "dodgy" (i.e., has some sort of noisy or high variability) and 1% for test cases considered dodgy. 
* This is a change to the triage thresholds from before which will likely lead to more cases being identified in the triage report.  **TODO**: we should consider changing how we handle triage to not only rely purely on what we considered "significant". Perhaps we can classify changes as noteworthy of the triage report if the meet an additional threshold - perhaps 2 times the size of the significance threshold. I'm very open to ideas here.
* We are using a mix of log change and relative change, and it's not clear why, so I started moving more exclusively to relative change. 

Fixes #952 