### PR TITLE
Make printed site URL clickable in some terminals

### DIFF
--- a/site/src/main.rs
+++ b/site/src/main.rs
@@ -40,7 +40,7 @@ async fn main() {
                 "Loading complete; {} commits and {} artifacts",
                 commits, artifacts,
             );
-            eprintln!("View the results in a web browser at 'localhost:2346/compare.html'");
+            eprintln!("View the results in a web browser at 'http://localhost:2346/compare.html'");
             // Spawn off a task to post the results of any commit results that we
             // are now aware of.
             site::github::post_finished(&res).await;


### PR DESCRIPTION
Adding `http://` to the printed site URL causes some terminal emulators
to treat it as a Ctrl/Cmd clickable link, which enables easily launching
the site in the browser.