### PR TITLE
Don't group testCases by benchmark/profile in comparison page

### DIFF
--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -423,7 +423,8 @@
             <table id="benches" class="compare">
                 <tbody>
                     <tr>
-                        <th>Benchmark Profile Scenario</th>
+                        <th>Benchmark & Profile</th>
+                        <th>Scenario</th>
                         <th>% Change</th>
                         <th>
                             Significance Factor<span class="tooltip">?
@@ -436,13 +437,15 @@
                                 </span>
                             </span>
                         </th>
-                        <th>{{before}} &lt;=&gt; {{after}}</th>
+                        <th>{{before}}</th>
+                        <th>{{after}}</th>
                     </tr>
                 </tbody>
                 <tbody>
                     <template v-for="testCase in testCases">
                         <tr>
-                            <td>{{ testCase.benchmark }} {{ testCase.profile }} <br /> {{ testCase.scenario }}</td>
+                            <td>{{ testCase.benchmark }} {{ testCase.profile }}</td>
+                            <td>{{ testCase.scenario }}</td>
                             <td>
                                 <a v-bind:href="percentLink(data.b.commit, data.a.commit, testCase)">
                                     <span v-bind:class="percentClass(testCase.percent)">
@@ -458,7 +461,8 @@
                                 <a v-bind:href="detailedQueryLink(data.a.commit, testCase)">
                                     {{ testCase.datumA }}
                                 </a>
-                                &lt;=&gt;
+                            </td>
+                            <td>
                                 <a v-bind:href="detailedQueryLink(data.b.commit, testCase)">
                                     {{ testCase.datumB }}
                                 </a>


### PR DESCRIPTION
Fixes #1068 

This changes the comparison page in two major ways:
* Test results are no longer grouped by benchmark/profile. Each test result exists independent of each other. 
* The raw results (which are less important than the percent change and significance factor) are moved to the end of each row.

I don't love how this looks, but I think the overall behavior is an improvement. Any thoughts on how we can make this look better?

![image](https://user-images.githubusercontent.com/1327285/136819685-0d179db3-02c0-4e43-ad1e-c202ba64b00e.png)
