### PR TITLE
Clip 'Fork me on GitHub' buttons

### DIFF
--- a/site/static/bootstrap.html
+++ b/site/static/bootstrap.html
@@ -76,7 +76,7 @@
     <div id="totalChart"></div>
     <div id="as-of"></div>
     <a href="https://github.com/rust-lang-nursery/rustc-perf">
-        <img style="position: absolute; top: 0; right: 0; border: 0;"
+        <img style="position: absolute; top: 0; right: 0; border: 0; clip-path: polygon(8% 0%, 100% 92%, 100% 0%);"
             src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67"
             alt="Fork me on GitHub"
             data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">

--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -529,7 +529,7 @@
     <br>
     <div id="as-of"></div>
     <a href="https://github.com/rust-lang-nursery/rustc-perf">
-        <img style="position: absolute; top: 0; right: 0; border: 0;"
+        <img style="position: absolute; top: 0; right: 0; border: 0; clip-path: polygon(8% 0%, 100% 92%, 100% 0%);"
             src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67"
             alt="Fork me on GitHub"
             data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">

--- a/site/static/index.html
+++ b/site/static/index.html
@@ -86,7 +86,7 @@
     <div id="charts"></div>
     <div id="as-of"></div>
     <a href="https://github.com/rust-lang-nursery/rustc-perf">
-        <img style="position: absolute; top: 0; right: 0; border: 0;"
+        <img style="position: absolute; top: 0; right: 0; border: 0; clip-path: polygon(8% 0%, 100% 92%, 100% 0%);"
             src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67"
             alt="Fork me on GitHub"
             data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">


### PR DESCRIPTION
The site is otherwise unusable on some mobile browsers because the clickable area of the 'Fork me on GitHub' button from https://github.com/rust-lang/rustc-perf/pull/167 completely covers the `instructions:u` dropdown.

<p align="center"><img src="https://user-images.githubusercontent.com/1940490/152903991-2011c0d9-7c0a-4593-a15f-8a0a6c33b951.png" width="30%"></p>

Clickable area before:

![Screenshot from 2022-02-07 18-01-39](https://user-images.githubusercontent.com/1940490/152904022-b4c8c8c1-add8-49f8-bcd9-caf1d2cffbec.png)

Clickable area after:

![Screenshot from 2022-02-07 18-01-49](https://user-images.githubusercontent.com/1940490/152904026-99a7db9e-1199-497d-8634-15c8724ae31e.png)

Switching to https://github.com/simonwhitaker/github-fork-ribbon-css would be a good alternative fix.