### PR TITLE
Stop using new ||= syntax since it breaks in some still widely used browsers

### DIFF
--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -556,8 +556,11 @@
                                 return !f || (n.benchmark + "-" + n.profile).includes(f);
                             }).
                             reduce((accum, next) => {
-                                accum[next.benchmark + "-" + next.profile] ||= [];
-                                accum[next.benchmark + "-" + next.profile].push(next);
+                                const key = next.benchmark + "-" + next.profile;
+                                if (!accum[key]) {
+                                    accum[key] = [];
+                                }
+                                accum[key].push(next);
                                 return accum;
                             }, {});
                     benches = Object.entries(benches).


### PR DESCRIPTION
Fixes #976 