### PR TITLE
Events may not be in start order

### DIFF
--- a/site/src/self_profile/codegen_schedule.rs
+++ b/site/src/self_profile/codegen_schedule.rs
@@ -26,8 +26,11 @@ fn by_thread(self_profile_data: Vec<u8>) -> anyhow::Result<(u64, HashMap<u32, Ve
     for event in data.iter().filter(|e| !e.timestamp.is_instant()) {
         let full_event = event.to_event();
         if is_interesting(&full_event.label) {
-            start = Some(event.timestamp.start());
-            break;
+            if start.is_some() {
+                start = std::cmp::min(start, Some(event.timestamp.start()));
+            } else {
+                start = Some(event.timestamp.start());
+            }
         }
     }
     let start = start.ok_or(anyhow::format_err!(


### PR DESCRIPTION
I'm seeing a panic in production which should hopefully be fixed by this:

```
thread 'tokio-runtime-worker' panicked at 'called `Result::unwrap()` on an `Err` value: SystemTimeError(15.198µs)', site/src/self_profile/codegen_schedule.rs:48:74 | thread  'tokio-runtime-worker' panicked at 'called `Result::unwrap()` on an  `Err` value: SystemTimeError(15.198µs)',  site/src/self_profile/codegen_schedule.rs:48:74
```