### PR TITLE
Demote `style-servo` to only run in the "stable" set.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,8 @@ jobs:
     strategy:
       matrix:
         BENCH_INCLUDE_EXCLUDE_OPTS: [
-          "--exclude webrender-wrench,style-servo,cargo",
-          "--include webrender-wrench,style-servo,cargo",
+          "--exclude webrender-wrench,cargo",
+          "--include webrender-wrench,cargo",
         ]
         PROFILES: [
           "Check,Doc,Debug",

--- a/collector/benchmarks/README.md
+++ b/collector/benchmarks/README.md
@@ -39,8 +39,6 @@ They mostly consist of real-world crates.
 - **serde**: A serialization/deserialization crate. Used by many other
   Rust programs.
 - **stm32f4**: A crate that has many thousands of blanket impl blocks.
-- **style-servo**: Servo's `style` crate. A large crate, and one used by
-  Firefox.
 - **syn**: A library for parsing Rust code. An important part of the Rust
   ecosystem.
 - **tokio-webpush-simple**: A simple web server built with tokio. Uses futures
@@ -136,6 +134,7 @@ Rust code being written today.
 - **inflate**: See above.
 - **regex**: See above.
 - **piston-image**: See above.
-- **style-servo**: See above.
+- **style-servo**: An old version of Servo's `style` crate. A large crate, and
+  one used by old versions of Firefox.
 - **syn**: See above.
 - **tokio-webpush-simple**: See above.

--- a/collector/benchmarks/README.md
+++ b/collector/benchmarks/README.md
@@ -7,7 +7,8 @@ The suite changes over time. Sometimes the code for a benchmark is updated, in
 which case a small suffix will be added (starting with "-2", then "-3", and so
 on.)
 
-There are two categories of benchmarks, **Primary** and **Secondary**.
+There are three categories of benchmarks, **Primary**, **Secondary**, and
+**Stable**.
 
 ## Primary
 
@@ -120,3 +121,21 @@ compiler in interesting ways.
 - **wg-grammar**: A parser generator.
   [Stresses](https://github.com/rust-lang/rust/issues/58178) the borrow
   checker's implementation of NLL.
+
+**Stable**
+
+These are benchmarks used in the
+[dashboard](https://perf.rust-lang.org/dashboard.html). They provide the
+longest continuous data set for compiler performance. As a result, they are
+quite old (e.g. 2017 or earlier), and not necessarily reflective of typical
+Rust code being written today.
+
+- **encoding**: See above.
+- **futures**: See above.
+- **html5ever**: See above.
+- **inflate**: See above.
+- **regex**: See above.
+- **piston-image**: See above.
+- **style-servo**: See above.
+- **syn**: See above.
+- **tokio-webpush-simple**: See above.

--- a/collector/benchmarks/encoding/perf-config.json
+++ b/collector/benchmarks/encoding/perf-config.json
@@ -1,5 +1,4 @@
 {
-    "supports_stable": true,
     "touch_file": "src/lib.rs",
-    "category": "primary"
+    "category": "primary-and-stable"
 }

--- a/collector/benchmarks/futures/perf-config.json
+++ b/collector/benchmarks/futures/perf-config.json
@@ -1,4 +1,3 @@
 {
-    "supports_stable": true,
-    "category": "primary"
+    "category": "primary-and-stable"
 }

--- a/collector/benchmarks/html5ever/perf-config.json
+++ b/collector/benchmarks/html5ever/perf-config.json
@@ -1,5 +1,4 @@
 {
-    "supports_stable": true,
     "touch_file": "src/lib.rs",
-    "category": "primary"
+    "category": "primary-and-stable"
 }

--- a/collector/benchmarks/inflate/perf-config.json
+++ b/collector/benchmarks/inflate/perf-config.json
@@ -1,4 +1,3 @@
 {
-    "supports_stable": true,
-    "category": "primary"
+    "category": "primary-and-stable"
 }

--- a/collector/benchmarks/match-stress-exhaustive_patterns/perf-config.json
+++ b/collector/benchmarks/match-stress-exhaustive_patterns/perf-config.json
@@ -1,5 +1,4 @@
 {
-    "supports_stable": false,
     "touch_file": "src/lib.rs",
     "category": "secondary"
 }

--- a/collector/benchmarks/piston-image/perf-config.json
+++ b/collector/benchmarks/piston-image/perf-config.json
@@ -1,5 +1,4 @@
 {
-    "supports_stable": true,
     "runs": 1,
-    "category": "primary"
+    "category": "primary-and-stable"
 }

--- a/collector/benchmarks/regex/perf-config.json
+++ b/collector/benchmarks/regex/perf-config.json
@@ -1,5 +1,4 @@
 {
-    "supports_stable": true,
     "touch_file": "src/lib.rs",
-    "category": "primary"
+    "category": "primary-and-stable"
 }

--- a/collector/benchmarks/style-servo/perf-config.json
+++ b/collector/benchmarks/style-servo/perf-config.json
@@ -4,5 +4,5 @@
     "cargo_toml": "components/style/Cargo.toml",
     "runs": 1,
     "touch_file": "components/style/lib.rs",
-    "category": "primary-and-stable"
+    "category": "stable"
 }

--- a/collector/benchmarks/style-servo/perf-config.json
+++ b/collector/benchmarks/style-servo/perf-config.json
@@ -3,7 +3,6 @@
     "cargo_rustc_opts": "--cap-lints=warn",
     "cargo_toml": "components/style/Cargo.toml",
     "runs": 1,
-    "supports_stable": true,
     "touch_file": "components/style/lib.rs",
-    "category": "primary"
+    "category": "primary-and-stable"
 }

--- a/collector/benchmarks/syn/perf-config.json
+++ b/collector/benchmarks/syn/perf-config.json
@@ -1,5 +1,4 @@
 {
-    "supports_stable": true,
     "touch_file": "src/lib.rs",
-    "category": "primary"
+    "category": "primary-and-stable"
 }

--- a/collector/benchmarks/tokio-webpush-simple/perf-config.json
+++ b/collector/benchmarks/tokio-webpush-simple/perf-config.json
@@ -1,5 +1,4 @@
 {
-    "supports_stable": true,
     "touch_file": "src/main.rs",
-    "category": "primary"
+    "category": "primary-and-stable"
 }

--- a/collector/src/execute.rs
+++ b/collector/src/execute.rs
@@ -4,9 +4,10 @@ use crate::{Compiler, Profile, Scenario};
 use anyhow::{bail, Context};
 use collector::command_output;
 use collector::etw_parser;
-use database::{Category, PatchName, QueryLabel};
+use database::{PatchName, QueryLabel};
 use futures::stream::FuturesUnordered;
 use futures::stream::StreamExt;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::env;
 use std::fmt;
@@ -106,6 +107,57 @@ fn touch_all(path: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, clap::ArgEnum)]
+#[serde(rename_all = "kebab-case")]
+pub enum Category {
+    Primary,
+    Secondary,
+    // FIXME: this should disappear after the 2022 benchmark overhaul is
+    // complete.
+    PrimaryAndStable,
+    Stable,
+}
+
+impl Category {
+    pub fn has_stable(&self) -> bool {
+        match self {
+            Category::Primary | Category::Secondary => false,
+            Category::PrimaryAndStable | Category::Stable => true,
+        }
+    }
+
+    pub fn is_primary_or_secondary(&self) -> bool {
+        match self {
+            Category::Primary | Category::Secondary | Category::PrimaryAndStable => true,
+            Category::Stable => false,
+        }
+    }
+
+    // Within the DB, `Category` is represented in two fields:
+    // - a `supports_stable` bool,
+    // - a `category` which is either "primary" or "secondary".
+    pub fn db_representation(&self) -> (bool, String) {
+        match self {
+            Category::Primary => (false, "primary".to_string()),
+            Category::Secondary => (false, "secondary".to_string()),
+            // These two have the same DB representation, even though they are
+            // treated differently when choosing which benchmarks to run.
+            Category::PrimaryAndStable | Category::Stable => (true, "primary".to_string()),
+        }
+    }
+}
+
+impl fmt::Display for Category {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Category::Primary => f.write_str("primary"),
+            Category::Secondary => f.write_str("secondary"),
+            Category::PrimaryAndStable => f.write_str("primary-and-stable"),
+            Category::Stable => f.write_str("stable"),
+        }
+    }
+}
+
 fn default_runs() -> usize {
     3
 }
