### PR TITLE
Adjust bootstrap boundary to 25

### DIFF
--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -126,6 +126,7 @@ pub mod bootstrap {
     pub struct Request {
         pub start: Bound,
         pub end: Bound,
+        pub min_seconds: u32,
     }
 
     #[derive(Debug, Clone, Serialize)]

--- a/site/src/request_handlers/bootstrap.rs
+++ b/site/src/request_handlers/bootstrap.rs
@@ -33,7 +33,9 @@ pub async fn handle_bootstrap(
         .filter_map(|(k, v)| {
             // We show any line that has at least one point exceeding the
             // critical line.
-            if v.iter().any(|v| v.map_or(false, |v| v.as_secs() >= 30)) {
+            if v.iter()
+                .any(|v| v.map_or(false, |v| v.as_secs() >= body.min_seconds as u64))
+            {
                 Some((
                     k,
                     v.into_iter()

--- a/site/static/bootstrap.html
+++ b/site/static/bootstrap.html
@@ -254,7 +254,7 @@
             }
 
             let byChartPlotOpts = genPlotOpts({
-                title: "Bootstrap time for crates >= 30 seconds",
+                title: `Bootstrap time for crates >= ${state.min_seconds} seconds`,
                 height: window.innerHeight * 0.56,
                 yAxisLabel: "",
                 series: byChartSeriesOpts,
@@ -298,6 +298,7 @@
             let values = Object.assign({}, {
                 start: "",
                 end: "",
+                min_seconds: 25,
             }, state);
             post_json("/bootstrap", values).then(data => renderPlots(data, values));
         });

--- a/site/static/bootstrap.html
+++ b/site/static/bootstrap.html
@@ -188,10 +188,10 @@
             };
         }
 
-        function genPlotOpts({ title, width, height, yAxisLabel, series, commits, alpha = 0.3, prox = 5 }) {
+        function genPlotOpts({ title, height, yAxisLabel, series, commits, alpha = 0.3, prox = 5 }) {
             return {
                 title,
-                width,
+                width: window.innerWidth * 0.9,
                 height,
                 series,
                 legend: {
@@ -255,7 +255,6 @@
 
             let byChartPlotOpts = genPlotOpts({
                 title: "Bootstrap time for crates >= 30 seconds",
-                width: Math.floor(window.innerWidth) - 16,
                 height: window.innerHeight * 0.56,
                 yAxisLabel: "",
                 series: byChartSeriesOpts,
@@ -268,7 +267,6 @@
 
             let totalPlotOpts = genPlotOpts({
                 title: "Total bootstrap time",
-                width: Math.floor(window.innerWidth) - 16,
                 height: window.innerHeight * 0.26,
                 yAxisLabel: "",
                 series: [{}, { label: "rustc", stroke: '#7cb5ec' }],


### PR DESCRIPTION
We have optimized compile times sufficiently that otherwise only 4 benchmarks would be shown on the page currently; lower the guardrail to 25 seconds to let us track more benchmarks.