### PR TITLE
Support directly rendering codegen scheduling

### DIFF
--- a/database/schema.md
+++ b/database/schema.md
@@ -128,7 +128,7 @@ series      aid         cid         value
 
 **TODO**
 
-### pull_request_builds
+### pull_request_build
 
 **TODO**
 

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -163,6 +163,16 @@ static MIGRATIONS: &[&str] = &[
     );
     "#,
     r#"alter table pull_request_builds rename to pull_request_build"#,
+    r#"
+    create table raw_self_profile(
+        aid integer references artifact(id) on delete cascade on update cascade,
+        cid integer references collection(id) on delete cascade on update cascade,
+        crate text not null references benchmark(name) on delete cascade on update cascade,
+        profile text not null,
+        cache text not null,
+        PRIMARY KEY(aid, cid, crate, profile, cache)
+    );
+    "#,
 ];
 
 #[async_trait::async_trait]

--- a/site/src/self_profile.rs
+++ b/site/src/self_profile.rs
@@ -4,6 +4,7 @@
 use anyhow::Context;
 use std::collections::HashMap;
 
+mod codegen_schedule;
 pub mod crox;
 pub mod flamegraph;
 
@@ -15,6 +16,7 @@ pub struct Output {
 
 pub fn generate(
     title: &str,
+    self_profile_base_data: Option<Vec<u8>>,
     self_profile_data: Vec<u8>,
     mut params: HashMap<String, String>,
 ) -> anyhow::Result<Output> {
@@ -38,6 +40,21 @@ pub fn generate(
                 is_download: false,
             })
         }
-        _ => anyhow::bail!("Unknown type, specify type={crox,flamegraph}"),
+        Some("codegen-schedule") => {
+            let opt =
+                serde_json::from_str(&serde_json::to_string(&params).unwrap()).context("params")?;
+            Ok(Output {
+                filename: "schedule.html",
+                data: codegen_schedule::generate(
+                    title,
+                    self_profile_base_data,
+                    self_profile_data,
+                    opt,
+                )
+                .context("codegen_schedule")?,
+                is_download: false,
+            })
+        }
+        _ => anyhow::bail!("Unknown type, specify type={crox,flamegraph,codegen-schedule}"),
     }
 }

--- a/site/src/self_profile/codegen_schedule.html
+++ b/site/src/self_profile/codegen_schedule.html
@@ -1,0 +1,61 @@
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>{{title}}</title>
+        <script>
+            window.TOTAL_DURATION_BOTH = {{TOTAL_DURATION_BOTH}};
+            window.TOTAL_DURATION_BASE = {{TOTAL_DURATION_BASE}};
+            window.TOTAL_DURATION_NEW = {{TOTAL_DURATION_NEW}};
+            window.BY_THREAD_BASE = {{BY_THREAD_BASE}};
+            window.BY_THREAD = {{BY_THREAD}};
+        </script>
+        <style>
+            .legend {
+                display: inline-block;
+                width: 1em;
+                height: 1em;
+                margin-left: 0.5em;
+            }
+
+            .legend.codegen_module_optimize {
+                background-color: #aa95e8;
+            }
+
+            .legend.codegen_module {
+                background-color: #6adb00;
+            }
+
+            .legend.codegen_module_perform_lto {
+                background-color: #428eff;
+            }
+
+            [mouse-details] {
+                display: none;
+            }
+
+            #prev {
+                display: none;
+            }
+        </style>
+        <script src="../schedule.js"></script>
+    </head>
+    <body>
+        <h3>{{title}}</h3>
+        <p>Full width is {{TOTAL_DURATION_BOTH}}ms</p>
+        <p>Legend:
+            <span class="codegen_module legend"></span> codegen_module (MIR lowering)
+            <span class="codegen_module_optimize legend"></span> codegen_module_optimize (LLVM)
+            <span class="codegen_module_perform_lto legend"></span> codegen_module_perform_lto (LLVM)
+        </p>
+        <canvas id="prev"></canvas>
+        <canvas id="current"></canvas>
+        <div mouse-details class="prev">
+            <p>Details (prev):</p>
+            <p mouse-details-content-js></p>
+        </div>
+        <div mouse-details class="current">
+            <p>Details (current):</p>
+            <p mouse-details-content-js></p>
+        </div>
+    </body>
+</html>

