### PR TITLE
Avoid sort failure due to NaN comparison

### DIFF
--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -653,8 +653,23 @@
                             b: format(b),
                             percent: 100 * (b - a) / a
                         };
-                    })
-                        .sort((a, b) => Math.abs(b.percent) - Math.abs(a.percent));
+                    }).sort((a, b) => {
+                        let bp = Math.abs(b.percent);
+                        if (Number.isNaN(bp)) {
+                            bp = 0;
+                        }
+                        let ap = Math.abs(a.percent);
+                        if (Number.isNaN(ap)) {
+                            ap = 0;
+                        }
+                        if (bp < ap) {
+                            return -1;
+                        } else if (bp > ap) {
+                            return 1;
+                        } else {
+                            return a.name.localeCompare(b.name);
+                        }
+                    });
                 },
                 before() {
                     if (!this.data) {


### PR DESCRIPTION
Noticed while looking at some bootstrap results that were incorrectly sorted -- this should ensure we always have a good sort order.

(Fixing the NaN presence is a separate problem -- I believe caused by division by zero, but not sure yet).