### PR TITLE
Merge `diff_local` into `profile_local`

### DIFF
--- a/ci/check-benchmarks.sh
+++ b/ci/check-benchmarks.sh
@@ -16,7 +16,8 @@ RUST_BACKTRACE=1 \
     CARGO_LOG=cargo::core::compiler::fingerprint=info \
     RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=debug \
     cargo run -p collector --bin collector -- \
-    bench_local $bindir/rustc Test \
+    bench_local $bindir/rustc \
+        --id Test \
         --builds $PROFILE_KINDS \
         --cargo $bindir/cargo \
         --runs All \

--- a/ci/check-profiling.sh
+++ b/ci/check-profiling.sh
@@ -22,7 +22,8 @@ cargo build -p collector --bin rustc-fake
 # time-passes.
 RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=debug \
     cargo run -p collector --bin collector -- \
-    profile_local time-passes $bindir/rustc Test \
+    profile_local time-passes $bindir/rustc \
+        --id Test \
         --builds Check \
         --cargo $bindir/cargo \
         --include helloworld \
@@ -35,7 +36,8 @@ grep -q "time:.*total" results/Ztp-Test-helloworld-Check-Full
 # hardware is virtualized and performance counters aren't available?
 #RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=debug \
 #    cargo run -p collector --bin collector -- \
-#    profile_local perf-record $bindir/rustc Test \
+#    profile_local perf-record $bindir/rustc \
+#        --id Test \
 #        --builds Check \
 #        --cargo $bindir/cargo \
 #        --include helloworld \
@@ -49,7 +51,8 @@ grep -q "time:.*total" results/Ztp-Test-helloworld-Check-Full
 # Cachegrind.
 RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=debug \
     cargo run -p collector --bin collector -- \
-    profile_local cachegrind $bindir/rustc Test \
+    profile_local cachegrind $bindir/rustc \
+        --id Test \
         --builds Check \
         --cargo $bindir/cargo \
         --include helloworld \
@@ -62,7 +65,8 @@ grep -q "PROGRAM TOTALS" results/cgann-Test-helloworld-Check-Full
 # Callgrind.
 RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=debug \
     cargo run -p collector --bin collector -- \
-    profile_local callgrind $bindir/rustc Test \
+    profile_local callgrind $bindir/rustc \
+        --id Test \
         --builds Check \
         --cargo $bindir/cargo \
         --include helloworld \
@@ -75,7 +79,8 @@ grep -q "Profile data file" results/clgann-Test-helloworld-Check-Full
 # DHAT.
 RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=debug \
     cargo run -p collector --bin collector -- \
-    profile_local dhat $bindir/rustc Test \
+    profile_local dhat $bindir/rustc \
+        --id Test \
         --builds Check \
         --cargo $bindir/cargo \
         --include helloworld \
@@ -86,7 +91,8 @@ grep -q "dhatFileVersion" results/dhout-Test-helloworld-Check-Full
 # Massif.
 RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=debug \
     cargo run -p collector --bin collector -- \
-    profile_local massif $bindir/rustc Test \
+    profile_local massif $bindir/rustc \
+        --id Test \
         --builds Check \
         --cargo $bindir/cargo \
         --include helloworld \
@@ -98,7 +104,8 @@ grep -q "snapshot=0" results/msout-Test-helloworld-Check-Full
 # anything to stderr.
 RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=debug \
     cargo run -p collector --bin collector -- \
-    profile_local eprintln $bindir/rustc Test \
+    profile_local eprintln $bindir/rustc \
+        --id Test \
         --builds Check \
         --cargo $bindir/cargo \
         --include helloworld \
@@ -112,7 +119,8 @@ test ! -s results/eprintln-Test-helloworld-Check-Full
 # latter of which has broken before.
 RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=debug \
     cargo run -p collector --bin collector -- \
-    profile_local llvm-lines $bindir/rustc Test \
+    profile_local llvm-lines $bindir/rustc \
+        --id Test \
         --builds Debug \
         --cargo $bindir/cargo \
         --include helloworld,futures \
@@ -131,7 +139,8 @@ grep -q "Lines.*Copies.*Function name" results/ll-Test-futures-Debug-Full
 # `Doc` files must not be present.
 RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=debug \
     cargo run -p collector --bin collector -- \
