### PR TITLE
Force enable query verification on all benchmarks

### DIFF
--- a/collector/src/rustc-fake.rs
+++ b/collector/src/rustc-fake.rs
@@ -30,6 +30,7 @@ fn main() {
 
     args.push(OsString::from("-Adeprecated"));
     args.push(OsString::from("-Aunknown-lints"));
+    args.push(OsString::from("-Zincremental-verify-ich"));
 
     if let Some(pos) = args.iter().position(|arg| arg == "--wrap-rustc-with") {
         // Strip out the flag and its argument, and run rustc under the wrapper


### PR DESCRIPTION
We don't have a great way to deploy this -- it'll cause a spike across all benchmarks on whatever the next commit is after landing it -- but particularly very recently, we're seeing large up/down movement in incr-unchanged benchmarks which I suspect is caused by the 1/32nd ~randomly chosen query verification.

Fixes #1105 