### PR TITLE
Use four space indents consistently in all `perf-config.json` files.

### DIFF
--- a/collector/benchmarks/clap-rs/perf-config.json
+++ b/collector/benchmarks/clap-rs/perf-config.json
@@ -1,3 +1,3 @@
 {
-  "category": "primary"
+    "category": "primary"
 }

--- a/collector/benchmarks/helloworld/perf-config.json
+++ b/collector/benchmarks/helloworld/perf-config.json
@@ -1,3 +1,3 @@
 {
-  "category": "primary"
+    "category": "primary"
 }

--- a/collector/benchmarks/keccak/perf-config.json
+++ b/collector/benchmarks/keccak/perf-config.json
@@ -1,3 +1,3 @@
 {
-  "category": "secondary"
+    "category": "secondary"
 }

--- a/collector/benchmarks/unicode_normalization/perf-config.json
+++ b/collector/benchmarks/unicode_normalization/perf-config.json
@@ -1,3 +1,3 @@
 {
-  "category": "primary"
+    "category": "primary"
 }


### PR DESCRIPTION
Note that the files generated by the `download` command use four space
indents.