--- a/site/src/self_profile/codegen_schedule.rs
+++ b/site/src/self_profile/codegen_schedule.rs
@@ -1,0 +1,117 @@
+use analyzeme::ProfilingData;
+use anyhow::Context;
+use hashbrown::HashMap;
+use serde::Serializer;
+use std::convert::TryInto;
+use std::time::Duration;
+
+#[derive(serde::Deserialize, Debug)]
+pub struct Opt {
+    #[serde(default)]
+    force_width: Option<String>,
+}
+
+fn is_interesting(name: &str) -> bool {
+    match name {
+        "codegen_module" | "codegen_module_optimize" | "codegen_module_perform_lto" => true,
+        _ => false,
+    }
+}
+
+fn by_thread(self_profile_data: Vec<u8>) -> anyhow::Result<(u64, HashMap<u32, Vec<Event>>)> {
+    let data = ProfilingData::from_paged_buffer(self_profile_data)
+        .map_err(|e| anyhow::format_err!("{:?}", e))?;
+
+    let mut start = None;
+    for event in data.iter().filter(|e| !e.timestamp.is_instant()) {
+        let full_event = event.to_event();
+        if is_interesting(&full_event.label) {
+            start = Some(event.timestamp.start());
+            break;
+        }
+    }
+    let start = start.ok_or(anyhow::format_err!("no codegen_crate event"))?;
+
+    let mut end = start;
+    let mut by_thread = HashMap::new();
+    for event in data.iter().filter(|e| !e.timestamp.is_instant()) {
+        let full_event = event.to_event();
+
+        if is_interesting(&full_event.label) {
+            by_thread
+                .entry(event.thread_id)
+                .or_insert_with(Vec::new)
+                .push(Event {
+                    name: full_event.label.into(),
+                    start: event.timestamp.start().duration_since(start).unwrap(),
+                    end: event.timestamp.end().duration_since(start).unwrap(),
+                });
+            end = std::cmp::max(end, event.timestamp.end());
+        }
+    }
+
+    Ok((
+        end.duration_since(start).unwrap().as_millis() as u64,
+        by_thread,
+    ))
+}
+
+pub fn generate(
+    title: &str,
+    self_profile_base_data: Option<Vec<u8>>,
+    self_profile_data: Vec<u8>,
+    opt: Opt,
+) -> anyhow::Result<Vec<u8>> {
+    let (total_duration_new, by_thread_new) = by_thread(self_profile_data)?;
+    let mut total_duration = total_duration_new;
+    let prev = if let Some(self_profile_base_data) = self_profile_base_data {
+        let (total_duration_prev, by_thread_prev) = by_thread(self_profile_base_data)?;
+        total_duration = std::cmp::max(total_duration_new, total_duration_prev);
+        Some((total_duration_prev, by_thread_prev))
+    } else {
+        None
+    };
+
+    if let Some(force_width) = opt.force_width {
+        let forced = force_width
+            .parse::<u64>()
+            .context(anyhow::format_err!("{} does not parse", force_width))?;
+        total_duration = std::cmp::max(forced, total_duration);
+    }
+
+    Ok(HTML_TEMPLATE
+        .replace("{{title}}", title)
+        .replace("{{TOTAL_DURATION_BOTH}}", &total_duration.to_string())
+        .replace(
+            "{{TOTAL_DURATION_BASE}}",
+            &prev
+                .as_ref()
+                .map(|p| p.0.to_string())
+                .unwrap_or_else(|| String::from("null")),
+        )
+        .replace("{{TOTAL_DURATION_NEW}}", &total_duration_new.to_string())
+        .replace(
+            "{{BY_THREAD_BASE}}",
+            &serde_json::to_string(&prev.map(|p| p.1)).unwrap(),
+        )
+        .replace(
+            "{{BY_THREAD}}",
+            &serde_json::to_string(&by_thread_new).unwrap(),
+        )
+        .into_bytes())
+}
+
+#[derive(serde::Serialize, Debug)]
+pub struct Event {
+    pub name: String,
+    #[serde(serialize_with = "as_millis")]
+    pub start: std::time::Duration,
+    #[serde(serialize_with = "as_millis")]
+    pub end: std::time::Duration,
+}
+
+fn as_millis<S: Serializer>(d: &Duration, s: S) -> Result<S::Ok, S::Error> {
+    s.serialize_u64(d.as_millis().try_into().unwrap())
+}
+
+static HTML_TEMPLATE: &str = include_str!("codegen_schedule.html");

--- a/site/static/detailed-query.html
+++ b/site/static/detailed-query.html
@@ -139,8 +139,8 @@
             let processed_url = (commit, bench, run, ty) => {
                 return `/perf/processed-self-profile?commit=${commit}&benchmark=${bench}&run_name=${run}&type=${ty}`;
             };
