### PR TITLE
fix typo in triage report

### DIFF
--- a/triage/2022-01-25.md
+++ b/triage/2022-01-25.md
@@ -1,6 +1,6 @@
 # 2022-01-26 Triage Log
 
-An awesome week. There was some bits of noise from PR [#91032](https://github.com/rust-lang/rust/issues/93032) that landed and then had to be backed out (and may soon land again), and we continue to wrestle with how to classify which things to include in rollup PR's. But overall there were some very real wins to the compiler's performance, and it is definitely reflected in the [total bootstrap time graph](https://perf.rust-lang.org/bootstrap.html). Great job!
+An awesome week. There was some bits of noise from PR [#91032](https://github.com/rust-lang/rust/issues/91032) that landed and then had to be backed out (and may soon land again), and we continue to wrestle with how to classify which things to include in rollup PR's. But overall there were some very real wins to the compiler's performance, and it is definitely reflected in the [total bootstrap time graph](https://perf.rust-lang.org/bootstrap.html). Great job!
 
 Triage done by **@pnkfelix**.
 Revision range: [7bc7be860f99f4a40d45b0f74e2d01b02e072357..c54dfee65126a0ac385d55389a316e89095a0713](https://perf.rust-lang.org/?start=7bc7be860f99f4a40d45b0f74e2d01b02e072357&end=c54dfee65126a0ac385d55389a316e89095a0713&absolute=false&stat=instructions%3Au)
@@ -21,7 +21,7 @@ Update some rustc dependencies to deduplicate them [#92896](https://github.com/r
 Disable drop range tracking in generators [#93165](https://github.com/rust-lang/rust/issues/93165)
 - Average relevant regression: 284.5%
 - Largest regression in [instruction counts](https://perf.rust-lang.org/compare.html?start=10c4c4afec6dfc483af6efb7019941bab9a51a29&end=d13e8dd41d44a73664943169d5b7fe39b22c449f&stat=instructions:u): 879.2% on `full` builds of `deeply-nested-async check`
-- This regression was expected; it is a result of backing out PR [#91032](https://github.com/rust-lang/rust/issues/93032), which was included in rollup PR [#93138](https://github.com/rust-lang/rust/issues/93138), but was reverted due to correctness concerns (discussed under "Mixed" section below).
+- This regression was expected; it is a result of backing out PR [#91032](https://github.com/rust-lang/rust/issues/91032), which was included in rollup PR [#93138](https://github.com/rust-lang/rust/issues/93138), but was reverted due to correctness concerns (discussed under "Mixed" section below).
 
 Revert "Do not hash leading zero bytes of i64 numbers in Sip128 hasher" [#93014](https://github.com/rust-lang/rust/issues/93014)
 - Average relevant regression: 1.5%


### PR DESCRIPTION
@pnkfelix there was a small typo for the link of PR `#91032`, it was pointing to `#93032`.

I hope my understanding is correct and not the other way around :-)

(kindly reported by @steffahn )