### PR TITLE
self-profile with all events locally

### DIFF
--- a/collector/src/rustc-fake.rs
+++ b/collector/src/rustc-fake.rs
@@ -161,6 +161,7 @@ fn main() {
 
             "self-profile" => {
                 let mut cmd = Command::new(&tool);
+                cmd.arg("-Zself-profile-events=all");
                 cmd.arg("-Zself-profile=Zsp").args(&args);
 
                 assert!(cmd.status().expect("failed to spawn").success());


### PR DESCRIPTION
This does use a lot of disk space, but seems like the better default
(potentially). My primary use case here is getting query keys. It
might be better to expose this as an option of some kind in the frontend,
but that also seems a little hard...