-    profile_local eprintln $bindir/rustc Builds1 \
+    profile_local eprintln $bindir/rustc \
+        --id Builds1 \
         --cargo $bindir/cargo \
         --include helloworld
 test   -f results/eprintln-Builds1-helloworld-Check-Full
@@ -155,8 +164,9 @@ test ! -e results/eprintln-Builds1-helloworld-Doc-IncrUnchanged
 # present, and `Doc` files must be present (but not for incremental runs).
 RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=debug \
     cargo run -p collector --bin collector -- \
-    profile_local eprintln $bindir/rustc Builds2 \
-	--builds Doc \
+    profile_local eprintln $bindir/rustc \
+        --id Builds2 \
+        --builds Doc \
         --cargo $bindir/cargo \
         --include helloworld
 test ! -e results/eprintln-Builds2-helloworld-Check-Full
@@ -180,8 +190,9 @@ test ! -f results/eprintln-Builds2-helloworld-Doc-IncrUnchanged
 # must be present.
 RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=debug \
     cargo run -p collector --bin collector -- \
-    profile_local eprintln $bindir/rustc Runs1 \
-	--builds Check \
+    profile_local eprintln $bindir/rustc \
+        --id Runs1 \
+        --builds Check \
         --cargo $bindir/cargo \
         --include helloworld \
         --runs IncrUnchanged
@@ -194,8 +205,9 @@ test ! -e results/eprintln-Runs1-helloworld-Check-IncrPatched0
 # be present.
 RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=debug \
     cargo run -p collector --bin collector -- \
-    profile_local eprintln $bindir/rustc Runs2 \
-	--builds Check \
+    profile_local eprintln $bindir/rustc \
+        --id Runs2 \
+        --builds Check \
         --cargo $bindir/cargo \
         --include helloworld \
         --runs IncrPatched

--- a/collector/README.md
+++ b/collector/README.md
@@ -405,16 +405,16 @@ The following options alter the behaviour of the `profile_local` subcommand.
 - `--cargo <CARGO>`: as for `bench_local`.
 - `--exclude <EXCLUDE>`: as for `bench_local`.
 - `--id <ID>`: an identifer that will form part of the output filenames.
-  Also, if `--rustc2` is identified, a `1` will be appended to the ID for the
-  first run and a `2` will be appended to the ID for the second run.
 - `--include <INCLUDE>`: as for `bench_local`.
 - `--out-dir <OUT_DIR>`: a path (relative or absolute) to a directory in
   which the output will be placed. If the directory doesn't exist, it will be
   created. The default is `results/`.
 - `--runs <RUNS>`: as for `bench_local`.
 - `--rustc2 <RUSTC>`: if given, profiles a second Rust compiler for comparison
-  against the first. If the profiler being used is Cachegrind, diff files will
-  also be produced.
+  against the first. If a non-toolchain identifier is being used, a `1` will be
+  appended to the identifier for the first run and a `2` will be appended to
+  the identifier for the second run. If the profiler being used is Cachegrind,
+  diff files will also be produced. 
 - `--rustdoc <RUSTDOC>` as for `bench_local`.
 
 `RUST_LOG=debug` can be specified to enable verbose logging, which is useful

--- a/collector/README.md
+++ b/collector/README.md
@@ -63,7 +63,7 @@ marked with a '?' in the `compare` page.
 
 The following command runs the benchmark suite using a local rustc:
 ```
-./target/release/collector bench_local <RUSTC> <ID>
+./target/release/collector bench_local <RUSTC>
 ```
 
 It will benchmark the entire suite and put the results in a SQLite database
@@ -78,14 +78,26 @@ The following arguments are mandatory.
   `$RUST/build/x86_64-unknown-linux-gnu/stage1/bin/rustc`, where `$RUST` is a
   path (relative or absolute) to a `rust` repository. You can use either a
   stage 1 or a stage 2 compiler, but if you're comparing two versions you
-  should choose consistently.
+  should choose consistently. **Alternatively**, it can be a `+`-prefixed
+  toolchain specifier such as `+nightly` or
+  `+f7bb8e3677ba4277914e85a3060e5d69151aed44` in which case `rustup` will be
+  used to obtain the toolchain, downloading it if necessary.
 
