### PR TITLE
Rename run_name to scenario

### DIFF
--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -229,7 +229,8 @@ pub mod self_profile_raw {
     pub struct Request {
         pub commit: String,
         pub benchmark: String,
-        pub run_name: String,
+        #[serde(alias = "run_name")]
+        pub scenario: String,
         pub cid: Option<i32>,
     }
 
@@ -257,7 +258,8 @@ pub mod self_profile_processed {
     pub struct Request {
         pub commit: String,
         pub benchmark: String,
-        pub run_name: String,
+        #[serde(alias = "run_name")]
+        pub scenario: String,
         pub cid: Option<i32>,
         #[serde(rename = "type")]
         pub processor_type: ProcessorType,
@@ -282,7 +284,8 @@ pub mod self_profile {
         pub commit: String,
         pub base_commit: Option<String>,
         pub benchmark: String,
-        pub run_name: String,
+        #[serde(alias = "run_name")]
+        pub scenario: String,
         pub sort_idx: String,
     }
 

--- a/site/src/request_handlers/self_profile.rs
+++ b/site/src/request_handlers/self_profile.rs
@@ -38,14 +38,14 @@ pub async fn handle_self_profile_processed_download(
             &diff_against[..std::cmp::min(7, diff_against.len())],
             &body.commit[..std::cmp::min(7, body.commit.len())],
             body.benchmark,
-            body.run_name
+            body.scenario
         )
     } else {
         format!(
             "{}: {} {}",
             &body.commit[..std::cmp::min(7, body.commit.len())],
             body.benchmark,
-            body.run_name
+            body.scenario
         )
     };
 
@@ -56,7 +56,7 @@ pub async fn handle_self_profile_processed_download(
             self_profile_raw::Request {
                 commit: diff_against,
                 benchmark: body.benchmark.clone(),
-                run_name: body.run_name.clone(),
+                scenario: body.scenario.clone(),
                 cid: None,
             },
             ctxt,
@@ -81,7 +81,7 @@ pub async fn handle_self_profile_processed_download(
         self_profile_raw::Request {
             commit: body.commit,
             benchmark: body.benchmark.clone(),
-            run_name: body.run_name.clone(),
+            scenario: body.scenario.clone(),
             cid: body.cid,
         },
         ctxt,
@@ -519,7 +519,7 @@ pub async fn handle_self_profile_raw(
     let bench_name = it.next().ok_or(format!("no benchmark name"))?;
 
     let scenario = body
-        .run_name
+        .scenario
         .parse::<database::Scenario>()
         .map_err(|e| format!("invalid run name: {:?}", e))?;
 
@@ -533,7 +533,7 @@ pub async fn handle_self_profile_raw(
             }),
             bench_name,
             profile,
-            &body.run_name,
+            &body.scenario,
         )
         .await;
     let (aid, first_cid) = aids_and_cids
@@ -621,7 +621,7 @@ pub async fn handle_self_profile(
     let profile = it.next().ok_or(format!("no benchmark type"))?;
     let bench_name = it.next().ok_or(format!("no benchmark name"))?;
     let scenario = body
-        .run_name
+        .scenario
         .parse::<database::Scenario>()
         .map_err(|e| format!("invalid run name: {:?}", e))?;
     let index = ctxt.index.load();
@@ -637,7 +637,7 @@ pub async fn handle_self_profile(
         .set(Tag::Profile, selector::Selector::One(profile))
         .set(
             Tag::Scenario,
-            selector::Selector::One(body.run_name.clone()),
+            selector::Selector::One(body.scenario.clone()),
         );
 
     let mut commits = vec![index
@@ -703,7 +703,7 @@ pub async fn handle_self_profile(
     let conn = ctxt.conn().await;
     for commit in commits.iter() {
         let aids_and_cids = conn
-            .list_self_profile(commit.clone(), bench_name, profile, &body.run_name)
+            .list_self_profile(commit.clone(), bench_name, profile, &body.scenario)
             .await;
         if let Some((aid, cid)) = aids_and_cids.first() {
             match fetch_raw_self_profile_data(*aid, bench_name, profile, scenario, *cid).await {

--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -454,7 +454,9 @@
                     </tr>
                 </thead>
                 <tbody v-if="testCases.length === 0">
-                    <tr><td colspan="6">No results</td></tr>
+                    <tr>
+                        <td colspan="6">No results</td>
+                    </tr>
                 </tbody>
                 <tbody v-else>
                     <template v-for="testCase in testCases">
@@ -644,7 +646,7 @@
                             percent: 100 * (b - a) / a
                         };
                     })
-                    .sort((a, b) => Math.abs(b.percent) - Math.abs(a.percent));
+                        .sort((a, b) => Math.abs(b.percent) - Math.abs(a.percent));
                 },
                 before() {
                     if (!this.data) {
@@ -738,10 +740,10 @@
 
                 },
                 detailedQueryLink(commit, testCase) {
-                    return `/detailed-query.html?commit=${commit}&benchmark=${testCase.benchmark + "-" + testCase.profile}&run_name=${testCase.scenario}`;
+                    return `/detailed-query.html?commit=${commit}&benchmark=${testCase.benchmark + "-" + testCase.profile}&scenario=${testCase.scenario}`;
                 },
                 percentLink(commit, baseCommit, testCase) {
-                    return `/detailed-query.html?commit=${commit}&base_commit=${baseCommit}&benchmark=${testCase.benchmark + "-" + testCase.profile}&run_name=${testCase.scenario}`;
+                    return `/detailed-query.html?commit=${commit}&base_commit=${baseCommit}&benchmark=${testCase.benchmark + "-" + testCase.profile}&scenario=${testCase.scenario}`;
                 },
                 commitLink(commit) {
                     return `https://github.com/rust-lang/rust/commit/${commit}`;

--- a/site/static/detailed-query.html
+++ b/site/static/detailed-query.html
@@ -152,28 +152,28 @@
         }
 
         function populate_data(data, state) {
-            let txt = `${state.commit.substring(0, 10)}: Self profile results for ${state.benchmark} run ${state.run_name}`;
+            let txt = `${state.commit.substring(0, 10)}: Self profile results for ${state.benchmark} run ${state.scenario}`;
             if (state.base_commit) {
                 let self_href =
-                    `/detailed-query.html?sort_idx=${state.sort_idx}&commit=${state.commit}&run_name=${state.run_name}&benchmark=${state.benchmark}`;
+                    `/detailed-query.html?sort_idx=${state.sort_idx}&commit=${state.commit}&scenario=${state.scenario}&benchmark=${state.benchmark}`;
                 let base_href =
-                    `/detailed-query.html?sort_idx=${state.sort_idx}&commit=${state.base_commit}&run_name=${state.run_name}&benchmark=${state.benchmark}`;
+                    `/detailed-query.html?sort_idx=${state.sort_idx}&commit=${state.base_commit}&scenario=${state.scenario}&benchmark=${state.benchmark}`;
                 txt += `<br>diff vs base ${state.base_commit.substring(0, 10)}, <a href="${base_href}">query info for just base commit</a>`;
                 txt += `<br><a href="${self_href}">query info for just this commit</a>`;
             }
             document.querySelector("#title").innerHTML = txt;
             let dl_url = (commit, bench, run) => {
-                return `/perf/download-raw-self-profile?commit=${commit}&benchmark=${bench}&run_name=${run}`
+                return `/perf/download-raw-self-profile?commit=${commit}&benchmark=${bench}&scenario=${run}`
             };
             let dl_link = (commit, bench, run) => {
                 let url = dl_url(commit, bench, run);
                 return `<a href="${url}">raw</a>`;
             };
             let processed_url = (commit, bench, run, ty) => {
-                return `/perf/processed-self-profile?commit=${commit}&benchmark=${bench}&run_name=${run}&type=${ty}`;
+                return `/perf/processed-self-profile?commit=${commit}&benchmark=${bench}&scenario=${run}&type=${ty}`;
             };
-            let processed_link = (commit, { benchmark, run_name }, ty) => {
-                let url = processed_url(commit, benchmark, run_name, ty);
+            let processed_link = (commit, { benchmark, scenario }, ty) => {
+                let url = processed_url(commit, benchmark, scenario, ty);
                 return `<a href="${url}">${ty}</a>`;
             };
             let processed_crox_url = (commit, bench, run) => {
@@ -194,52 +194,52 @@
             txt = "";
             if (state.base_commit) {
                 txt += `Download/view
-                    ${dl_link(state.base_commit, state.benchmark, state.run_name)},
+                    ${dl_link(state.base_commit, state.benchmark, state.scenario)},
                     ${processed_link(state.base_commit, state, "flamegraph")},
                     ${processed_link(state.base_commit, state, "crox")},
                     ${processed_link(state.base_commit, state, "codegen-schedule")}
-                    (${speedscope_link(state.base_commit, state.benchmark, state.run_name)},
-                     ${firefox_profiler_link(state.base_commit, state.benchmark, state.run_name)})
+                    (${speedscope_link(state.base_commit, state.benchmark, state.scenario)},
+                     ${firefox_profiler_link(state.base_commit, state.benchmark, state.scenario)})
                     results for ${state.base_commit.substring(0, 10)} (base commit)`;
                 txt += "<br>";
             }
             txt += `Download/view
-                ${dl_link(state.commit, state.benchmark, state.run_name)},
+                ${dl_link(state.commit, state.benchmark, state.scenario)},
                 ${processed_link(state.commit, state, "flamegraph")},
                 ${processed_link(state.commit, state, "crox")},
                 ${processed_link(state.commit, state, "codegen-schedule")}
-                (${speedscope_link(state.commit, state.benchmark, state.run_name)},
-                 ${firefox_profiler_link(state.commit, state.benchmark, state.run_name)})
+                (${speedscope_link(state.commit, state.benchmark, state.scenario)},
+                 ${firefox_profiler_link(state.commit, state.benchmark, state.scenario)})
                 results for ${state.commit.substring(0, 10)} (new commit)`;
             let profile = b => b.endsWith("-opt") ? "Opt" :
-                        b.endsWith("-doc") ? "Doc" :
-                        b.endsWith("-debug") ? "Debug" :
+                b.endsWith("-doc") ? "Doc" :
+                    b.endsWith("-debug") ? "Debug" :
                         b.endsWith("-check") ? "Check" : "???";
             let bench_name = b => b.replace(/-[^-]*$/, "");
-            let run_filter = r => r == "full" ? "Full" :
-                        r == "incr-full" ? "IncrFull" :
-                        r == "incr-unchanged" ? "IncrUnchanged" :
-                        r.startsWith("incr-patched") ? "IncrPatched" :
-                        "???";
+            let scenario_filter = s => s == "full" ? "Full" :
+                s == "incr-full" ? "IncrFull" :
+                    s == "incr-unchanged" ? "IncrUnchanged" :
+                        s.startsWith("incr-patched") ? "IncrPatched" :
+                            "???";
             if (state.base_commit) {
                 txt += "<br>";
                 txt += `Diff: <a
-                        href="/perf/processed-self-profile?commit=${state.commit}&base_commit=${state.base_commit}&benchmark=${state.benchmark}&run_name=${state.run_name}&type=codegen-schedule"
+                        href="/perf/processed-self-profile?commit=${state.commit}&base_commit=${state.base_commit}&benchmark=${state.benchmark}&scenario=${state.scenario}&type=codegen-schedule"
                         >codegen-schedule</a>`;
                 txt += "<br>Local profile (base): <code>" +
                     `./target/release/collector profile_local cachegrind
                     +${state.base_commit} --include ${bench_name(state.benchmark)} --builds
-                ${profile(state.benchmark)} --runs ${run_filter(state.run_name)}</code>`;
+                ${profile(state.benchmark)} --runs ${scenario_filter(state.scenario)}</code>`;
             }
             txt += "<br>Local profile (new): <code>" +
                 `./target/release/collector profile_local cachegrind
                 +${state.commit} --include ${bench_name(state.benchmark)} --builds
-                ${profile(state.benchmark)} --runs ${run_filter(state.run_name)}</code>`;
+                ${profile(state.benchmark)} --runs ${scenario_filter(state.scenario)}</code>`;
             if (state.base_commit) {
-            txt += "<br>Local profile (diff): <code>" +
-                `./target/release/collector diff_local cachegrind
+                txt += "<br>Local profile (diff): <code>" +
+                    `./target/release/collector diff_local cachegrind
                 +${state.base_commit} +${state.commit} --include ${bench_name(state.benchmark)} --builds
-                ${profile(state.benchmark)} --runs ${run_filter(state.run_name)}</code>`;
+                ${profile(state.benchmark)} --runs ${scenario_filter(state.scenario)}</code>`;
             }
             document.querySelector("#raw-urls").innerHTML = txt;
             let sort_idx = state.sort_idx;
@@ -276,7 +276,7 @@
                 th.innerHTML = `<a href="${query_string_for_state(clickState)}">${inner}</a>`;
             }
 
-            if (!state.run_name.includes("incr-")) {
+            if (!state.scenario.includes("incr-")) {
                 // No need to show incremental columns if not showing
                 // incremental data.
                 document.body.classList.add("hide-incr");

--- a/site/static/shared.js
+++ b/site/static/shared.js
@@ -197,6 +197,11 @@ function loadState(callback, skip_settings) {
         let value = param[1];
         state[key] = value;
     }
+    // Handle renaming of `run_name` to `scenario`
+    if (state.run_name && !state.scenario) {
+        state.scenario = state.run_name;
+        state.run_name = undefined;
+    }
     if (state.start) {
         document.getElementById("start-bound").value = state.start;
     }


### PR DESCRIPTION
This changes the final usages of the older term `run_name` to the more consistent name `scenario` in the site. `run_name` is still used in the collector a bit, but we can take care of that in another PR.