### PR TITLE
Consider any comparison with medium changes as probably relevant

### DIFF
--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -266,9 +266,9 @@ impl ComparisonSummary {
         ) {
             (_, _, vl) if vl > 0 => ComparisonConfidence::DefinitelyRelevant,
             (m, l, _) if m + (l * 2) > 4 => ComparisonConfidence::DefinitelyRelevant,
-            (m, l, _) if m > 1 || l > 0 => ComparisonConfidence::ProbablyRelevant,
-            (m, _, _) => {
-                if (m * 2 + num_small_changes) > 10 {
+            (m, l, _) if m > 0 || l > 0 => ComparisonConfidence::ProbablyRelevant,
+            _ => {
+                if num_small_changes > 8 {
                     ComparisonConfidence::ProbablyRelevant
                 } else {
                     ComparisonConfidence::MaybeRelevant


### PR DESCRIPTION
When doing the latest triage @pnkfelix noted that https://github.com/rust-lang/rust/issues/87736 which yielded [this comparison](https://perf.rust-lang.org/compare.html?start=7f3dc0464422ebadf3b8647f591bcf6e3107e805&end=6fe0886723c9e08b800c9951f1c6f6a57b2bf22c&stat=instructions:u) was not included under "probably relevant". This is because previously, we only considered something with only medium and below size changes "probably relevant" if it had either 4 or more medium size changes or if `num_medium_size_changes * 2 + num_small_size_changes > 10` which this comparison did not have. 

This changes the logic such that anything with medium and above size changes are considered at least "probably relevant". It also slightly lowers the threshold for "probably relevant" when there are only small changes down to 8 small changes being considered "probably relevant".