### PR TITLE
Update `cargo-llvm-lines` version and CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Install profilers
         run: |
           sudo apt install -y valgrind
-          cargo install --version 0.4.6 cargo-llvm-lines
+          cargo install --version 0.4.12 cargo-llvm-lines
 
       - name: Configure environment
         run: |

--- a/ci/check-profiling.sh
+++ b/ci/check-profiling.sh
@@ -107,15 +107,21 @@ test   -f results/eprintln-Test-helloworld-Check-Full
 test ! -s results/eprintln-Test-helloworld-Check-Full
 
 # llvm-lines. `Debug` not `Check` because it doesn't support `Check` builds.
+# Including both `helloworld` and `futures` benchmarks, as they exercise the
+# zero dependency and the greater than zero dependency cases, respectively, the
+# latter of which has broken before.
 RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=debug \
     cargo run -p collector --bin collector -- \
     profile_local llvm-lines $bindir/rustc Test \
         --builds Debug \
         --cargo $bindir/cargo \
-        --include helloworld \
+        --include helloworld,futures \
         --runs Full
 test -f results/ll-Test-helloworld-Debug-Full
 grep -q "Lines.*Copies.*Function name" results/ll-Test-helloworld-Debug-Full
+test -f results/ll-Test-futures-Debug-Full
+grep -q "Lines.*Copies.*Function name" results/ll-Test-futures-Debug-Full
+
 
 #----------------------------------------------------------------------------
 # Test option handling


### PR DESCRIPTION
An issue has been fixed in `cargo-llvm-lines` 0.4.12 which would cause
us to fail whenever profiling a crate which had any crate dependencies.
Update to 0.4.12 and add a CI check that profiles a crate with
dependencies to exercise this case.

The issue was that we would invoke a particular `cargo` executable and
`cargo-llvm-lines` would invoke a different one. This would cause us to
try to build the crate's dependencies a second time with the different
`cargo`. The `EXPECT_ONLY_WRAPPED_RUSTC` check would detect this case
and produce an error.