### PR TITLE
Make `--include` and `--exclude` use exact matching.

### DIFF
--- a/collector/README.md
+++ b/collector/README.md
@@ -100,13 +100,13 @@ The following options alter the behaviour of the `bench_local` subcommand.
   supports postgres as a backend and the URL can be specified (beginning with
   `postgres://`), but this is unlikely to be useful for local collection.
 - `--exclude <EXCLUDE>`: this is used to run a subset of the benchmarks. The
-  argument is a comma-separated list of strings. When this option is specified,
-  a benchmark is excluded from the run if its name contains one or more of the
-  given strings.
+  argument is a comma-separated list of benchmark names. When this option is
+  specified, a benchmark is excluded from the run if its name matches one or
+  more of the given names.
 - `--include <INCLUDE>`: the inverse of `--exclude`. The argument is a
-  comma-separated list of strings. When this option is specified, a benchmark
-  is included in the run only if its name contains one or more of the given
-  strings.
+  comma-separated list of benchmark names. When this option is specified, a
+  benchmark is included in the run only if its name matches one or more of the
+  given names.
 - `--runs $RUNS`: the run kinds to be benchmarked. The possible choices are one
   or more (comma-separated) of `Full`, `IncrFull`, `IncrUnchanged`,
   `IncrPatched`, and `All`. The default is `All`. Note that `IncrFull` is


### PR DESCRIPTION
Currently they do substring matching. But because some benchmarks have a
name that is a substring of another it's impossible to match some
benchmarks by themselves. E.g.:
- Want `webrender`? You'll get `webrender-wrench` too.
- Want `syn`? You'll get `deeply-nested-async` too.
- Want `deeply-nested`? You'll get `deeply-nested-async` and
  `deeply-nested-closures` too.

This commit makes the matching exact. As a heavy user of these tools I
think this is a good trade-off. It makes some things possible that are
currently impossible (e.g. including or excluding just `webrender`), at
the cost of more typing on occasion, e.g. `--include ctfe-stress-4`
instead of `--include ctfe`.

(Note: if you specify something that doesn't match any benchmark's name
the command will give an error.)