### PR TITLE
Compare site: cache master-branch Rust commits to improve performance

### DIFF
--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -265,8 +265,7 @@ pub struct MasterCommit {
 /// Note that this does not contain try commits today, so it should not be used
 /// to validate hashes or expand them generally speaking. This may also change
 /// in the future.
-pub async fn master_commits() -> Result<Vec<MasterCommit>, Box<dyn std::error::Error + Sync + Send>>
-{
+pub async fn master_commits() -> anyhow::Result<Vec<MasterCommit>> {
     let response = reqwest::get("https://triage.rust-lang.org/bors-commit-list").await?;
     Ok(response.json().await?)
 }

--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -25,9 +25,10 @@ pub async fn handle_triage(
     log::info!("handle_triage({:?})", body);
     let start = body.start;
     let end = body.end;
-    let master_commits = collector::master_commits()
+    ctxt.update_master_commits()
         .await
         .map_err(|e| format!("error retrieving master commit list: {}", e))?;
+    let master_commits = &ctxt.master_commits.load().commits;
 
     let start_artifact = ctxt
         .artifact_id_for_bound(start.clone(), true)
@@ -95,20 +96,22 @@ pub async fn handle_compare(
     ctxt: &SiteCtxt,
 ) -> api::ServerResult<api::comparison::Response> {
     log::info!("handle_compare({:?})", body);
-    let master_commits = collector::master_commits()
+    ctxt.update_master_commits()
         .await
         .map_err(|e| format!("error retrieving master commit list: {}", e))?;
+    let master_commits = &ctxt.master_commits.load().commits;
+
     let end = body.end;
     let comparison =
-        compare_given_commits(body.start, end.clone(), body.stat, ctxt, &master_commits)
+        compare_given_commits(body.start, end.clone(), body.stat, ctxt, master_commits)
             .await
             .map_err(|e| format!("error comparing commits: {}", e))?
             .ok_or_else(|| format!("could not find end commit for bound {:?}", end))?;
 
     let conn = ctxt.conn().await;
-    let prev = comparison.prev(&master_commits);
-    let next = comparison.next(&master_commits);
-    let is_contiguous = comparison.is_contiguous(&*conn, &master_commits).await;
+    let prev = comparison.prev(master_commits);
+    let next = comparison.next(master_commits);
+    let is_contiguous = comparison.is_contiguous(&*conn, master_commits).await;
     let benchmark_map = conn.get_benchmarks().await;
 
     let comparisons = comparison
@@ -455,7 +458,9 @@ pub async fn compare(
     stat: String,
     ctxt: &SiteCtxt,
 ) -> Result<Option<Comparison>, BoxedError> {
-    let master_commits = collector::master_commits().await?;
+    ctxt.update_master_commits().await?;
+    let master_commits = &ctxt.master_commits.load().commits;
+
     compare_given_commits(start, end, stat, ctxt, &master_commits).await
 }
 

--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -25,10 +25,7 @@ pub async fn handle_triage(
     log::info!("handle_triage({:?})", body);
     let start = body.start;
     let end = body.end;
-    ctxt.update_master_commits()
-        .await
-        .map_err(|e| format!("error retrieving master commit list: {}", e))?;
-    let master_commits = &ctxt.master_commits.load().commits;
+    let master_commits = &ctxt.get_master_commits().commits;
 
     let start_artifact = ctxt
         .artifact_id_for_bound(start.clone(), true)
@@ -96,10 +93,7 @@ pub async fn handle_compare(
     ctxt: &SiteCtxt,
 ) -> api::ServerResult<api::comparison::Response> {
     log::info!("handle_compare({:?})", body);
-    ctxt.update_master_commits()
-        .await
-        .map_err(|e| format!("error retrieving master commit list: {}", e))?;
-    let master_commits = &ctxt.master_commits.load().commits;
+    let master_commits = &ctxt.get_master_commits().commits;
 
     let end = body.end;
     let comparison =
@@ -458,10 +452,9 @@ pub async fn compare(
     stat: String,
     ctxt: &SiteCtxt,
 ) -> Result<Option<Comparison>, BoxedError> {
-    ctxt.update_master_commits().await?;
-    let master_commits = &ctxt.master_commits.load().commits;
+    let master_commits = &ctxt.get_master_commits().commits;
 
-    compare_given_commits(start, end, stat, ctxt, &master_commits).await
+    compare_given_commits(start, end, stat, ctxt, master_commits).await
 }
 
 /// Compare two bounds on a given stat

--- a/site/src/load.rs
+++ b/site/src/load.rs
@@ -210,7 +210,7 @@ impl SiteCtxt {
         let conn = self.conn().await;
         let (queued_pr_commits, in_progress_artifacts) =
             futures::join!(conn.queued_commits(), conn.in_progress_artifacts());
-        let master_commits = &self.master_commits.load().commits;
+        let master_commits = &self.get_master_commits().commits;
 
         let index = self.index.load();
         let all_commits = index

--- a/site/src/load.rs
+++ b/site/src/load.rs
@@ -116,14 +116,6 @@ impl MasterCommitCache {
             updated: Instant::now(),
         })
     }
-
-    /// Returns an empty cache that is marked as stale
-    pub fn empty() -> Self {
-        Self {
-            commits: Vec::new(),
-            updated: Instant::now() - std::time::Duration::from_secs(2 * 60),
-        }
-    }
 }
 
 /// Site context object that contains global data
@@ -188,9 +180,7 @@ impl SiteCtxt {
             }
         };
 
-        let master_commits = MasterCommitCache::download()
-            .await
-            .unwrap_or(MasterCommitCache::empty()); // still run the site if we can't get the commits right now
+        let master_commits = MasterCommitCache::download().await?;
 
         Ok(Self {
             config,

--- a/site/src/server.rs
+++ b/site/src/server.rs
@@ -277,8 +277,6 @@ impl Server {
         // Refresh the landing page
         ctxt.landing_page.store(Arc::new(None));
 
-        let _ = ctxt.get_master_commits();
-
         // Spawn off a task to post the results of any commit results that we
         // are now aware of.
         tokio::spawn(async move {

--- a/site/src/server.rs
+++ b/site/src/server.rs
@@ -277,6 +277,8 @@ impl Server {
         // Refresh the landing page
         ctxt.landing_page.store(Arc::new(None));
 
+        let _ = ctxt.update_master_commits().await;
+
         // Spawn off a task to post the results of any commit results that we
         // are now aware of.
         tokio::spawn(async move {

--- a/site/src/server.rs
+++ b/site/src/server.rs
@@ -277,7 +277,7 @@ impl Server {
         // Refresh the landing page
         ctxt.landing_page.store(Arc::new(None));
 
-        let _ = ctxt.update_master_commits().await;
+        let _ = ctxt.get_master_commits();
 
         // Spawn off a task to post the results of any commit results that we
         // are now aware of.


### PR DESCRIPTION
The compare site currently gets the [Bors commit list](https://triage.rust-lang.org/bors-commit-list) over the network for every single request. On my machine, this means a time-to-first-byte of 1.4 seconds (400ms of which is spent parsing JSON) even for comparing just a single benchmark! Caching the parsed result cuts that down to a couple ms. Of course I expect it to matter less in the prod system, but there could still be some nice performance gains here, making browsing the site much more pleasant. 

Some questions where a review would be appreciated:

- Is the general idea ok like this? What changes still need to be made?
- What's the maximum acceptable stale response? I've chosen one minute here.
- Maybe stale responses/premature refreshes can be avoided altogether? I've set the cache to refresh when [perf/onpush](https://perf.rust-lang.org/perf/onpush) is called. Does this happen automatically somewhere? Ideally we would just load the commit data once when it changes.