### PR TITLE
mono-item profiler

### DIFF
--- a/collector/README.md
+++ b/collector/README.md
@@ -359,6 +359,13 @@ The mandatory `<PROFILER>` argument must be one of the following.
   - **Output**. Human-readable output is written to files with an `ll` prefix.
   - **Notes**. Does not work with the `Check` build kind. Also does not work
     with the `IncrFull`, `IncrUnchanged`, and `IncrPatched` run kinds.
+- `mono-items`: Dump monomorphization items for each (merged) CGU in the crate.
+  These are also post-processed from the raw format into per-file dumps.
+  - **Purpose**. This is useful to investigate changes in CGU partionining.
+  - **Slowdown**. Equivalent to normal compilation.
+  - **Output**. File per CGU, currently, placed in a directory inside results.
+  - **Notes**. Will likely work best with `Full` builds, on either Debug or Opt
+    profiles.
 
 The mandatory `<RUSTC>` argument is a patch to a rustc executable, similar to
 `bench_local`.

--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -674,7 +674,7 @@ fn main_result() -> anyhow::Result<i32> {
             (@arg PROFILER: +required +takes_value
              "One of: 'self-profile', 'time-passes', 'perf-record',\n\
              'oprofile', 'cachegrind', 'callgrind', 'dhat', 'massif',\n\
-             'eprintln', 'llvm-lines'")
+             'eprintln', 'llvm-lines', 'mono-items'")
             (@arg RUSTC:    +required +takes_value "The path to the local rustc to benchmark")
             (@arg ID:       +required +takes_value "Identifier to associate benchmark results with")
 
@@ -703,7 +703,7 @@ fn main_result() -> anyhow::Result<i32> {
             (@arg PROFILER: +required +takes_value
              "One of: 'self-profile', 'time-passes', 'perf-record',\n\
              'oprofile', 'cachegrind', 'callgrind', 'dhat', 'massif',\n\
-             'eprintln', 'llvm-lines'")
+             'eprintln', 'llvm-lines', 'mono-items'")
             (@arg RUSTC_BEFORE: +required +takes_value "The path to the local rustc to benchmark")
             (@arg RUSTC_AFTER:  +required +takes_value "The path to the local rustc to benchmark")
 

--- a/collector/src/rustc-fake.rs
+++ b/collector/src/rustc-fake.rs
@@ -285,6 +285,15 @@ fn main() {
                 assert!(cmd.status().expect("failed to spawn").success());
             }
 
+            "mono-items" => {
+                // Lazy item collection is the default (i.e., without this
+                // option)
+                args.push("-Zprint-mono-items=lazy".into());
+                let mut cmd = bash_command(tool, args, "1> mono-items");
+
+                assert!(cmd.status().expect("failed to spawn").success());
+            }
+
             _ => {
                 panic!("unknown wrapper: {}", wrapper);
             }


### PR DESCRIPTION
This adds another profiler which runs the benchmark with -Zprint-mono-items and then slightly parses the output to split into per-CGU lists of mono items. These are the post-merging CGUs.

Posting this to get it merged into master; I'm using this locally to mediocre success but I feel like it is probably at least a little useful to have. Eventually I'd like to work some more on it and get this displayed as part of our results on each benchmark, so we can e.g. give warnings when CGU allocation changes. Potentially there's some useful work to show the "forest" of CGUs that got merged into the final set as well, but I am not sure that is genuinely helpful (vs. pretty).
