### PR TITLE
Cache static responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1880,6 +1880,7 @@ dependencies = [
  "tokio",
  "toml",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -2201,6 +2202,15 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+]
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]

--- a/site/Cargo.toml
+++ b/site/Cargo.toml
@@ -44,6 +44,7 @@ tar = "0.4"
 inferno = { version="0.10", default-features = false }
 mime = "0.3"
 prometheus = "0.12"
+uuid = { version = "0.8.2", features = ["v4"] }
 
 [target.'cfg(unix)'.dependencies]
 jemallocator = "0.3"


### PR DESCRIPTION
Allowing the browser to cache responses to requests for static content should save another 200-800ms per page load, depending on connection speed.  

In the first commit, the current git commit id is compiled into the binary and used as an `ETag` header in responses. The browser will cache responses for one minute, after which new requests for the same file will include an `If-None-Match` header with the ETag, to which the server then replies `304 Not Modified` if the ETag matches, instead of resending the file.

On a fast connection, this doesn't save much time though (since the files are small anyway and request time is dominated by time-to-first-byte), which is why the second commit enables non-html content to be cached for longer by introducing versioned file names for cache-busting. To accomplish this, static content is served from memory instead of from disk, and occurrences of the string `{rustc_perf_version}` are replaced with the git commit id.

This could of course still be smarter, i.e. by versioning links with the file hash instead of the git commit id, but I've tried to keep complexity as low as possible while still hopefully gaining a nice speed boost. Please let me know what you think.