### PR TITLE
Categorize percents less than -1% as negative, not those less than 1%

### DIFF
--- a/site/static/detailed-query.html
+++ b/site/static/detailed-query.html
@@ -101,7 +101,7 @@
                 let classes;
                 if (pct > 1) {
                     classes = "positive";
-                } else if (pct < 1) {
+                } else if (pct < -1) {
                     classes = "negative";
                 } else {
                     classes = "neutral";


### PR DESCRIPTION
Fixes certain delta percent changes between -1% and 1% being regarded as
improvements (and colored green), rather than neutral.