### PR TITLE
Add support for GET requests for triage

### DIFF
--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -88,7 +88,7 @@ impl<'de> Deserialize<'de> for Bound {
                 }
 
                 let bound = value
-                    .parse::<NaiveDate>()
+                    .parse::<chrono::NaiveDate>()
                     .map(|d| Bound::Date(d))
                     .unwrap_or(Bound::Commit(value.to_string()));
                 Ok(bound)


### PR DESCRIPTION
This makes it a little simpler to (for example) get the triage report in the
browser.