### PR TITLE
Compare site: Make tooltips fade out properly

### DIFF
--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -158,7 +158,7 @@
             margin-left: -60px;
 
             opacity: 0;
-            transition: opacity 0.3s;
+            transition: opacity 0.3s, visibility 0.3s;
         }
 
         .tooltip:hover .tooltiptext {


### PR DESCRIPTION
Make tooltips fade out properly instead of immediately disappearing. This also makes links in tooltips actually clickable. Fixes #1185 