-- `<ID>`: an identifier which will be used to identify the results in the
-  database.
+The identifier under which the results will be put into the database varies.
+- If the `--id` option is specified, that identifer will be used.
+- Otherwise, if rustc is specified via a path, `Id` will be used.
+- Otherwise, rustc is specified via a `+`-prefixed toolchain specifier, and the
+  toolchain name will be used.
 
 ### Benchmarking options
 
 The following options alter the behaviour of the `bench_local` subcommand.
+- `--bench-rustc`: there is a special `rustc` benchmark that involves
+  downloading a recent Rust compiler and measuring the time taken to compile
+  it. This benchmark works very differently to all the other benchmarks. For
+  example, `--runs` and `--builds` don't affect it, and the given `ID` is used
+  as the `rust-lang/rust` ref (falling back to `HEAD` if the `ID` is not a
+  valid ref). It is for advanced and CI use only. This option enables it.
 - `--builds <BUILDS>`: the build kinds to be benchmarked. The possible choices
   are one or more (comma-separated) of `Check`, `Debug`, `Doc`, `Opt`, and
   `All`. The default is `Check,Debug,Opt`.
@@ -103,16 +115,12 @@ The following options alter the behaviour of the `bench_local` subcommand.
   argument is a comma-separated list of benchmark names. When this option is
   specified, a benchmark is excluded from the run if its name matches one or
   more of the given names.
+- `--id <ID>` the identifier that will be used to identify the results in the
+  database.
 - `--include <INCLUDE>`: the inverse of `--exclude`. The argument is a
   comma-separated list of benchmark names. When this option is specified, a
   benchmark is included in the run only if its name matches one or more of the
   given names.
-- `--bench-rustc`: there is a special `rustc` benchmark that involves
-  downloading a recent Rust compiler and measuring the time taken to compile
-  it. This benchmark works very differently to all the other benchmarks. For
-  example, `--runs` and `--builds` don't affect it, and the given `ID` is used
-  as the `rust-lang/rust` ref (falling back to `HEAD` if the `ID` is not a
-  valid ref). It is for advanced and CI use only. This option enables it.
 - `--runs $RUNS`: the run kinds to be benchmarked. The possible choices are one
   or more (comma-separated) of `Full`, `IncrFull`, `IncrUnchanged`,
   `IncrPatched`, and `All`. The default is `All`. Note that `IncrFull` is
@@ -232,7 +240,7 @@ Without this you won't get useful file names and line numbers in the output.
 
 To profile a local rustc with one of several profilers:
 ```
-./target/release/collector profile_local <PROFILER> <RUSTC> <ID>
+./target/release/collector profile_local <PROFILER> <RUSTC>
 ```
 It will profile the entire suite and put the results in a directory called
 `results/`.
@@ -384,11 +392,11 @@ The mandatory `<PROFILER>` argument must be one of the following.
   - **Output**. .dot and .txt file (.txt likely is what you want to see first).
   - **Notes**. Works primarily with incremental compilation kinds.
 
-The mandatory `<RUSTC>` argument is a patch to a rustc executable, similar to
-`bench_local`.
+The mandatory `<RUSTC>` argument is a path to a rustc executable or a
+`+`-prefixed toolchain specifier, the same as for `bench_local`.
 
-The mandatory `<ID>` argument is an identifer that will form part of the
-output filenames.
+The identifier that forms part of the output filenames is chosen in a similar
+fashion to the one chosen for `bench_local`.
 
 ### Profiling options
 
@@ -396,11 +404,17 @@ The following options alter the behaviour of the `profile_local` subcommand.
 - `--builds <BUILDS>`: as for `bench_local`.
 - `--cargo <CARGO>`: as for `bench_local`.
 - `--exclude <EXCLUDE>`: as for `bench_local`.
+- `--id <ID>`: an identifer that will form part of the output filenames.
+  Also, if `--rustc2` is identified, a `1` will be appended to the ID for the
+  first run and a `2` will be appended to the ID for the second run.
 - `--include <INCLUDE>`: as for `bench_local`.
 - `--out-dir <OUT_DIR>`: a path (relative or absolute) to a directory in
   which the output will be placed. If the directory doesn't exist, it will be
   created. The default is `results/`.
 - `--runs <RUNS>`: as for `bench_local`.
+- `--rustc2 <RUSTC>`: if given, profiles a second Rust compiler for comparison
+  against the first. If the profiler being used is Cachegrind, diff files will
+  also be produced.
 - `--rustdoc <RUSTDOC>` as for `bench_local`.
 
 `RUST_LOG=debug` can be specified to enable verbose logging, which is useful

