### PR TITLE
fix(compare) Reduce display section: collapse by default

### DIFF
--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -784,6 +784,8 @@
         }
         toggleFilters("filters-content", "filters-toggle-indicator");
         toggleFilters("search-content", "search-toggle-indicator");
+        // Toggle twice in order to display the icon and keep the section closed
+        toggleFilters("display-content", "display-toggle-indicator");
         toggleFilters("display-content", "display-toggle-indicator");
 
         function testCaseString(testCase) {


### PR DESCRIPTION
Addresses https://github.com/rust-lang/rustc-perf/pull/1091#issuecomment-961331799

r? @Mark-Simulacrum

```javascript
document.getElementById('content').offsetTop; // 420
```

This is an alternative to #1093 