### PR TITLE
Upgrade to clap 3.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,15 +63,6 @@ dependencies = [
 
 [[package]]
 name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
@@ -213,21 +204,6 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
-dependencies = [
- "ansi_term 0.11.0",
- "atty",
- "bitflags",
- "strsim 0.8.0",
- "textwrap 0.11.0",
- "unicode-width",
- "vec_map",
-]
-
-[[package]]
-name = "clap"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1957aa4a5fb388f0a0a73ce7556c5b42025b874e5cdc2c670775e346e97adec0"
@@ -238,9 +214,9 @@ dependencies = [
  "indexmap",
  "lazy_static",
  "os_str_bytes",
- "strsim 0.10.0",
+ "strsim",
  "termcolor",
- "textwrap 0.14.2",
+ "textwrap",
 ]
 
 [[package]]
@@ -262,7 +238,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
- "clap 3.0.6",
+ "clap",
  "crossbeam-utils",
  "database",
  "env_logger",
@@ -374,7 +350,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "chrono",
- "clap 2.33.3",
+ "clap",
  "csv",
  "env_logger",
  "futures",
@@ -1367,7 +1343,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cab0e7c02cf376875e9335e0ba1da535775beb5450d21e1dffca068818ed98b"
 dependencies = [
- "ansi_term 0.12.1",
+ "ansi_term",
  "ctor",
  "diff",
  "output_vt100",
@@ -1883,12 +1859,6 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
@@ -1942,15 +1912,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -2144,12 +2105,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-width"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2178,12 +2133,6 @@ name = "vcpkg"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "025ce40a007e1907e58d5bc1a594def78e5573bb0b1160bc389634e8f12e4faa"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,10 +220,40 @@ dependencies = [
  "ansi_term 0.11.0",
  "atty",
  "bitflags",
- "strsim",
- "textwrap",
+ "strsim 0.8.0",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1957aa4a5fb388f0a0a73ce7556c5b42025b874e5cdc2c670775e346e97adec0"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap 0.14.2",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "517358c28fcef6607bf6f76108e02afad7e82297d132a6b846dcc1fc3efcd153"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -232,7 +262,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
- "clap",
+ "clap 3.0.6",
  "crossbeam-utils",
  "database",
  "env_logger",
@@ -344,7 +374,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "chrono",
- "clap",
+ "clap 2.33.3",
  "csv",
  "env_logger",
  "futures",
@@ -662,6 +692,12 @@ checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
  "http",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -1162,6 +1198,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "output_vt100"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1329,6 +1374,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1342,9 +1411,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.27"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
@@ -1819,6 +1888,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "subtle"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1826,9 +1901,9 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
-version = "1.0.73"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
+checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1877,6 +1952,12 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 
 [[package]]
 name = "thiserror"

--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
-authors = ["Mark Simulacrum <mark.simulacrum@gmail.com>"]
+authors = ["The Rust Compiler Team"]
 name = "collector"
 version = "0.1.0"
-edition = '2018'
+edition = "2018"
+description = "Collects Rust performance data"
 
 [dependencies]
-clap = "2.25"
+clap = { version = "3.0.6", features = ["derive"] }
 env_logger = "0.8"
 anyhow = "1"
 thiserror = "1"

--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -768,7 +768,7 @@ struct DbOption {
 
 #[derive(Debug, clap::Args)]
 struct BenchRustcOption {
-    // Run the special `rustc` benchmark
+    /// Run the special `rustc` benchmark
     #[clap(long = "bench-rustc")]
     bench_rustc: bool,
 }
@@ -1217,4 +1217,12 @@ pub fn get_commit_or_fake_it(sha: &str) -> anyhow::Result<Commit> {
                 date: database::Date::ymd_hms(2000, 01, 01, 0, 0, 0),
             }
         }))
