### PR TITLE
Update Rust before building a freshly pulled collector

### DIFF
--- a/collector/collect.sh
+++ b/collector/collect.sh
@@ -32,4 +32,7 @@ while : ; do
 
         target/release/collector bench_next $SITE_URL --self-profile --bench-rustc --db $DATABASE;
         echo finished run at `date`;
+
+        # Wait a little bit before the next run starts.
+        sleep 120
 done

--- a/collector/collect.sh
+++ b/collector/collect.sh
@@ -13,6 +13,10 @@ while : ; do
         # Update and rebuild the collector.
         git pull
         git reset --hard @{upstream}
+
+        # Make sure we have a recent build, so that we can successfully build
+        # the collector.
+        rustup update
         cargo +nightly build --release -p collector
 
         # Install measureme tooling


### PR DESCRIPTION
This ensures that we can seamlessly start using new features, and as such an
updated collector binary. I've already bumped Rust manually but I believe this was
the cause of the failure to update crates to the "primary" category, as the collector
wasn't building.