### PR TITLE
Show data for queries present only in one profile in comparison

### DIFF
--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -310,7 +310,7 @@ pub mod self_profile {
     #[derive(Serialize, Debug, Clone)]
     pub struct SelfProfileDelta {
         pub totals: QueryDataDelta,
-        pub query_data: Vec<Option<QueryDataDelta>>,
+        pub query_data: Vec<QueryDataDelta>,
     }
 
     #[derive(Serialize, Clone, Debug)]

--- a/site/static/detailed-query.html
+++ b/site/static/detailed-query.html
@@ -97,25 +97,26 @@
             if (from == to) {
                 pct = 0;
             }
-            if (pct != Infinity && pct != -Infinity) {
-                let classes;
-                if (pct > 1) {
-                    classes = "positive";
-                } else if (pct < -1) {
-                    classes = "negative";
-                } else {
-                    classes = "neutral";
-                }
-                // some arbitrary "small" value
-                // ignore this because it's not too interesting likely
-                if (Math.abs(delta) <= 0.05) {
-                    classes = "neutral";
-                }
-                let text = delta.toFixed(3) + `(${pct.toFixed(1)}%)`.padStart(10, ' ');
-                return `<span class="${classes}" title="${from.toFixed(3)} to ${to.toFixed(3)} ≈ ${delta.toFixed(3)}">${text}</span>`;
+            let classes;
+            if (pct > 1) {
+                classes = "positive";
+            } else if (pct < -1) {
+                classes = "negative";
             } else {
-                return `<span title="error pct=${pct}" style="color: orange;">-</span>`;
+                classes = "neutral";
             }
+            // some arbitrary "small" value
+            // ignore this because it's not too interesting likely
+            if (Math.abs(delta) <= 0.05) {
+                classes = "neutral";
+            }
+            let text = delta.toFixed(3);
+            if (pct != Infinity && pct != -Infinity) {
+                text += `(${pct.toFixed(1)}%)`.padStart(10, ' ');
+            } else {
+                text += `-`.padStart(10, ' ');
+            }
+            return `<span class="${classes}" title="${from.toFixed(3)} to ${to.toFixed(3)} ≈ ${delta.toFixed(3)}">${text}</span>`;
         }
 
         function populate_data(data, state) {

--- a/site/static/detailed-query.html
+++ b/site/static/detailed-query.html
@@ -91,7 +91,7 @@
             return time / 1000000000;
         }
 
-        function fmt_delta(to, delta) {
+        function fmt_delta(to, delta, is_integral_delta) {
             let from = to - delta;
             let pct = (to - from) / from * 100;
             if (from == to) {
@@ -110,7 +110,12 @@
             if (Math.abs(delta) <= 0.05) {
                 classes = "neutral";
             }
-            let text = delta.toFixed(3);
+            let text;
+            if (is_integral_delta) {
+                text = delta.toString();
+            } else {
+                text = delta.toFixed(3);
+            }
             if (pct != Infinity && pct != -Infinity) {
                 text += `(${pct.toFixed(1)}%)`.padStart(10, ' ');
             } else {
@@ -260,13 +265,13 @@
                 }
                 td(row, to_seconds(cur.self_time).toFixed(3));
                 if (delta) {
-                    td(row, fmt_delta(to_seconds(cur.self_time), to_seconds(delta.self_time)), true);
+                    td(row, fmt_delta(to_seconds(cur.self_time), to_seconds(delta.self_time), false), true);
                 } else {
                     td(row, "-", true);
                 }
                 td(row, cur.invocation_count);
                 if (delta) {
-                    td(row, fmt_delta(cur.invocation_count, delta.invocation_count), true);
+                    td(row, fmt_delta(cur.invocation_count, delta.invocation_count, true), true);
                 } else {
                     td(row, "-", true);
                 }
@@ -277,6 +282,7 @@
                         fmt_delta(
                             to_seconds(cur.incremental_load_time),
                             to_seconds(delta.incremental_load_time),
+                           false,
                         ),
                         true).classList.add("incr");
                 } else {


### PR DESCRIPTION
Add showing rows for self-profile queries present only in base profile,
and add showing deltas for queries present only in main profile.

Fixes #1022.