### PR TITLE
Fix new warnings generated on nightly

### DIFF
--- a/collector/src/execute.rs
+++ b/collector/src/execute.rs
@@ -1166,9 +1166,8 @@ impl Benchmark {
             }
         }
 
-        patches.sort();
-
-        let patches = patches.into_iter().map(|p| Patch::new(p)).collect();
+        let mut patches: Vec<_> = patches.into_iter().map(|p| Patch::new(p)).collect();
+        patches.sort_by_key(|p| p.index);
 
         let config_path = path.join("perf-config.json");
         let config: BenchmarkConfig = if config_path.exists() {

--- a/collector/src/sysroot.rs
+++ b/collector/src/sysroot.rs
@@ -1,17 +1,10 @@
 use anyhow::{anyhow, Context};
-use chrono::{DateTime, Utc};
 use std::fmt;
 use std::fs::{self, File};
 use std::io::{BufReader, Read};
 use std::path::PathBuf;
 use tar::Archive;
 use xz2::bufread::XzDecoder;
-
-#[derive(Debug, Clone)]
-struct Commit {
-    sha: String,
-    date: DateTime<Utc>,
-}
 
 pub struct Sysroot {
     pub sha: String,


### PR DESCRIPTION
First commit fixes a bug, and could affect benchmarks -- particularly if the string-wise path sort didn't match the numeric sort. Not sure if that happened in practice.

Second commit just drops an unused struct.

cc https://github.com/rust-lang/rust/issues/88900 (actionable and real cases, fwiw)