-            let processed_link = (commit, bench, run, ty) => {
-                let url = processed_url(commit, bench, run, ty);
+            let processed_link = (commit, {benchmark, run_name}, ty) => {
+                let url = processed_url(commit, benchmark, run_name, ty);
                 return `<a href="${url}">${ty}</a>`;
             };
             let processed_crox_url = (commit, bench, run) => {
@@ -162,8 +162,9 @@
             if (state.base_commit) {
                 txt += `Download/view
                     ${dl_link(state.base_commit, state.benchmark, state.run_name)},
-                    ${processed_link(state.base_commit, state.benchmark, state.run_name, "flamegraph")},
-                    ${processed_link(state.base_commit, state.benchmark, state.run_name, "crox")}
+                    ${processed_link(state.base_commit, state, "flamegraph")},
+                    ${processed_link(state.base_commit, state, "crox")},
+                    ${processed_link(state.base_commit, state, "codegen-schedule")}
                     (${speedscope_link(state.base_commit, state.benchmark, state.run_name)},
                      ${firefox_profiler_link(state.base_commit, state.benchmark, state.run_name)})
                     results for ${state.base_commit.substring(0, 10)} (base commit)`;
@@ -171,11 +172,18 @@
             }
             txt += `Download/view
                 ${dl_link(state.commit, state.benchmark, state.run_name)},
-                ${processed_link(state.commit, state.benchmark, state.run_name, "flamegraph")},
-                ${processed_link(state.commit, state.benchmark, state.run_name, "crox")}
+                ${processed_link(state.commit, state, "flamegraph")},
+                ${processed_link(state.commit, state, "crox")},
+                ${processed_link(state.commit, state, "codegen-schedule")}
                 (${speedscope_link(state.commit, state.benchmark, state.run_name)},
                  ${firefox_profiler_link(state.commit, state.benchmark, state.run_name)})
                 results for ${state.commit.substring(0, 10)} (new commit)`;
+            if (state.base_commit) {
+                txt += "<br>";
+                        txt += `Diff: <a
+                        href="/perf/processed-self-profile?commit=${state.commit}&base_commit=${state.base_commit}&benchmark=${state.benchmark}&run_name=${state.run_name}&type=codegen-schedule"
+                        >codegen-schedule</a>`;
+            }
             document.querySelector("#raw-urls").innerHTML = txt;
             let sort_idx = state.sort_idx;
             if (!data.base_profile_delta) {

--- a/site/static/detailed-query.html
+++ b/site/static/detailed-query.html
@@ -158,6 +158,7 @@
                 let ff_url = `https://profiler.firefox.com/from-url/${crox_url}/marker-chart/?v=5`;
                 return `<a href="${ff_url}">Firefox profiler</a>`;
             };
+            txt = "";
             if (state.base_commit) {
                 txt += `Download/view
                     ${dl_link(state.base_commit, state.benchmark, state.run_name)},

--- a/site/static/schedule.js
+++ b/site/static/schedule.js
@@ -1,0 +1,146 @@
+// Parts of this file taken from https://github.com/rust-lang/cargo,
+// specifically src/cargo/core/compiler/timings.js. That content is licensed as
+// dual MIT/Apache 2.0 as well.
+
+let thread_height = 18;
+let margin = { x: 20, y: 6 };
+let event_paths = [];
+let px_per_micros = 0;
+
+function roundedRect(x, y, width, height, r) {
+    let path = new Path2D();
+    r = Math.min(r, width, height);
+    width -= r*2;
+    height -= r*2;
+    path.moveTo(x+r, y);
+    path.lineTo(x+r+width, y);
+    path.arc(x+r+width, y+r, r, -Math.PI/2, 0);
+    path.lineTo(x+r+width+r, y+r);
+    path.lineTo(x+r+width+r, y+r+height);
+    path.arc(x+r+width, y+height+r, r, 0, Math.PI/2);
+    path.lineTo(x+r, y+r+height+r);
+    path.arc(x+r, y+r+height, r, Math.PI/2, Math.PI);
+    path.lineTo(x, y+r);
+    path.arc(x+r, y+r, r, Math.PI, 3*Math.PI/2);
+    path.closePath();
+    return path;
+}
+
+function setup(canvas_display_id, by_thread, tagline) {
+    let primary = document.getElementById(canvas_display_id);
+    let ctx = primary.getContext('2d');
+
+    const threads = Object.keys(by_thread).map(k => parseInt(k, 10));
+    threads.sort((a, b) => a - b);
+    const canvas_height = Math.ceil(thread_height*(threads.length+1))+margin.y*2;
+
+    let scale = (document.body.getBoundingClientRect().width - margin.x*2.3) / TOTAL_DURATION_BOTH * 50;
+    let env = { tagline, event_paths: [] };
+
+    render(env, threads, by_thread, primary, canvas_height, ctx, scale);
+
+    let isShown = null;
+    primary.addEventListener("mousemove", e => {
+        let dpr = window.devicePixelRatio || 1;
+        for (let {event, path, thread} of env.event_paths) {
+            if (ctx.isPointInPath(path, e.offsetX * dpr, e.offsetY * dpr)) {
+                if (isShown != event) {
+                    env.suffix = ` ${event.name} took ${event.end-event.start}ms`;
+                    render(env, threads, by_thread, primary, canvas_height, ctx, scale);
+                    ctx.strokeStyle = 'red';
+                    ctx.stroke(path);
+
+                    ctx.beginPath();
+                    ctx.setLineDash([3, 10]);
+                    ctx.moveTo(margin.x + px_per_micros*by_thread[thread][0].start, margin.y);
+                    ctx.lineTo(margin.x + px_per_micros*by_thread[thread][0].start, canvas_height-margin.y);
+
+                    if (event != by_thread[thread][0]) {
+                        ctx.moveTo(margin.x + px_per_micros*event.start, margin.y);
+                        ctx.lineTo(margin.x + px_per_micros*event.start, canvas_height-margin.y);
+                    }
+
+                    ctx.stroke();
+                    ctx.setLineDash([]);
+
+                    isShown = event;
+                }
+                return;
+            }
+        }
+    });
+
+    primary.style.display = "block";
+}
+
+function render(env, threads, by_thread, primary, canvas_height, ctx, scale) {
+    const canvas_width = Math.min(4096, margin.x*2 + (scale / 50) * TOTAL_DURATION_BOTH);
+    let dpr = window.devicePixelRatio || 1;
+    primary.width = canvas_width * dpr;
+    primary.height = canvas_height * dpr;
+    primary.style.width = canvas_width;
+    primary.style.height = canvas_height;
+    ctx.clearRect(0, 0, canvas_width, canvas_height);
+    ctx.scale(dpr, dpr);
+
+    px_per_micros = (canvas_width - margin.x*2) / TOTAL_DURATION_BOTH;
+
+    env.event_paths = [];
+
+    ctx.textBaseline="top";
+
+    ctx.fillStyle = 'black';
+    ctx.fillText(env.tagline + (env.suffix || ""), 0, 0 + 2);
+
+    for (let i = 0; i < threads.length; i++) {
+        let thread = threads[i];
+        let events = by_thread[thread];
+        ctx.fillStyle = 'black';
+        ctx.fillText(thread, 0, topleft_thread_box(margin, thread_height, i) + 2);
+
+        ctx.beginPath();
+        ctx.strokeStyle = '#ededed';
+        ctx.moveTo(margin.x, topleft_thread_box(margin, thread_height, i));
+        ctx.lineTo(margin.x + px_per_micros*TOTAL_DURATION_BOTH, topleft_thread_box(margin, thread_height, i));
+        ctx.stroke();
+
+        for (let event of events) {
+            let eventPath = roundedRect(
+                margin.x+px_per_micros*event.start,
+                topleft_thread_box(margin, thread_height, i) + 2,
+                px_per_micros*(event.end-event.start),
+                thread_height-4,
+                8,
+            );
+            env.event_paths.push({ event, path: eventPath, thread });
+
+            ctx.fillStyle = color(event.name);
+            ctx.fill(eventPath);
+        }
+    }
+
+    ctx.strokeStyle = 'lightgrey';
+    ctx.stroke(roundedRect(margin, topleft_thread_box(margin, thread_height, 0), px_per_micros*TOTAL_DURATION_BOTH, threads.length * thread_height, 0));
+}
+
+function color(name) {
+    switch (name) {
+        case "codegen_module_optimize":
+            return '#aa95e8';
+        case "codegen_module_perform_lto":
+            return '#428eff';
+        case "codegen_module":
+            return '#6adb00';
+    }
+}
+
+function topleft_thread_box(margin, thread_height, i) {
+    return margin.y + (i+1)*thread_height;
+}
+
+window.addEventListener("DOMContentLoaded", () => {
+    setup("current", BY_THREAD, "Current:");
+    if (BY_THREAD_BASE) {
+        setup("prev", BY_THREAD_BASE, "Baseline:");
+    }
+});


### PR DESCRIPTION
This cherry picks a few of the commits from https://github.com/rust-lang/rustc-perf/pull/1005 to build up the ability to use self profile with sqlite (currently using an export of the prod db locally).

The schedule is rendered onto canvas, essentially a subset of the view that crox (and then chrome profiler tooling) provides, but easier to get to and with significantly less complexity. We'll likely want to continue iterating on how to get to these views (currently integrated into the self profile page) and what exactly is displayed -- this isn't really going to mesh well with any kind of query nesting, but seems like a good start still.

Graph drawing is at least partly inspired by Cargo's -Ztimings view.

Example:

![rendered page](https://user-images.githubusercontent.com/5047365/133897028-f76de988-43d4-40f4-a5ca-d80b6de0dfbd.png)
