### PR TITLE
Hide charts with no data in graphs page

### DIFF
--- a/site/src/selector.rs
+++ b/site/src/selector.rs
@@ -473,9 +473,9 @@ impl StatisticSeries {
             .get_pstats(&sids, &aids)
             .await
             .into_iter()
-            .enumerate()
-            .map(|(idx, points)| {
-                let &&(benchmark, profile, scenario, metric) = &statistic_descriptions[idx];
+            .zip(&statistic_descriptions)
+            .filter(|(points, _)| points.iter().any(|value| value.is_some()))
+            .map(|(points, &&(benchmark, profile, scenario, metric))| {
                 SeriesResponse {
                     series: StatisticSeries {
                         artifact_ids: ArtifactIdIter::new(artifact_ids.clone()),


### PR DESCRIPTION
This should hide a chart in the `graphs` page if it has no data at all.