### PR TITLE
Remove unrelated directory from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ target
 /cache/
 /rust.git/
 /rust/
-rust-baseline


### PR DESCRIPTION
This was committed by accident in https://github.com/rust-lang/rustc-perf/pull/1125. Sorry for that.