### PR TITLE
Refactor significance calculations

### DIFF
--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -199,7 +199,7 @@ pub mod comparison {
         pub profile: String,
         pub scenario: String,
         pub is_significant: bool,
-        pub significance_threshold: f64,
+        pub significance_factor: Option<f64>,
         pub is_dodgy: bool,
         pub historical_statistics: Option<Vec<f64>>,
         pub statistics: (f64, f64),

--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -453,7 +453,7 @@
                                     </a>
                                 </td>
                                 <td>
-                                    {{ Math.abs(run.percent / run.significanceThreshold).toFixed(2) }}x
+                                    {{ run.significance_factor ? run.significance_factor.toFixed(2) + "x" :"-" }}
                                 </td>
                             </tr>
                         </template>
@@ -571,7 +571,7 @@
                                     datumB,
                                     percent,
                                     isDodgy,
-                                    significanceThreshold: r.significance_threshold,
+                                    significance_factor: r.significance_factor,
                                     isSignificant
                                 });
                             }


### PR DESCRIPTION
This moves significance factor calculation to the backend and does some refactoring around that, but doesn't actually change the calculation significantly.

The minor difference is that the significance threshold is calculated as `median + ...` rather than `q3 + ...`, which seems more appropriate. Basing the significance threshold at the q3 marker introduces a sort of "partial iqr" and that feels fishy.