### PR TITLE
Name bin target differently from lib

### DIFF
--- a/collector/benchmarks/token-stream-stress/Cargo.toml
+++ b/collector/benchmarks/token-stream-stress/Cargo.toml
@@ -5,11 +5,15 @@ edition = "2018"
 publish = false
 
 [lib]
+# Documenting the library means that we try to rebuild it after src/main.rs
+# changes, as of rust-lang/cargo#10172. Since our benchmarks don't actually care
+# about it being built, disable that.
+doc = false
 path = "src/lib.rs"
 proc-macro = true
 
 [[bin]]
-name = "token-stream-stress"
+name = "token-stream-stress-bin"
 path = "src/main.rs"
 
 [workspace]

--- a/collector/benchmarks/token-stream-stress/perf-config.json
+++ b/collector/benchmarks/token-stream-stress/perf-config.json
@@ -1,4 +1,4 @@
 {
-    "cargo_opts": "--bin token-stream-stress",
+    "cargo_opts": "--bin token-stream-stress-bin",
     "touch_file": "src/main.rs"
 }


### PR DESCRIPTION
This avoids file collisions, which lead to spurious rebuilds and errors from
Cargo (recently added by rust-lang/cargo#10172).

I haven't been able to confirm this locally yet, possibly because the wrong
Cargo gets used (not sure), but this should hopefully fix the benchmark on perf.r-l.o.