### PR TITLE
Include the profile in a result's summary; more documentation for rust-timer commands

### DIFF
--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -1000,8 +1000,8 @@ impl TestResultComparison {
         .unwrap();
         writeln!(
             summary,
-            " (up to {:.1}% on `{}` builds of `{}`)",
-            percent, self.scenario, self.benchmark
+            " (up to {:.1}% on `{}` builds of `{} {}`)",
+            percent, self.scenario, self.benchmark, self.profile
         )
         .unwrap();
     }

--- a/site/static/help.html
+++ b/site/static/help.html
@@ -54,8 +54,20 @@
                 <code>&lt;RUNS&gt;</code> times.
             </li>
         </ul>
-        <p><code>@rust-timer</code> has more commands than just <code>@rust-timer queue</code>, but the
-            <code>queue</code> command is the most used.
+        <p><code>@rust-timer</code> has
+            <a href="https://github.com/rust-lang/rustc-perf/blob/dcae222b6a7fbb4c9e21d95bc93313ebe5107c7c/site/src/request_handlers/github.rs#L12-L21">more commands</a>
+            than just <code>@rust-timer queue</code>, but the <code>queue</code> command is the most used.
+        </p>
+        <p><code>@rust-timer build $commit</code> will queue a perf run for the given commit <code>$commit</code>.
+            It is usually invoked with the commit from a successful "try" run. (The
+            <code>queue</code> command can be seen as a shortcut that automatically selects the
+            "try" run's commit for the <code>build</code> command)
+            This command also supports the same <code>include</code>, <code>exclude</code>, and <code>runs</code> options
+            as <code>@rust-timer queue</code>.
+        </p>
+        <p>
+            The other two commands are a work in progress and will be documented here when they're
+            finalized. They are dedicated to helping diagnose the cause of regressions in rollup PRs.
         </p>
         <script src="shared.js"></script>
 </body>


### PR DESCRIPTION
Fixes #1048 by changing the summary line of a benchmark result by adding its profile as well.

This matches the compare page's "Benchmark & Profile" column, so I think it's clearer in that sense (but maybe it can be put elsewhere in the summary sentence). But this change will also impact the automated weekly report: I therefore wonder if this is how you'd want it to be fixed ?

For example, [this summary](https://github.com/rust-lang/rust/pull/88679#issuecomment-932841079) would now mention that the regression was in a `doc` benchmark: from "Very large regression in instruction counts (up to 6.6% on `full` builds of `regression-31157`)" to "Very large regression in instruction counts (up to 6.6% on `full` builds of `regression-31157 doc`)".

And [this one](https://github.com/rust-lang/rust/pull/92534#issuecomment-1008392640) would go from "Large regression in instruction counts (up to 1.6% on `incr-unchanged` builds of `derive`)" to "Large regression in instruction counts (up to 1.6% on `incr-unchanged` builds of `derive check`)"

Resolves #1099 by adding a tiny bit more documentation about rust-timer commands on the Help page, and the link Scott suggests. 

<details>
<summary>Here's how it looks rendered</summary>

![image](https://user-images.githubusercontent.com/247183/149415464-ace904fb-a235-47e2-842e-b5221ee87c68.png)

</details>