@@ -121,8 +173,6 @@ struct BenchmarkConfig {
     disabled: bool,
     #[serde(default = "default_runs")]
     runs: usize,
-    #[serde(default)]
-    supports_stable: bool,
 
     /// The file that should be touched to ensure cargo re-checks the leaf crate
     /// we're interested in. Likely, something similar to `src/lib.rs`. The
@@ -1236,12 +1286,8 @@ impl Benchmark {
         })
     }
 
-    pub fn supports_stable(&self) -> bool {
-        self.config.supports_stable
-    }
-
-    pub fn category(&self) -> &Category {
-        &self.config.category
+    pub fn category(&self) -> Category {
+        self.config.category
     }
 
     #[cfg(windows)]

--- a/collector/src/execute.rs
+++ b/collector/src/execute.rs
@@ -134,21 +134,6 @@ struct BenchmarkConfig {
     category: Category,
 }
 
-impl Default for BenchmarkConfig {
-    fn default() -> BenchmarkConfig {
-        BenchmarkConfig {
-            cargo_opts: None,
-            cargo_rustc_opts: None,
-            cargo_toml: None,
-            disabled: false,
-            runs: default_runs(),
-            supports_stable: false,
-            touch_file: None,
-            category: Category::Secondary,
-        }
-    }
-}
-
 #[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Hash)]
 pub struct BenchmarkName(pub String);
 
@@ -1240,7 +1225,7 @@ impl Benchmark {
             )
             .with_context(|| format!("failed to parse {:?}", config_path))?
         } else {
-            BenchmarkConfig::default()
+            bail!("missing a perf-config.json file for `{}`", name);
         };
 
         Ok(Benchmark {

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -767,38 +767,5 @@ impl fmt::Display for CollectionId {
 #[derive(Debug, Clone, Serialize)]
 pub struct BenchmarkData {
     pub name: String,
-    pub category: Category,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum Category {
-    Primary,
-    Secondary,
-}
-
-impl Default for Category {
-    fn default() -> Self {
-        Self::Secondary
-    }
-}
-
-impl fmt::Display for Category {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Category::Primary => f.write_str("primary"),
-            Category::Secondary => f.write_str("secondary"),
-        }
-    }
-}
-impl std::str::FromStr for Category {
-    type Err = anyhow::Error;
-
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
-        match input {
-            "primary" => Ok(Category::Primary),
-            "secondary" => Ok(Category::Secondary),
-            _ => Err(anyhow::anyhow!("Invalid category {input}")),
-        }
-    }
+    pub category: String,
 }

--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -1,4 +1,4 @@
-use crate::{ArtifactId, ArtifactIdNumber, BenchmarkData, Category};
+use crate::{ArtifactId, ArtifactIdNumber, BenchmarkData};
 use crate::{CollectionId, Index, Profile, QueryDatum, QueuedCommit, Scenario, Step};
 use chrono::{DateTime, Utc};
 use hashbrown::HashMap;
@@ -27,12 +27,7 @@ pub trait Connection: Send + Sync {
     async fn artifact_id(&self, artifact: &ArtifactId) -> ArtifactIdNumber;
     /// None means that the caller doesn't know; it should be left alone if
     /// known or set to false if unknown.
-    async fn record_benchmark(
-        &self,
-        krate: &str,
-        supports_stable: Option<bool>,
-        category: Category,
-    );
+    async fn record_benchmark(&self, krate: &str, supports_stable: Option<bool>, category: String);
     async fn record_statistic(
         &self,
         collection: CollectionId,

--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -1,7 +1,7 @@
 use crate::pool::{Connection, ConnectionManager, ManagedConnection, Transaction};
 use crate::{
-    ArtifactId, ArtifactIdNumber, Benchmark, BenchmarkData, Category, CollectionId, Commit, Date,
-    Index, Profile, QueuedCommit, Scenario,
+    ArtifactId, ArtifactIdNumber, Benchmark, BenchmarkData, CollectionId, Commit, Date, Index,
+    Profile, QueuedCommit, Scenario,
 };
 use anyhow::Context as _;
 use chrono::{DateTime, TimeZone, Utc};
@@ -9,7 +9,6 @@ use hashbrown::HashMap;
 use native_tls::{Certificate, TlsConnector};
 use postgres_native_tls::MakeTlsConnector;
 use std::convert::TryFrom;
-use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio_postgres::GenericClient;
@@ -614,13 +613,9 @@ where
             .await
             .unwrap();
         rows.into_iter()
-            .map(|r| {
-                let name: String = r.get(0);
-                let category: String = r.get(1);
-                BenchmarkData {
-                    name,
-                    category: Category::from_str(&category).unwrap(),
-                }
+            .map(|r| BenchmarkData {
+                name: r.get(0),
+                category: r.get(1),
             })
             .collect()
     }
@@ -995,13 +990,13 @@ where
             .await
             .unwrap();
     }
+
     async fn record_benchmark(
         &self,
         benchmark: &str,
         supports_stable: Option<bool>,
-        category: Category,
+        category: String,
     ) {
-        let category = category.to_string();
         if let Some(r) = self
             .conn()
             .query_opt(

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -1,5 +1,5 @@
 use crate::pool::{Connection, ConnectionManager, ManagedConnection, Transaction};
-use crate::{ArtifactId, Benchmark, BenchmarkData, Category, CollectionId, Commit, Date, Profile};
+use crate::{ArtifactId, Benchmark, BenchmarkData, CollectionId, Commit, Date, Profile};
 use crate::{ArtifactIdNumber, Index, QueryDatum, QueuedCommit};
 use chrono::{DateTime, TimeZone, Utc};
 use hashbrown::HashMap;
@@ -7,7 +7,6 @@ use rusqlite::params;
 use rusqlite::OptionalExtension;
 use std::convert::TryFrom;
 use std::path::PathBuf;
-use std::str::FromStr;
 use std::sync::Mutex;
 use std::sync::Once;
 use std::time::Duration;
@@ -514,7 +513,7 @@ impl Connection for SqliteConnection {
             .query_map([], |row| {
                 Ok(BenchmarkData {
                     name: row.get(0)?,
-                    category: Category::from_str(&row.get::<_, String>(1)?).unwrap(),
+                    category: row.get::<_, String>(1)?,
                 })
             })
             .unwrap();
@@ -889,9 +888,8 @@ impl Connection for SqliteConnection {
         &self,
         benchmark: &str,
         supports_stable: Option<bool>,
-        category: Category,
+        category: String,
     ) {
-        let category = category.to_string();
         if let Some(stable) = supports_stable {
             self.raw_ref()
                 .execute(

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -9,7 +9,7 @@ The following is a glossary of domain specific terminology. Although benchmarks 
 * **scenario**: The scenario under which a user is compiling their code. Currently, this is the incremental cache state and an optional change in the source since last compilation (e.g., full incremental cache and a `println!` statement is added).  
 * **metric**: a name of a quantifiable metric being measured (e.g., instruction count)
 * **artifact**: a specific version of rustc (usually a commit sha or some sort of human readable "tag" like 1.51.0)
-* **category**: a high-level group of benchmarks. Currently, there are two categories, primary (mostly real-world crates) and secondary (mostly stress tests).
+* **category**: a high-level group of benchmarks. Currently, there are three categories, primary (mostly real-world crates), secondary (mostly stress tests), and stable (old real-world crates, only used for the dashboard).
 
 ## Benchmarks
 

--- a/site/src/request_handlers/dashboard.rs
+++ b/site/src/request_handlers/dashboard.rs
@@ -71,9 +71,6 @@ pub async fn handle_dashboard(ctxt: Arc<SiteCtxt>) -> ServerResult<dashboard::Re
         versions
             .into_iter()
             .map(|v| ArtifactId::Tag(v.to_string()))
-            .chain(std::iter::once(
-                ctxt.index.load().commits().last().unwrap().clone().into(),
-            ))
             .collect::<Vec<_>>(),
     );
 


### PR DESCRIPTION
It's the longest-running benchmark in the suite, but doesn't provide results that are all that different to other benchmarks. Plus its importance in the Rust ecosystem is less than it once was. But we keep it as part of the "stable" set to preserve data continuity.

Best reviewed one commit at a time.