### PR TITLE
Fix status page display for artifacts

### DIFF
--- a/site/static/status.html
+++ b/site/static/status.html
@@ -110,7 +110,7 @@
                 if (data.current.artifact.Commit) {
                     artifact_desc = commit_url(data.current.artifact.Commit);
                 } else {
-                    artifact_desc = data.current.artifact.Artifact;
+                    artifact_desc = data.current.artifact.Tag;
                 }
                 element.innerHTML = `Currently benchmarking: ${artifact_desc}.
                 <br>Time left: ${format_duration(left)}`;


### PR DESCRIPTION
This wasn't adjusted when ArtifactId::Artifact was renamed to ArtifactId::Tag.