### PR TITLE
Replace "fork me on github" banner with link

### DIFF
--- a/site/static/bootstrap.html
+++ b/site/static/bootstrap.html
@@ -75,13 +75,9 @@
     <div id="byCrateChart"></div>
     <div id="totalChart"></div>
     <div id="as-of"></div>
-    <a href="https://github.com/rust-lang-nursery/rustc-perf">
-        <img style="position: absolute; top: 0; right: 0; border: 0; clip-path: polygon(8% 0%, 100% 92%, 100% 0%);"
-            src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67"
-            alt="Fork me on GitHub"
-            data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
-    </a>
-
+    <div style="text-align: center;">
+        <a href="https://github.com/rust-lang/rustc-perf">Contribute on GitHub</a>
+    </div>
     <script>
         function tooltipPlugin({ onclick, commits, shiftX = 10, shiftY = 10 }) {
             let tooltipLeftOffset = 0;

--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -528,12 +528,9 @@
     </div>
     <br>
     <div id="as-of"></div>
-    <a href="https://github.com/rust-lang-nursery/rustc-perf">
-        <img style="position: absolute; top: 0; right: 0; border: 0; clip-path: polygon(8% 0%, 100% 92%, 100% 0%);"
-            src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67"
-            alt="Fork me on GitHub"
-            data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
-    </a>
+    <div style="text-align: center;">
+        <a href="https://github.com/rust-lang/rustc-perf">Contribute on GitHub</a>
+    </div>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/msgpack-lite/0.1.26/msgpack.min.js"></script>
     <script src="shared.js"></script>
     <script>

--- a/site/static/dashboard.html
+++ b/site/static/dashboard.html
@@ -20,7 +20,7 @@
     <div id="opt-average-times"></div>
     <div id="as-of"></div>
     <div style="text-align: center;">
-        <a href="https://github.com/rust-lang-nursery/rustc-perf">Contribute on GitHub</a>
+        <a href="https://github.com/rust-lang/rustc-perf">Contribute on GitHub</a>
     </div>
     <script src="shared.js"></script>
     <script>

--- a/site/static/help.html
+++ b/site/static/help.html
@@ -29,7 +29,7 @@
         <a href="status.html">status</a>, <a href="help.html">help</a>.
     </div>
     <div style="text-align: center;">
-        <a href="https://github.com/rust-lang-nursery/rustc-perf">Contribute on GitHub</a>
+        <a href="https://github.com/rust-lang/rustc-perf">Contribute on GitHub</a>
     </div>
     <div class="help-content">
         <h3><b><code>@rust-timer</code> commands</b></h3>

--- a/site/static/status.html
+++ b/site/static/status.html
@@ -32,7 +32,7 @@
     </div>
     <div id="as-of"></div>
     <div style="text-align: center;">
-        <a href="https://github.com/rust-lang-nursery/rustc-perf">Contribute on GitHub</a>
+        <a href="https://github.com/rust-lang/rustc-perf">Contribute on GitHub</a>
     </div>
     <script src="shared.js"></script>
     <script>


### PR DESCRIPTION
The banner makes it impossible to click "status" on mobile.

![Screenshot_20220217-120918](https://user-images.githubusercontent.com/7673145/154585254-f8686461-65c8-487c-9223-480e9677a8cb.png)
