### PR TITLE
Use new significance algorithm by default

### DIFF
--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -48,7 +48,7 @@ pub async fn handle_triage(
             "instructions:u".to_owned(),
             ctxt,
             &master_commits,
-            body.calcNewSig.unwrap_or(false),
+            body.calcNewSig.unwrap_or(true),
         )
         .await
         .map_err(|e| format!("error comparing commits: {}", e))?
@@ -103,7 +103,7 @@ pub async fn handle_compare(
         body.stat,
         ctxt,
         &master_commits,
-        body.calcNewSig.unwrap_or(false),
+        body.calcNewSig.unwrap_or(true),
     )
     .await
     .map_err(|e| format!("error comparing commits: {}", e))?
@@ -353,7 +353,7 @@ pub async fn compare(
     ctxt: &SiteCtxt,
 ) -> Result<Option<Comparison>, BoxedError> {
     let master_commits = collector::master_commits().await?;
-    compare_given_commits(start, end, stat, ctxt, &master_commits, false).await
+    compare_given_commits(start, end, stat, ctxt, &master_commits, true).await
 }
 
 /// Compare two bounds on a given stat


### PR DESCRIPTION
This currently just completely removes the old algorithm (at least where it was if-gated). I think we could allow switching back, but I've not really seen a use case for that (you can always disable filtering by significance in the UI).