### PR TITLE
Refactorings: graph => graphs

### DIFF
--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -70,7 +70,7 @@ pub mod graph {
         // y-values
         pub points: Vec<f32>,
         // The index of interpolated coordinates
-        pub is_interpolated: HashSet<u16>,
+        pub interpolated_indices: HashSet<u16>,
     }
 
     #[derive(Debug, PartialEq, Clone, Serialize)]

--- a/site/src/average.rs
+++ b/site/src/average.rs
@@ -110,7 +110,7 @@ mod tests {
     fn test_interpolation_average() {
         // Test that averaging works with interpolation.
         use crate::db::Point;
-        use crate::interpolate::{Interpolate, Interpolated};
+        use crate::interpolate::{Interpolate, IsInterpolated};
 
         let v = vec![
             vec![("a", Some(0.0)), ("b", Some(200.0))],
@@ -125,11 +125,11 @@ mod tests {
         let mut average = average(iterators);
 
         let a = average.next().unwrap();
-        assert_eq!(a, (("a", Some(50.0)), Interpolated::No));
+        assert_eq!(a, (("a", Some(50.0)), IsInterpolated::No));
         assert_eq!(a.interpolated(), false);
 
         let b = average.next().unwrap();
-        assert_eq!(b, (("b", Some(150.0)), Interpolated::Yes));
+        assert_eq!(b, (("b", Some(150.0)), IsInterpolated::Yes));
         assert_eq!(b.interpolated(), true);
 
         assert!(average.next().is_none());

--- a/site/src/request_handlers.rs
+++ b/site/src/request_handlers.rs
@@ -9,7 +9,7 @@ mod status_page;
 pub use bootstrap::handle_bootstrap;
 pub use dashboard::handle_dashboard;
 pub use github::handle_github;
-pub use graph::handle_graph;
+pub use graph::handle_graphs;
 pub use next_commit::handle_next_commit;
 pub use self_profile::{
     handle_self_profile, handle_self_profile_processed_download, handle_self_profile_raw,

--- a/site/src/server.rs
+++ b/site/src/server.rs
@@ -403,16 +403,12 @@ async fn serve_req(server: Server, req: Request) -> Result<Response, ServerError
         "/perf/self-profile-raw" => Ok(to_response(
             request_handlers::handle_self_profile_raw(check!(parse_body(&body)), &ctxt).await,
         )),
-        "/perf/graph" => Ok(
-            match request_handlers::handle_graph(check!(parse_body(&body)), &ctxt).await {
+        "/perf/graphs" => Ok(
+            match request_handlers::handle_graphs(check!(parse_body(&body)), &ctxt).await {
                 Ok(result) => {
-                    let mut response = http::Response::builder()
+                    let response = http::Response::builder()
                         .header_typed(ContentType::json())
                         .header_typed(CacheControl::new().with_no_cache().with_no_store());
-                    response.headers_mut().unwrap().insert(
-                        hyper::header::ACCESS_CONTROL_ALLOW_ORIGIN,
-                        hyper::header::HeaderValue::from_static("*"),
-                    );
                     let body = serde_json::to_vec(&result).unwrap();
                     response.body(hyper::Body::from(body)).unwrap()
                 }

--- a/site/static/index.html
+++ b/site/static/index.html
@@ -74,6 +74,11 @@
         See <a href="/compare.html">compare page</a> for descriptions of what
         the names mean.
     </div>
+    <div>
+        <strong>Note:</strong> pink in the graphs represent data points that are interpolated
+        due to missing data. Interpolated data is simply the last known data point repeated until
+        another known data point is found.
+    </div>
     <div id="loading">
         <h2>Loading &amp; rendering data..</h2>
         <h3>This may take a while!</h3>
@@ -368,7 +373,7 @@
                         commits: data.commits,
                         stat: state.stat,
                         isInterpolated(dataIdx) {
-                            return cacheStates.full.is_interpolated.has(dataIdx);
+                            return cacheStates.full.interpolated_indices.has(dataIdx);
                         },
                         absoluteMode: state.kind == "raw",
                     });
@@ -396,7 +401,7 @@
 
             function optInterpolated(buildKind) {
                 for (let cacheState in buildKind)
-                    buildKind[cacheState].is_interpolated = new Set(buildKind[cacheState].is_interpolated);
+                    buildKind[cacheState].interpolated_indices = new Set(buildKind[cacheState].interpolated_indices);
 
                 return buildKind;
             }
@@ -434,7 +439,7 @@
                 stat: "instructions:u",
                 kind: "raw",
             }, state);
-            post_json("/graph", values).then(prepData).then(data =>
+            post_json("/graphs", values).then(prepData).then(data =>
                 renderPlots(data, values));
         });
     </script>


### PR DESCRIPTION
This is a small refactoring that will make way for an endpoint for producing individual graphs (which we will use to be able to show historical data for specific test cases to help clarify the nature of noise). The changes in this PR include:
- Renaming `interpolated` related variables to be more clear
- Renaming the "/graph" endpoint to be "/graphs"
- Some additional documentation
- Adding indicator for what the pink color in graphs means (fixes #548)