### PR TITLE
Remove calcNewSig parameters

### DIFF
--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -133,12 +133,10 @@ pub mod comparison {
     use std::collections::HashMap;
 
     #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-    #[allow(non_snake_case)]
     pub struct Request {
         pub start: Bound,
         pub end: Bound,
         pub stat: String,
-        pub calcNewSig: Option<bool>,
     }
 
     #[derive(Debug, Clone, Serialize)]
@@ -397,11 +395,9 @@ pub mod triage {
     use serde::{Deserialize, Serialize};
 
     #[derive(Debug, Clone, Serialize, Deserialize)]
-    #[allow(non_snake_case)]
     pub struct Request {
         pub start: Bound,
         pub end: Option<Bound>,
-        pub calcNewSig: Option<bool>,
     }
 
     #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -813,13 +813,8 @@
             let values = Object.assign({}, {
                 start: "",
                 end: "",
-                calcNewSig: true,
                 stat: "instructions:u",
             }, state);
-            // Make sure we pass a boolean.
-            if (typeof values.calcNewSig === "string") {
-                values.calcNewSig = values.calcNewSig === "true";
-            }
             makeRequest("/get", values).then(function (data) {
                 app.data = data;
             }).finally(function () {


### PR DESCRIPTION
Simplifies the code by dropping support for calculating significance by the old algorithm (which we've not been using for a while).