+}
+
+#[test]
+fn verify_app() {
+    // By default, clap lazily checks subcommands. This provides eager testing
+    // without having to run the binary for each subcommand.
+    use clap::IntoApp;
+    Cli::into_app().debug_assert()
 }

--- a/collector/src/rustc-fake.rs
+++ b/collector/src/rustc-fake.rs
@@ -59,8 +59,9 @@ fn main() {
 
         raise_priority();
 
+        // These strings come from `PerfTool::name()`.
         match wrapper {
-            "perf-stat" | "perf-stat-self-profile" => {
+            "PerfStat" | "PerfStatSelfProfile" => {
                 let mut cmd = Command::new("perf");
                 determinism_env(&mut cmd);
                 let has_perf = cmd.output().is_ok();
@@ -102,22 +103,27 @@ fn main() {
                 }
             }
 
-            "xperf-stat" | "xperf-stat-self-profile" => {
-                // For Windows, we use a combination of xperf and tracelog to capture ETW events including hardware performance counters.
-                // To do this, we start an ETW trace using tracelog, telling it to include the InstructionRetired and TotalCycles PMCs
-                // for each CSwitch event that is recorded. Then when ETW records a context switch event, it will be preceeded by a
-                // PMC event which contains the raw counters at that instant. After we've finished compilation, we then use xperf
-                // to stop the trace and dump the results to a plain text file. This file is then processed by the `etw_parser` module
-                // which finds events related to the rustc process and calculates the total values for those performance counters.
-                // Conceptually, this is similar to how `perf` works on Linux except we have to do more of the work ourselves as there
-                // isn't an out of the box way to get the data we care about.
+            "XperfStat" | "XperfStatSelfProfile" => {
+                // For Windows, we use a combination of xperf and tracelog to capture ETW events
+                // including hardware performance counters. To do this, we start an ETW trace using
+                // tracelog, telling it to include the InstructionRetired and TotalCycles PMCs for
+                // each CSwitch event that is recorded. Then when ETW records a context switch
+                // event, it will be preceeded by a PMC event which contains the raw counters at
+                // that instant. After we've finished compilation, we then use xperf to stop the
+                // trace and dump the results to a plain text file. This file is then processed by
+                // the `etw_parser` module which finds events related to the rustc process and
+                // calculates the total values for those performance counters. Conceptually, this
+                // is similar to how `perf` works on Linux except we have to do more of the work
+                // ourselves as there isn't an out of the box way to get the data we care about.
 
-                // Read the path to xperf.exe and tracelog.exe from an environment variable, falling back to assuming it's on the PATH.
+                // Read the path to xperf.exe and tracelog.exe from an environment variable,
+                // falling back to assuming it's on the PATH.
                 let xperf = std::env::var("XPERF").unwrap_or("xperf.exe".to_string());
                 let mut cmd = Command::new(&xperf);
                 assert!(cmd.output().is_ok(), "xperf.exe could not be started");
 
-                // go ahead and run `xperf -stop rustc-perf-counters` in case there are leftover counters running from a failed prior attempt
+                // Go ahead and run `xperf -stop rustc-perf-counters` in case there are leftover
+                // counters running from a failed prior attempt.
                 let mut cmd = Command::new(&xperf);
                 cmd.args(&["-stop", "rustc-perf-counters"]);
                 cmd.status().expect("failed to spawn xperf");
@@ -180,7 +186,7 @@ fn main() {
                 }
             }
 
-            "self-profile" => {
+            "SelfProfile" => {
                 let mut cmd = Command::new(&tool);
                 determinism_env(&mut cmd);
                 cmd.arg("-Zself-profile-events=all");
@@ -189,7 +195,7 @@ fn main() {
                 assert!(cmd.status().expect("failed to spawn").success());
             }
 
-            "time-passes" => {
+            "TimePasses" => {
                 args.insert(0, "-Ztime-passes".into());
 
                 let mut cmd = Command::new(&tool);
@@ -200,7 +206,7 @@ fn main() {
                 assert!(cmd.status().expect("failed to spawn").success());
             }
 
-            "perf-record" => {
+            "PerfRecord" => {
                 let mut cmd = Command::new("perf");
                 determinism_env(&mut cmd);
                 let has_perf = cmd.output().is_ok();
@@ -216,7 +222,7 @@ fn main() {
                 assert!(cmd.status().expect("failed to spawn").success());
             }
 
-            "oprofile" => {
+            "Oprofile" => {
                 let mut cmd = Command::new("operf");
                 determinism_env(&mut cmd);
                 let has_oprofile = cmd.output().is_ok();
@@ -227,7 +233,7 @@ fn main() {
                 assert!(cmd.status().expect("failed to spawn").success());
             }
 
-            "cachegrind" => {
+            "Cachegrind" => {
                 let mut cmd = Command::new("valgrind");
                 determinism_env(&mut cmd);
                 let has_valgrind = cmd.output().is_ok();
@@ -252,7 +258,7 @@ fn main() {
                 assert!(cmd.status().expect("failed to spawn").success());
             }
 
-            "callgrind" => {
+            "Callgrind" => {
                 let mut cmd = Command::new("valgrind");
                 determinism_env(&mut cmd);
                 let has_valgrind = cmd.output().is_ok();
@@ -270,7 +276,7 @@ fn main() {
                 assert!(cmd.status().expect("failed to spawn").success());
             }
 
-            "dhat" => {
+            "Dhat" => {
                 let mut cmd = Command::new("valgrind");
                 determinism_env(&mut cmd);
                 let has_valgrind = cmd.output().is_ok();
@@ -284,7 +290,7 @@ fn main() {
                 assert!(cmd.status().expect("failed to spawn").success());
             }
 
-            "massif" => {
+            "Massif" => {
                 let mut cmd = Command::new("valgrind");
                 determinism_env(&mut cmd);
                 let has_valgrind = cmd.output().is_ok();
@@ -301,14 +307,14 @@ fn main() {
                 assert!(cmd.status().expect("failed to spawn").success());
             }
 
-            "eprintln" => {
+            "Eprintln" => {
                 let mut cmd = bash_command(tool, args, "2> eprintln");
                 determinism_env(&mut cmd);
 
                 assert!(cmd.status().expect("failed to spawn").success());
             }
 
-            "llvm-lines" => {
+            "LlvmLines" => {
                 // `cargo llvm-lines` writes its output to stdout. But we can't
                 // redirect it to a file here like we do for "time-passes" and
                 // "eprintln". This is because `cargo llvm-lines` invokes rustc
@@ -323,7 +329,7 @@ fn main() {
                 assert!(cmd.status().expect("failed to spawn").success());
             }
 
-            "llvm-ir" => {
+            "LlvmIr" => {
                 args.push("--emit=llvm-ir=./llvm-ir".into());
                 args.push("-Cno-prepopulate-passes".into());
                 args.push("-Cpasses=name-anon-globals".into());
@@ -333,7 +339,7 @@ fn main() {
                 assert!(cmd.status().expect("failed to spawn").success());
             }
 
-            "mono-items" => {
+            "MonoItems" => {
                 // Lazy item collection is the default (i.e., without this
                 // option)
                 args.push("-Zprint-mono-items=lazy".into());
@@ -343,7 +349,7 @@ fn main() {
                 assert!(cmd.status().expect("failed to spawn").success());
             }
 
-            "dep-graph" => {
+            "DepGraph" => {
                 args.push("-Zdump-dep-graph".into());
                 args.push("-Zquery-dep-graph".into());
                 let mut cmd = Command::new(tool);

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -25,4 +25,4 @@ futures = "0.3.5"
 log = "0.4"
 bytes = "1"
 csv = "1"
-clap = "2.25"
+clap = { version = "3.0.6", features = ["cargo"] }

--- a/database/src/bin/postgres-to-sqlite.rs
+++ b/database/src/bin/postgres-to-sqlite.rs
@@ -4,7 +4,6 @@
 //! transactions, and will likely fail if used on a populated database.
 
 use chrono::{DateTime, Utc};
-use clap::value_t;
 use database::pool::{postgres, sqlite, ConnectionManager};
 use futures::StreamExt;
 use rusqlite::params;
@@ -464,8 +463,9 @@ async fn main() -> anyhow::Result<()> {
 
     let matches = clap::App::new("postgres-to-sqlite")
         .about("Exports a rustc-perf Postgres database to a SQLite database")
+        .version(clap::crate_version!())
         .arg(
-            clap::Arg::with_name("exclude-tables")
+            clap::Arg::new("exclude-tables")
                 .long("exclude-tables")
                 .takes_value(true)
                 .value_name("TABLES")
@@ -474,24 +474,24 @@ async fn main() -> anyhow::Result<()> {
                 .help("Exclude given tables (as foreign key constraints allow)"),
         )
         .arg(
-            clap::Arg::with_name("no-self-profile")
+            clap::Arg::new("no-self-profile")
                 .long("no-self-profile")
                 .help("Exclude some potentially large self-profile tables (additive with --exclude-tables)"),
         )
         .arg(
-            clap::Arg::with_name("since-weeks-ago")
+            clap::Arg::new("since-weeks-ago")
                 .long("since-weeks-ago")
                 .takes_value(true)
                 .value_name("WEEKS")
                 .help("Exclude data associated with artifacts whose date value precedes <WEEKS> weeks ago"),
         )
         .arg(
-            clap::Arg::with_name("fast-unsafe")
+            clap::Arg::new("fast-unsafe")
                 .long("fast-unsafe")
                 .help("Enable faster execution at the risk of corrupting SQLite database in the event of a crash"),
         )
         .arg(
-            clap::Arg::with_name("postgres-db")
+            clap::Arg::new("postgres-db")
                 .required(true)
                 .value_name("POSTGRES_DB")
                 .help(
@@ -500,7 +500,7 @@ async fn main() -> anyhow::Result<()> {
                 ),
         )
         .arg(
-            clap::Arg::with_name("sqlite-db")
+            clap::Arg::new("sqlite-db")
                 .required(true)
                 .value_name("SQLITE_DB")
                 .help("SQLite database file"),
@@ -521,7 +521,7 @@ async fn main() -> anyhow::Result<()> {
         // `RawSelfProfile` is intentionally kept.
     }
 
-    let since_weeks_ago = match clap::value_t!(matches, "since-weeks-ago", u32) {
+    let since_weeks_ago = match matches.value_of_t("since-weeks-ago") {
         Ok(weeks) => Some(weeks),
         Err(err) if err.kind == clap::ErrorKind::ArgumentNotFound => None,
         Err(err) => err.exit(),

--- a/database/src/bin/sqlite-to-postgres.rs
+++ b/database/src/bin/sqlite-to-postgres.rs
@@ -614,14 +614,15 @@ async fn main() -> anyhow::Result<()> {
 
     let matches = clap::App::new("sqlite-to-postgres")
         .about("Exports a rustc-perf SQLite database to a Postgres database")
+        .version(clap::crate_version!())
         .arg(
-            clap::Arg::with_name("sqlite-db")
+            clap::Arg::new("sqlite-db")
                 .required(true)
                 .value_name("SQLITE_DB")
                 .help("SQLite database file"),
         )
         .arg(
-            clap::Arg::with_name("postgres-db")
+            clap::Arg::new("postgres-db")
                 .required(true)
                 .value_name("POSTGRES_DB")
                 .help(


### PR DESCRIPTION
This requires moving away from the deprecated `clap_app!` macro. Clap's
derive API (formerly `StructOpt`) is nicer anyway, because it's not
stringly-typed.

There is quite a bit of furniture moving in `execute.rs` to better
separate the perf tools used for `bench_*` subcommands from those used
for the profile subcommands.