### PR TITLE
Fetch self profile data from s3 on demand and parse artifact sizes

### DIFF
--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -296,6 +296,7 @@ pub mod self_profile {
     pub struct SelfProfile {
         pub totals: QueryData,
         pub query_data: Vec<QueryData>,
+        pub artifact_sizes: Option<Vec<ArtifactSize>>,
     }
 
     #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -313,10 +314,17 @@ pub mod self_profile {
         pub incremental_load_time: u64,
     }
 
+    #[derive(Serialize, Deserialize, Clone, Debug)]
+    pub struct ArtifactSize {
+        pub label: QueryLabel,
+        pub bytes: u64,
+    }
+
     #[derive(Serialize, Debug, Clone)]
     pub struct SelfProfileDelta {
         pub totals: QueryDataDelta,
         pub query_data: Vec<QueryDataDelta>,
+        pub artifact_sizes: Vec<ArtifactSizeDelta>,
     }
 
     #[derive(Serialize, Clone, Debug)]
@@ -326,6 +334,11 @@ pub mod self_profile {
         pub invocation_count: i32,
         // Nanoseconds
         pub incremental_load_time: i64,
+    }
+
+    #[derive(Serialize, Clone, Debug)]
+    pub struct ArtifactSizeDelta {
+        pub bytes: u64,
     }
 }
 

--- a/site/static/detailed-query.html
+++ b/site/static/detailed-query.html
@@ -59,6 +59,14 @@
             border-radius: 3px;
             user-select: all;
         }
+
+        #artifact-table th {
+            text-align: center;
+        }
+
+        #artifact-table td {
+            padding: 0 0 0 20px;
+        }
     </style>
 </head>
 
@@ -70,6 +78,18 @@
     <div id="content">
         <h3 id="title"></h3>
         <div id="raw-urls"></div>
+        <h4>Artifact Size</h4>
+        <table id="artifact-table">
+            <thead>
+                <tr id="table-header">
+                    <th>Artifact</th>
+                    <th>Size</th>
+                    <th>Size delta</th>
+                </tr>
+            </thead>
+            <tbody id="artifact-body">
+            </tbody>
+        </table>
         <p>'Time (%)' is the percentage of the cpu-clock time spent on this query (we do not use
             wall-time as we want to account for parallelism).</p>
         <p>Executions do not include cached executions.</p>
@@ -152,7 +172,7 @@
             let processed_url = (commit, bench, run, ty) => {
                 return `/perf/processed-self-profile?commit=${commit}&benchmark=${bench}&run_name=${run}&type=${ty}`;
             };
-            let processed_link = (commit, {benchmark, run_name}, ty) => {
+            let processed_link = (commit, { benchmark, run_name }, ty) => {
                 let url = processed_url(commit, benchmark, run_name, ty);
                 return `<a href="${url}">${ty}</a>`;
             };
@@ -313,13 +333,32 @@
                         fmt_delta(
                             to_seconds(cur.incremental_load_time),
                             to_seconds(delta.incremental_load_time),
-                           false,
+                            false,
                         ),
                         true).classList.add("incr");
                 } else {
                     td(row, "-", true).classList.add("incr");
                 }
                 table.appendChild(row);
+                idx += 1;
+            }
+
+            let artifactTable = document.getElementById("artifact-body");
+            function td(row, content) {
+                let td = document.createElement("td");
+                td.innerHTML = content;
+                row.appendChild(td);
+                return td;
+            }
+            for (let [idx, element] of data.profile.artifact_sizes.entries()) {
+                let row = document.createElement("tr");
+                const label = td(row, element.label);
+                label.style.textAlign = "center";
+                td(row, element.bytes);
+                if (data.base_profile_delta && data.base_profile_delta.artifact_sizes[idx]) {
+                    td(row, data.base_profile_delta.artifact_sizes[idx].bytes);
+                }
+                artifactTable.appendChild(row);
                 idx += 1;
             }
         }


### PR DESCRIPTION
co-authored with @michaelwoerister 

This is the start of functionality for showing artifact sizes in the detailed-query.html page. Instead of story the data in the database, this approach fetches and parsed the data on demand. If this approaches works, we may want to consider doing the same for the other self-profile data.

Unfortunately, it's not possible to test this code locally so it's likely horribly broken. Any tips or thoughts on how best to test this code and push it forward would be very helpful.