### PR TITLE
Remove rustc version from stable crate IDs

### DIFF
--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -321,7 +321,7 @@ fn bench(
 }
 
 fn check_measureme_installed() -> Result<(), String> {
-    let not_installed = std::array::IntoIter::new(["summarize", "crox", "flamegraph"])
+    let not_installed = IntoIterator::into_iter(["summarize", "crox", "flamegraph"])
         .filter(|n| !is_installed(n))
         .collect::<Vec<_>>();
     if not_installed.is_empty() {


### PR DESCRIPTION
Since rust-lang/rust#89836, rustc stable crate IDs include a hash of the
rustc version (including the git commit it's built from), which means
that hashmaps or other structures have different behavior when comparing
different rustc builds. This is bad for rustc-perf, as it means that
comparing two commits has a source of noise that makes it harder to know
what the actual change between two artifacts is.

cc https://github.com/rust-lang/rustc-perf/issues/1126