### PR TITLE
Print out paths for auto-generated cgdiff results

### DIFF
--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -1084,7 +1084,10 @@ fn main_result() -> anyhow::Result<i32> {
                         eprintln!("{}", diff.to_string_lossy());
                     }
                 } else if diffs.len() == 1 {
-                    eprintln!("Diff: {}", diffs[0].to_string_lossy());
+                    let short = out_dir.join("cgdiffann-latest");
+                    std::fs::copy(&diffs[0], &short).expect("copy to short path");
+                    eprintln!("Original diff at: {}", diffs[0].to_string_lossy());
+                    eprintln!("Short path: {}", short.to_string_lossy());
                 }
             }
 


### PR DESCRIPTION
This also generates a shorter path for the (likely) common case of benchmarking just one test case, which is easier to copy/paste and keep in command history, etc.

Example:

```
$ ./target/release/collector diff_local cachegrind +aa5740c715001f981515ed46faaddebf67cb9539 +91b931926fd49fc97d1e39f2b8206abf1d77ce7d --include externs --builds Doc --runs Full
Profiling aa5740c715001f981515ed46faaddebf67cb9539 with Cachegrind
1 benchmark remaining
Preparing externs
Running externs: Doc + [Full]
Profiling 91b931926fd49fc97d1e39f2b8206abf1d77ce7d with Cachegrind
1 benchmark remaining
Preparing externs
Running externs: Doc + [Full]
Original diff at: results/cgann-aa5740c715001f981515ed46faaddebf67cb9539-91b931926fd49fc97d1e39f2b8206abf1d77ce7d-externs-Doc-Full
Short path: results/cgdiffann-latest
```