### PR TITLE
Skip the `rustc` benchmark in `bench_local` and `bench_published`.

### DIFF
--- a/collector/src/execute.rs
+++ b/collector/src/execute.rs
@@ -572,7 +572,7 @@ pub trait Processor {
     }
 }
 
-pub struct MeasureProcessor<'a> {
+pub struct BenchProcessor<'a> {
     rt: &'a mut Runtime,
     benchmark: &'a BenchmarkName,
     conn: &'a mut dyn database::Connection,
@@ -584,7 +584,7 @@ pub struct MeasureProcessor<'a> {
     tries: u8,
 }
 
-impl<'a> MeasureProcessor<'a> {
+impl<'a> BenchProcessor<'a> {
     pub fn new(
         rt: &'a mut Runtime,
         conn: &'a mut dyn database::Connection,
@@ -610,7 +610,7 @@ impl<'a> MeasureProcessor<'a> {
             assert!(has_tracelog);
         }
 
-        MeasureProcessor {
+        BenchProcessor {
             rt,
             upload: None,
             conn,
@@ -807,7 +807,7 @@ impl Upload {
     }
 }
 
-impl<'a> Processor for MeasureProcessor<'a> {
+impl<'a> Processor for BenchProcessor<'a> {
     fn profiler(&self, _profile: ProfileKind) -> Profiler {
         if self.is_first_collection && self.is_self_profile {
             if cfg!(unix) {

--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -267,7 +267,7 @@ fn bench(
             n_benchmarks_remaining(benchmarks.len() - nth_benchmark)
         );
 
-        let mut processor = execute::MeasureProcessor::new(
+        let mut processor = execute::BenchProcessor::new(
             rt,
             tx.conn(),
             &benchmark.name,


### PR DESCRIPTION
The `rustc` benchmark really confused me, see https://rust-lang.zulipchat.com/#narrow/stream/247081-t-compiler.2Fperformance/topic/.60collector.20bench_local.60.20weirdness for discussion. I think it's best to restrict it to just `bench_next`, which is used for the perf.rust-lang.org runs.