--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -66,11 +66,11 @@ impl ProfileKind {
         vec![ProfileKind::Check, ProfileKind::Debug, ProfileKind::Opt]
     }
 
-    fn expand_all(vec: Vec<Self>) -> Vec<Self> {
-        if vec.contains(&ProfileKind::All) {
+    fn expand_all(kinds: &[Self]) -> Vec<Self> {
+        if kinds.contains(&ProfileKind::All) {
             Self::all()
         } else {
-            vec
+            kinds.to_vec()
         }
     }
 }
@@ -102,11 +102,11 @@ impl ScenarioKind {
         vec![ScenarioKind::Full]
     }
 
-    fn expand_all(vec: Vec<Self>) -> Vec<Self> {
-        if vec.contains(&ScenarioKind::All) {
+    fn expand_all(kinds: &[Self]) -> Vec<Self> {
+        if kinds.contains(&ScenarioKind::All) {
             Self::all()
         } else {
-            vec
+            kinds.to_vec()
         }
     }
 
@@ -316,8 +316,8 @@ fn is_installed(name: &str) -> bool {
 
 fn get_benchmarks(
     benchmark_dir: &Path,
-    include: Option<String>,
-    exclude: Option<String>,
+    include: Option<&str>,
+    exclude: Option<&str>,
 ) -> anyhow::Result<Vec<Benchmark>> {
     let mut benchmarks = Vec::new();
 
@@ -346,8 +346,6 @@ fn get_benchmarks(
         paths.push((path, name));
     }
 
-    let include = include.as_ref();
-    let exclude = exclude.as_ref();
     let mut includes = include.map(|list| list.split(',').collect::<HashSet<&str>>());
     let mut excludes = exclude.map(|list| list.split(',').collect::<HashSet<&str>>());
 
@@ -414,11 +412,13 @@ fn get_local_toolchain(
     rustc: &str,
     rustdoc: Option<&Path>,
     cargo: Option<&Path>,
-) -> anyhow::Result<(PathBuf, Option<PathBuf>, PathBuf)> {
+    id: Option<&str>,
+    id_suffix: &str,
+) -> anyhow::Result<(PathBuf, Option<PathBuf>, PathBuf, String)> {
     // `+`-prefixed rustc is an indicator to fetch the rustc of the toolchain
     // specified. This follows the similar pattern used by rustup's binaries
     // (e.g., `rustc +stage1`).
-    let rustc = if let Some(toolchain) = rustc.strip_prefix('+') {
+    let (rustc, id) = if let Some(toolchain) = rustc.strip_prefix('+') {
         let output = Command::new("rustup")
             .args(&["which", "rustc", "--toolchain", &toolchain])
             .output()
@@ -428,6 +428,14 @@ fn get_local_toolchain(
         if output.status.code() == Some(101) && toolchain.len() == 40 {
             // No such toolchain exists, so let's try to install it with
             // rustup-toolchain-install-master.
+
+            if Command::new("rustup-toolchain-install-master")
+                .arg("-V")
+                .output()
+                .is_err()
+            {
+                anyhow::bail!("rustup-toolchain-install-master is not installed but must be");
+            }
 
             if !Command::new("rustup-toolchain-install-master")
                 .arg(&toolchain)
@@ -456,11 +464,31 @@ fn get_local_toolchain(
 
         let rustc = PathBuf::from(s.trim());
         debug!("found rustc: {:?}", &rustc);
-        rustc
+
+        // When the id comes from a +toolchain, the suffix is *not* added.
+        let id = if let Some(id) = id {
+            let mut id = id.to_owned();
+            id.push_str(id_suffix);
+            id
+        } else {
+            toolchain.to_owned()
+        };
+        (rustc, id)
     } else {
-        PathBuf::from(rustc)
+        let rustc = PathBuf::from(rustc)
             .canonicalize()
-            .with_context(|| format!("failed to canonicalize rustc executable {:?}", rustc))?
+            .with_context(|| format!("failed to canonicalize rustc executable {:?}", rustc))?;
+
+        // When specifying rustc via a path, the suffix is always added to the
+        // id.
+        let mut id = if let Some(id) = id {
+            id.to_owned()
+        } else {
+            "Id".to_string()
+        };
+        id.push_str(id_suffix);
+
+        (rustc, id)
     };
 
     let rustdoc =
@@ -509,7 +537,7 @@ fn get_local_toolchain(
         cargo
     };
 
-    Ok((rustc, rustdoc, cargo))
+    Ok((rustc, rustdoc, cargo, id))
 }
 
 fn generate_cachegrind_diffs(
@@ -549,8 +577,8 @@ fn generate_cachegrind_diffs(
                 let cgout2 = out_dir.join(filename("cgout", id2));
                 let cgfilt1 = out_dir.join(filename("cgfilt", id1));
                 let cgfilt2 = out_dir.join(filename("cgfilt", id2));
-                let cgdiff = out_dir.join(filename("cgdiff", &id_diff));
-                let cgann = out_dir.join(filename("cgann", &id_diff));
+                let cgfilt_diff = out_dir.join(filename("cgfilt-diff", &id_diff));
+                let cgann_diff = out_dir.join(filename("cgann-diff", &id_diff));
 
                 if let Err(e) = rustfilt(&cgout1, &cgfilt1) {
                     errors.incr();
@@ -562,18 +590,18 @@ fn generate_cachegrind_diffs(
                     eprintln!("collector error: {:?}", e);
                     continue;
                 }
-                if let Err(e) = cg_diff(&cgfilt1, &cgfilt2, &cgdiff) {
+                if let Err(e) = cg_diff(&cgfilt1, &cgfilt2, &cgfilt_diff) {
                     errors.incr();
                     eprintln!("collector error: {:?}", e);
                     continue;
                 }
-                if let Err(e) = cg_annotate(&cgdiff, &cgann) {
+                if let Err(e) = cg_annotate(&cgfilt_diff, &cgann_diff) {
                     errors.incr();
                     eprintln!("collector error: {:?}", e);
                     continue;
                 }
 
-                annotated_diffs.push(cgann);
+                annotated_diffs.push(cgann_diff);
             }
         }
     }
@@ -694,21 +722,16 @@ struct Cli {
 }
 
 #[derive(Debug, clap::Args)]
-struct RustcOption {
-    /// The path to the local rustc to benchmark
+struct LocalOptions {
+    /// The path to the local rustc to measure
     // Not a `PathBuf` because it can be a file path *or* a `+`-prefixed
     // toolchain name, and `PathBuf` doesn't work well for the latter.
     rustc: String,
-}
 
-#[derive(Debug, clap::Args)]
-struct IdOption {
     /// Identifier to associate benchmark results with
-    id: String,
-}
+    #[clap(long)]
+    id: Option<String>,
 
-#[derive(Debug, clap::Args)]
-struct LocalOptions {
     /// Measure the build profiles in this comma-separated list
     // This must be normalized via `ProfilerKind::expand_all()` before use.
     #[clap(
@@ -734,7 +757,7 @@ struct LocalOptions {
     #[clap(long)]
     include: Option<String>,
 
-    /// The path to the local rustdoc to benchmark
+    /// The path to the local rustdoc to measure
     #[clap(long, parse(from_os_str))]
     rustdoc: Option<PathBuf>,
 
@@ -780,12 +803,6 @@ struct BenchRustcOption {
 enum Commands {
     /// Benchmarks a local rustc
     BenchLocal {
-        #[clap(flatten)]
-        rustc: RustcOption,
-
-        #[clap(flatten)]
-        id: IdOption,
-
         #[clap(flatten)]
         local: LocalOptions,
 
@@ -834,38 +851,17 @@ enum Commands {
         profiler: Profiler,
 
         #[clap(flatten)]
-        rustc: RustcOption,
-
-        #[clap(flatten)]
-        id: IdOption,
-
-        #[clap(flatten)]
         local: LocalOptions,
 
         /// Output directory
         #[clap(long = "out-dir", default_value = "results/")]
         out_dir: PathBuf,
-    },
 
-    /// Profiles and compares two toolchains with one of several profilers. If
-    /// the profiler is Cachegrind, also performs a diff
-    DiffLocal {
-        /// Profiler to use
-        #[clap(arg_enum)]
-        profiler: Profiler,
-
-        /// The path to the first local rustc to benchmark
-        rustc_before: String,
-
-        /// The path to the second local rustc to benchmark
-        rustc_after: String,
-
-        #[clap(flatten)]
-        local: LocalOptions,
-
-        /// Output directory
-        #[clap(long = "out-dir", default_value = "results/")]
-        out_dir: PathBuf,
+        /// The path to the second local rustc (to diff against)
+        // Not a `PathBuf` because it can be a file path *or* a `+`-prefixed
+        // toolchain name, and `PathBuf` doesn't work well for the latter.
+        #[clap(long)]
+        rustc2: Option<String>,
     },
 
     /// Installs the next commit for perf.rust-lang.org
@@ -892,32 +888,36 @@ fn main_result() -> anyhow::Result<i32> {
 
     match args.command {
         Commands::BenchLocal {
-            rustc,
-            id,
             local,
             db,
             bench_rustc,
             iterations,
             self_profile,
         } => {
-            let profile_kinds = ProfileKind::expand_all(local.profile_kinds);
-            let scenario_kinds = ScenarioKind::expand_all(local.scenario_kinds);
+            let profile_kinds = ProfileKind::expand_all(&local.profile_kinds);
+            let scenario_kinds = ScenarioKind::expand_all(&local.scenario_kinds);
 
             let pool = database::Pool::open(&db.db);
 
-            let (rustc, rustdoc, cargo) = get_local_toolchain(
+            let (rustc, rustdoc, cargo, id) = get_local_toolchain(
                 &profile_kinds,
-                &rustc.rustc,
+                &local.rustc,
                 local.rustdoc.as_deref(),
                 local.cargo.as_deref(),
+                local.id.as_deref(),
+                "",
             )?;
 
-            let benchmarks = get_benchmarks(&benchmark_dir, local.include, local.exclude)?;
+            let benchmarks = get_benchmarks(
+                &benchmark_dir,
+                local.include.as_deref(),
+                local.exclude.as_deref(),
+            )?;
 
             let res = bench(
                 &mut rt,
                 pool,
-                &ArtifactId::Tag(id.id),
+                &ArtifactId::Tag(id),
                 &profile_kinds,
                 &scenario_kinds,
                 bench_rustc.bench_rustc,
@@ -962,7 +962,11 @@ fn main_result() -> anyhow::Result<i32> {
             let sysroot = Sysroot::install(commit.sha.to_string(), &target_triple)
                 .with_context(|| format!("failed to install sysroot for {:?}", commit))?;
 
-            let benchmarks = get_benchmarks(&benchmark_dir, next.include, next.exclude)?;
+            let benchmarks = get_benchmarks(
+                &benchmark_dir,
+                next.include.as_deref(),
+                next.exclude.as_deref(),
+            )?;
 
             let res = bench(
                 &mut rt,
@@ -1050,125 +1054,82 @@ fn main_result() -> anyhow::Result<i32> {
 
         Commands::ProfileLocal {
             profiler,
-            rustc,
-            id,
             local,
             out_dir,
+            rustc2,
         } => {
-            // Options
-            let profile_kinds = ProfileKind::expand_all(local.profile_kinds);
-            let scenario_kinds = ScenarioKind::expand_all(local.scenario_kinds);
+            let profile_kinds = ProfileKind::expand_all(&local.profile_kinds);
+            let scenario_kinds = ScenarioKind::expand_all(&local.scenario_kinds);
 
-            let (rustc, rustdoc, cargo) = get_local_toolchain(
-                &profile_kinds,
-                &rustc.rustc,
-                local.rustdoc.as_deref(),
-                local.cargo.as_deref(),
+            let benchmarks = get_benchmarks(
+                &benchmark_dir,
+                local.include.as_deref(),
+                local.exclude.as_deref(),
             )?;
-            let compiler = Compiler {
-                rustc: &rustc,
-                rustdoc: rustdoc.as_deref(),
-                cargo: &cargo,
-                triple: &target_triple,
-                is_nightly: true,
-            };
-            let benchmarks = get_benchmarks(&benchmark_dir, local.include, local.exclude)?;
             let mut errors = BenchmarkErrors::new();
-            profile(
-                compiler,
-                &id.id,
-                profiler,
-                &out_dir,
-                &benchmarks,
-                &profile_kinds,
-                &scenario_kinds,
-                &mut errors,
-            );
-            errors.fail_if_nonzero()?;
-            Ok(0)
-        }
 
-        Commands::DiffLocal {
-            profiler,
-            rustc_before,
-            rustc_after,
-            local,
-            out_dir,
-        } => {
-            let profile_kinds = ProfileKind::expand_all(local.profile_kinds);
-            let scenario_kinds = ScenarioKind::expand_all(local.scenario_kinds);
-
-            check_installed("valgrind")?;
-            check_installed("cg_annotate")?;
-            check_installed("rustfilt")?;
-
-            // Avoid just straight running rustup-toolchain-install-master which
-            // will install the current master commit (fetching quite a bit of
-            // data, including hitting GitHub)...
-            if Command::new("rustup-toolchain-install-master")
-                .arg("-V")
-                .output()
-                .is_err()
-            {
-                anyhow::bail!("rustup-toolchain-install-master is not installed but must be");
-            }
-
-            let id1 = rustc_before.strip_prefix('+').unwrap_or("before");
-            let id2 = rustc_after.strip_prefix('+').unwrap_or("after");
-            let mut toolchains = Vec::new();
-            for (id, rustc) in [(id1, &rustc_before), (id2, &rustc_after)] {
-                let (rustc, rustdoc, cargo) = get_local_toolchain(
-                    &profile_kinds,
-                    rustc,
-                    local.rustdoc.as_deref(),
-                    local.cargo.as_deref(),
-                )?;
-                toolchains.push((id.to_owned(), rustc, rustdoc, cargo));
-            }
-
-            let benchmarks = get_benchmarks(&benchmark_dir, local.include, local.exclude)?;
-            let mut errors = BenchmarkErrors::new();
-            for (id, rustc, rustdoc, cargo) in &toolchains {
-                let compiler = Compiler {
-                    rustc: &rustc,
-                    rustdoc: rustdoc.as_deref(),
-                    cargo: &cargo,
-                    triple: &target_triple,
-                    is_nightly: true,
+            let mut get_toolchain_and_profile =
+                |rustc: &str, suffix: &str| -> anyhow::Result<String> {
+                    let (rustc, rustdoc, cargo, id) = get_local_toolchain(
+                        &profile_kinds,
+                        &rustc,
+                        local.rustdoc.as_deref(),
+                        local.cargo.as_deref(),
+                        local.id.as_deref(),
+                        suffix,
+                    )?;
+                    let compiler = Compiler {
+                        rustc: &rustc,
+                        rustdoc: rustdoc.as_deref(),
+                        cargo: &cargo,
+                        triple: &target_triple,
+                        is_nightly: true,
+                    };
+                    profile(
+                        compiler,
+                        &id,
+                        profiler,
+                        &out_dir,
+                        &benchmarks,
+                        &profile_kinds,
+                        &scenario_kinds,
+                        &mut errors,
+                    );
+                    Ok(id)
                 };
-                profile(
-                    compiler,
-                    id,
-                    profiler,
-                    &out_dir,
-                    &benchmarks,
-                    &profile_kinds,
-                    &scenario_kinds,
-                    &mut errors,
-                );
-            }
 
-            if let Profiler::Cachegrind = profiler {
-                let diffs = generate_cachegrind_diffs(
-                    id1,
-                    id2,
-                    &out_dir,
-                    &benchmarks,
-                    &profile_kinds,
-                    &scenario_kinds,
-                    &mut errors,
-                );
-                if diffs.len() > 1 {
-                    eprintln!("Diffs:");
-                    for diff in diffs {
-                        eprintln!("{}", diff.to_string_lossy());
+            if let Some(rustc2) = rustc2 {
+                let id1 = get_toolchain_and_profile(local.rustc.as_str(), "1")?;
+                let id2 = get_toolchain_and_profile(rustc2.as_str(), "2")?;
+
+                if profiler == Profiler::Cachegrind {
+                    check_installed("valgrind")?;
+                    check_installed("cg_annotate")?;
+                    check_installed("rustfilt")?;
+
+                    let diffs = generate_cachegrind_diffs(
+                        &id1,
+                        &id2,
+                        &out_dir,
+                        &benchmarks,
+                        &profile_kinds,
+                        &scenario_kinds,
+                        &mut errors,
+                    );
+                    if diffs.len() > 1 {
+                        eprintln!("Diffs:");
+                        for diff in diffs {
+                            eprintln!("{}", diff.to_string_lossy());
+                        }
+                    } else if diffs.len() == 1 {
+                        let short = out_dir.join("cgann-diff-latest");
+                        std::fs::copy(&diffs[0], &short).expect("copy to short path");
+                        eprintln!("Original diff at: {}", diffs[0].to_string_lossy());
+                        eprintln!("Short path: {}", short.to_string_lossy());
                     }
-                } else if diffs.len() == 1 {
-                    let short = out_dir.join("cgdiffann-latest");
-                    std::fs::copy(&diffs[0], &short).expect("copy to short path");
-                    eprintln!("Original diff at: {}", diffs[0].to_string_lossy());
-                    eprintln!("Short path: {}", short.to_string_lossy());
                 }
+            } else {
+                get_toolchain_and_profile(local.rustc.as_str(), "")?;
             }
 
             errors.fail_if_nonzero()?;

--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -1099,6 +1099,9 @@ fn main_result() -> anyhow::Result<i32> {
                 };
 
             if let Some(rustc2) = rustc2 {
+                if local.rustc.starts_with('+') && local.rustc == rustc2 && local.id.is_none() {
+                    anyhow::bail!("identical toolchain IDs; use --id to get distinct IDs");
+                }
                 let id1 = get_toolchain_and_profile(local.rustc.as_str(), "1")?;
                 let id2 = get_toolchain_and_profile(rustc2.as_str(), "2")?;
 

--- a/site/static/detailed-query.html
+++ b/site/static/detailed-query.html
@@ -237,8 +237,8 @@
                 ${profile(state.benchmark)} --runs ${scenario_filter(state.scenario)}</code>`;
             if (state.base_commit) {
                 txt += "<br>Local profile (diff): <code>" +
-                    `./target/release/collector diff_local cachegrind
-                +${state.base_commit} +${state.commit} --include ${bench_name(state.benchmark)} --builds
+                    `./target/release/collector profile_local cachegrind
+                +${state.base_commit} --rustc2 +${state.commit} --include ${bench_name(state.benchmark)} --builds
                 ${profile(state.benchmark)} --runs ${scenario_filter(state.scenario)}</code>`;
             }
             document.querySelector("#raw-urls").innerHTML = txt;


### PR DESCRIPTION
The `diff_local` subcommand has a lot in common with `profile_local`,
but also has some unnecessary differences in behaviour, such as not
using an `<ID>` argument. This commit removes `diff_local` and moves the
diff functionality to `profile_local` by adding a single new option to
it, which makes things more consistent and simplifies the code.

The commit also changes the naming of output files, to be more
consistent. For example:

**OLD**

`collector diff_local cachegrind $RUSTC1 $RUSTC2 --builds Check --runs Full`

raw output
- `cgout-after-helloworld-Check-Full`
- `cgout-before-helloworld-Check-Full`

filtered raw output
- `cgfilt-after-helloworld-Check-Full`
- `cgfilt-before-helloworld-Check-Full`

human-readable output
- `cgann-after-helloworld-Check-Full`
- `cgann-before-helloworld-Check-Full`

filtered raw diff
- `cgdiff-before-after-helloworld-Check-Full`

human-readable diff
- `cgann-before-after-helloworld-Check-Full`
- `cgdiffann-latest`

**NEW**

`collector profile_local cachegrind $RUSTC1 MyId --rustc2 $RUSTC2 --builds Check --runs Full`

raw output
- `cgout-MyId1-helloworld-Check-Full`
- `cgout-MyId2-helloworld-Check-Full`

filtered raw output
- `cgfilt-MyId1-helloworld-Check-Full`
- `cgfilt-MyId2-helloworld-Check-Full`

human-readable output
- `cgann-MyId1-helloworld-Check-Full`
- `cgann-MyId2-helloworld-Check-Full`

filtered raw diff
- `cgfilt-diff-MyId1-MyId2-helloworld-Check-Full`

human-readable diff
- `cgann-diff-MyId1-MyId2-helloworld-Check-Full`
- `cgann-diff-latest`

The diff files are named more consistently and the prefixes are more
consistent.

Also, with `diff_local` if you specified a toolchain via a `+abcdef`
revid it would use `abcdef` as the Id instead of `before` or `after`.
When diffing with `profile_local` it now uses `MyId1`/`MyId2`, for
consistency with the non-diff case.

Some of the "is this binary installed?" checks are moved around
so they are only run if necessary.

Finally, this commit documents the new behaviour in the README. (There
was no documentation at all for `diff_local`.) It also documents how
`+`-prefixed `<RUSTC>` options work, something that was also missing
from the docs.