### PR TITLE
LLVM IR emission option

### DIFF
--- a/collector/src/execute.rs
+++ b/collector/src/execute.rs
@@ -181,6 +181,7 @@ pub enum Profiler {
     LlvmLines,
     MonoItems,
     DepGraph,
+    LlvmIr,
 }
 
 impl Profiler {
@@ -203,6 +204,7 @@ impl Profiler {
             "llvm-lines" => Ok(Profiler::LlvmLines),
             "mono-items" => Ok(Profiler::MonoItems),
             "dep-graph" => Ok(Profiler::DepGraph),
+            "llvm-ir" => Ok(Profiler::LlvmIr),
             _ => Err(anyhow!("'{}' is not a known profiler", name)),
         }
     }
@@ -225,6 +227,7 @@ impl Profiler {
             Profiler::LlvmLines => "llvm-lines",
             Profiler::MonoItems => "mono-items",
             Profiler::DepGraph => "dep-graph",
+            Profiler::LlvmIr => "llvm-ir",
         }
     }
 
@@ -246,6 +249,7 @@ impl Profiler {
             | Profiler::Massif
             | Profiler::DepGraph
             | Profiler::MonoItems
+            | Profiler::LlvmIr
             | Profiler::Eprintln => {
                 if profile_kind == ProfileKind::Doc {
                     Some("rustdoc")
@@ -275,6 +279,7 @@ impl Profiler {
             | Profiler::DHAT
             | Profiler::Massif
             | Profiler::MonoItems
+            | Profiler::LlvmIr
             | Profiler::Eprintln => true,
             // only incremental
             Profiler::DepGraph => scenario_kind != ScenarioKind::Full,
@@ -1203,6 +1208,12 @@ impl<'a> Processor for ProfileProcessor<'a> {
                     filepath(self.output_dir, &out_file("dep-graph")).with_extension("dot");
 
                 // May not exist if not incremental, but then that's OK.
+                fs::copy(&tmp_file, &output)?;
+            }
+
+            Profiler::LlvmIr => {
+                let tmp_file = filepath(data.cwd.as_ref(), "llvm-ir");
+                let output = filepath(self.output_dir, &out_file("llir"));
                 fs::copy(&tmp_file, &output)?;
             }
 

--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -1062,8 +1062,17 @@ fn main_result() -> anyhow::Result<i32> {
             let rustdoc = sub_m.value_of("RUSTDOC");
             check_installed("valgrind")?;
             check_installed("cg_annotate")?;
-            check_installed("rustup-toolchain-install-master")?;
             check_installed("rustfilt")?;
+            // Avoid just straight running rustup-toolchain-install-master which
+            // will install the current master commit (fetching quite a bit of
+            // data, including hitting GitHub)...
+            if Command::new("rustup-toolchain-install-master")
+                .arg("-V")
+                .output()
+                .is_err()
+            {
+                anyhow::bail!("rustup-toolchain-install-master is not installed but must be");
+            }
 
             let id1 = rustc1.strip_prefix('+').unwrap_or("before");
             let id2 = rustc2.strip_prefix('+').unwrap_or("after");

--- a/collector/src/rustc-fake.rs
+++ b/collector/src/rustc-fake.rs
@@ -323,6 +323,16 @@ fn main() {
                 assert!(cmd.status().expect("failed to spawn").success());
             }
 
+            "llvm-ir" => {
+                args.push("--emit=llvm-ir=./llvm-ir".into());
+                args.push("-Cno-prepopulate-passes".into());
+                args.push("-Cpasses=name-anon-globals".into());
+                let mut cmd = Command::new(tool);
+                cmd.args(args);
+                determinism_env(&mut cmd);
+                assert!(cmd.status().expect("failed to spawn").success());
+            }
+
             "mono-items" => {
                 // Lazy item collection is the default (i.e., without this
                 // option)


### PR DESCRIPTION
This dumps the pre-optimization LLVM-IR (matching cargo llvm-ir input).

Also avoids a rustup-toolchain-install-master install of the rust-lang/rust master commit for no reason.