### PR TITLE
Add `DhatCopy` as a profiler.

### DIFF
--- a/ci/check-profiling.sh
+++ b/ci/check-profiling.sh
@@ -88,6 +88,21 @@ RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=
 test -f results/dhout-Test-helloworld-Check-Full
 grep -q "dhatFileVersion" results/dhout-Test-helloworld-Check-Full
 
+
+# DHAT (copy mode).
+# FIXME: CI currently runs Ubuntu 20.04 LTS, which has a Valgrind that is too
+# old to run with `--mode=copy`. When CI is upgraded to 22.04, uncomment this.
+#RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=debug \
+#    cargo run -p collector --bin collector -- \
+#    profile_local dhat-copy $bindir/rustc \
+#        --id Test \
+#        --profiles Check \
+#        --cargo $bindir/cargo \
+#        --include helloworld \
+#        --scenarios Full
+#test -f results/dhcopy-Test-helloworld-Check-Full
+#grep -q "dhatFileVersion" results/dhcopy-Test-helloworld-Check-Full
+
 # Massif.
 RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=debug \
     cargo run -p collector --bin collector -- \

--- a/collector/README.md
+++ b/collector/README.md
@@ -340,6 +340,15 @@ The mandatory `<PROFILER>` argument must be one of the following.
     run more slowly and increase the size of its data files.
   - **Output**. Raw output is written to files with a `dhout` prefix. Those
     files can be viewed with DHAT's viewer (`dh_view.html`).
+- `dhat-copy`: Profile with DHAT in "copy mode". Requires Valgrind 3.17 or later.
+  - **Purpose**. DHAT's copy mode is good for finding which parts of the code
+    are causing a lot of memory copies. This is relevant if another profiler
+    such as `perf-record` or Cachegrind tell you that functions like `memcpy`
+    or `memmove` are hot (as they often are).
+  - **Slowdown**. Roughly 5--20x.
+  - **Configuration**. Same as for DHAT.
+  - **Output**. Raw output is written to files with a `dhcopy` prefix. Those
+    files can be viewed with DHAT's viewer (`dh_view.html`).
 - `massif`: Profile with
   [Massif](http://valgrind.org/docs/manual/ms-manual.html), a heap profiler.
   - **Purpose**. Massif is designed to give insight into a program's peak

--- a/collector/src/execute.rs
+++ b/collector/src/execute.rs
@@ -181,6 +181,7 @@ pub enum Profiler {
     Cachegrind,
     Callgrind,
     Dhat,
+    DhatCopy,
     Massif,
     Eprintln,
     LlvmLines,
@@ -221,6 +222,7 @@ impl PerfTool {
             | ProfileTool(Cachegrind)
             | ProfileTool(Callgrind)
             | ProfileTool(Dhat)
+            | ProfileTool(DhatCopy)
             | ProfileTool(Massif)
             | ProfileTool(Eprintln)
             | ProfileTool(DepGraph)
@@ -256,6 +258,7 @@ impl PerfTool {
             | ProfileTool(Cachegrind)
             | ProfileTool(Callgrind)
             | ProfileTool(Dhat)
+            | ProfileTool(DhatCopy)
             | ProfileTool(Massif)
             | ProfileTool(MonoItems)
             | ProfileTool(LlvmIr)
@@ -1085,6 +1088,16 @@ impl<'a> Processor for ProfileProcessor<'a> {
                 let dhout_file = filepath(self.output_dir, &out_file("dhout"));
 
                 fs::copy(&tmp_dhout_file, &dhout_file)?;
+            }
+
+            // DHAT (in copy mode) produces (via rustc-fake) a data file called
+            // `dhcopy`. We copy it from the temp dir to the output dir, giving
+            // it a new name in the process.
+            Profiler::DhatCopy => {
+                let tmp_dhcopy_file = filepath(data.cwd.as_ref(), "dhcopy");
+                let dhcopy_file = filepath(self.output_dir, &out_file("dhcopy"));
+
+                fs::copy(&tmp_dhcopy_file, &dhcopy_file)?;
             }
 
             // Massif produces (via rustc-fake) a data file called `msout`. We

--- a/collector/src/rustc-fake.rs
+++ b/collector/src/rustc-fake.rs
@@ -291,6 +291,21 @@ fn main() {
                 assert!(cmd.status().expect("failed to spawn").success());
             }
 
+            "DhatCopy" => {
+                let mut cmd = Command::new("valgrind");
+                determinism_env(&mut cmd);
+                let has_valgrind = cmd.output().is_ok();
+                assert!(has_valgrind);
+                cmd.arg("--tool=dhat")
+                    .arg("--mode=copy")
+                    .arg("--num-callers=4")
+                    .arg("--dhat-out-file=dhcopy")
+                    .arg(&tool)
+                    .args(&args);
+
+                assert!(cmd.status().expect("failed to spawn").success());
+            }
+
             "Massif" => {
                 let mut cmd = Command::new("valgrind");
                 determinism_env(&mut cmd);


### PR DESCRIPTION
This is DHAT running in "copy mode", which profiles `memcpy`/`memmove`
calls instead of allocations. I have found it useful numerous times but
I've always had to invoke it for rustc-perf by just modifying the
existing DHAT invocation. Time to provide an easier way of doing it.