### PR TITLE
Demote `tokio-webpush-simple` to run only in the stable set.

### DIFF
--- a/collector/benchmarks/README.md
+++ b/collector/benchmarks/README.md
@@ -41,8 +41,6 @@ They mostly consist of real-world crates.
 - **stm32f4**: A crate that has many thousands of blanket impl blocks.
 - **syn**: A library for parsing Rust code. An important part of the Rust
   ecosystem.
-- **tokio-webpush-simple**: A simple web server built with tokio. Uses futures
-  a lot.
 - **ucd**: A Unicode crate. Contains large statics that
   [stress](https://github.com/rust-lang/rust/issues/53643) the borrow checker's
   implementation of NLL.
@@ -141,4 +139,5 @@ Rust code being written today.
 - **style-servo**: An old version of Servo's `style` crate. A large crate, and
   one used by old versions of Firefox.
 - **syn**: See above.
-- **tokio-webpush-simple**: See above.
+- **tokio-webpush-simple**: A simple web server built with a very old version
+  of tokio. Uses futures a lot, but doesn't use `async`/`await`.

--- a/collector/benchmarks/tokio-webpush-simple/perf-config.json
+++ b/collector/benchmarks/tokio-webpush-simple/perf-config.json
@@ -1,4 +1,4 @@
 {
     "touch_file": "src/main.rs",
-    "category": "primary-and-stable"
+    "category": "stable"
 }


### PR DESCRIPTION
It's old, not that interesting, and not reflective of modern async code.