### PR TITLE
Update flamegraph and crox support

### DIFF
--- a/site/src/self_profile.rs
+++ b/site/src/self_profile.rs
@@ -3,8 +3,6 @@
 
 use anyhow::Context;
 use std::collections::HashMap;
-use std::fmt;
-use std::io::Read;
 
 pub mod crox;
 pub mod flamegraph;
@@ -17,7 +15,7 @@ pub struct Output {
 
 pub fn generate(
     title: &str,
-    pieces: Pieces,
+    self_profile_data: Vec<u8>,
     mut params: HashMap<String, String>,
 ) -> anyhow::Result<Output> {
     let removed = params.remove("type");
@@ -27,7 +25,7 @@ pub fn generate(
                 .context("crox opts")?;
             Ok(Output {
                 filename: "chrome_profiler.json",
-                data: crox::generate(pieces, opt).context("crox")?,
+                data: crox::generate(self_profile_data, opt).context("crox")?,
                 is_download: true,
             })
         }
@@ -36,56 +34,10 @@ pub fn generate(
                 .context("flame opts")?;
             Ok(Output {
                 filename: "flamegraph.svg",
-                data: flamegraph::generate(title, pieces, opt).context("flame")?,
+                data: flamegraph::generate(title, self_profile_data, opt).context("flame")?,
                 is_download: false,
             })
         }
         _ => anyhow::bail!("Unknown type, specify type={crox,flamegraph}"),
-    }
-}
-
-pub struct Pieces {
-    pub string_data: Vec<u8>,
-    pub string_index: Vec<u8>,
-    pub events: Vec<u8>,
-}
-
-impl fmt::Debug for Pieces {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Pieces")
-            .field("string_data", &self.string_data.len())
-            .field("string_index", &self.string_index.len())
-            .field("events", &self.events.len())
-            .finish()
-    }
-}
-
-impl Pieces {
-    pub fn from_tarball<R: std::io::Read>(mut tarball: tar::Archive<R>) -> anyhow::Result<Pieces> {
-        let mut pieces = Pieces {
-            string_data: Vec::new(),
-            string_index: Vec::new(),
-            events: Vec::new(),
-        };
-
-        for entry in tarball.entries().context("entries")? {
-            let mut entry = entry.context("tarball entry")?;
-            let path = entry.path_bytes();
-            if *path == *b"self-profile.string_index" {
-                entry
-                    .read_to_end(&mut pieces.string_index)
-                    .context("reading string index")?;
-            } else if *path == *b"self-profile.string_data" {
-                entry
-                    .read_to_end(&mut pieces.string_data)
-                    .context("reading string data")?;
-            } else if *path == *b"self-profile.events" {
-                entry
-                    .read_to_end(&mut pieces.events)
-                    .context("reading events")?;
-            }
-        }
-
-        Ok(pieces)
     }
 }

--- a/site/src/self_profile/crox.rs
+++ b/site/src/self_profile/crox.rs
@@ -125,14 +125,13 @@ fn get_args(full_event: &analyzeme::Event) -> Option<HashMap<String, String>> {
 }
 
 /// Returns JSON blob fit, `chrome_profiler.json`.
-pub fn generate(pieces: super::Pieces, opt: Opt) -> anyhow::Result<Vec<u8>> {
+pub fn generate(self_profile_data: Vec<u8>, opt: Opt) -> anyhow::Result<Vec<u8>> {
     let mut serializer = serde_json::Serializer::new(Vec::new());
 
     let mut seq = serializer.serialize_seq(None)?;
 
-    let data =
-        ProfilingData::from_buffers(pieces.string_data, pieces.string_index, pieces.events, None)
-            .map_err(|e| anyhow::format_err!("{:?}", e))?;
+    let data = ProfilingData::from_paged_buffer(self_profile_data)
+        .map_err(|e| anyhow::format_err!("{:?}", e))?;
 
     let thread_to_collapsed_thread =
         generate_thread_to_collapsed_thread_mapping(opt.collapse_threads, &data);

--- a/site/src/self_profile/flamegraph.rs
+++ b/site/src/self_profile/flamegraph.rs
@@ -5,10 +5,9 @@ use inferno::flamegraph::{from_lines, Options as FlamegraphOptions};
 #[derive(serde::Deserialize, Debug)]
 pub struct Opt {}
 
-pub fn generate(title: &str, pieces: super::Pieces, _: Opt) -> anyhow::Result<Vec<u8>> {
-    let profiling_data =
-        ProfilingData::from_buffers(pieces.string_data, pieces.string_index, pieces.events, None)
-            .map_err(|e| anyhow::format_err!("{:?}", e))?;
+pub fn generate(title: &str, self_profile_data: Vec<u8>, _: Opt) -> anyhow::Result<Vec<u8>> {
+    let profiling_data = ProfilingData::from_paged_buffer(self_profile_data)
+        .map_err(|e| anyhow::format_err!("{:?}", e))?;
 
     let recorded_stacks = collapse_stacks(&profiling_data)
         .iter()


### PR DESCRIPTION
Add support for generating flamegraph and crox files from newer
self-profile format, and remove support for old format. Fixes broken
flamegraph and crox links on detailed query page for self-profile data
in newer format. Breaks links for self-profile data in older format,
for what it's worth.