### PR TITLE
Track context-switches on perf-stat collection

### DIFF
--- a/collector/src/rustc-fake.rs
+++ b/collector/src/rustc-fake.rs
@@ -52,7 +52,7 @@ fn main() {
                     .env("LC_NUMERIC", "C")
                     .arg("-x;")
                     .arg("-e")
-                    .arg("instructions:u,cycles:u,task-clock,cpu-clock,faults")
+                    .arg("instructions:u,cycles:u,task-clock,cpu-clock,faults,context-switches")
                     .arg("--log-fd")
                     .arg("1")
                     .arg("setarch")


### PR DESCRIPTION
I believe we're fully setup to just start pushing these into the database and rendering them.

Fixes https://github.com/rust-lang/rustc-perf/issues/1013