### PR TITLE
Fix graphs labels

### DIFF
--- a/site/src/selector.rs
+++ b/site/src/selector.rs
@@ -479,8 +479,8 @@ impl StatisticSeries {
                 SeriesResponse {
                     series: StatisticSeries {
                         artifact_ids: ArtifactIdIter::new(artifact_ids.clone()),
-                        points: if metric == *"cpu-clock" {
-                            // Convert to seconds -- perf reports this measurement in
+                        points: if metric == *"cpu-clock" || metric == *"task-clock" {
+                            // Convert to seconds -- perf reports these measurements in
                             // milliseconds
                             points
                                 .into_iter()

--- a/site/static/index.html
+++ b/site/static/index.html
@@ -323,7 +323,7 @@
                     let cacheStateNames = Object.keys(cacheStates);
                     cacheStateNames.sort();
 
-                    let yAxis = "Value";
+                    let yAxis = state.stat;
                     let yAxisUnit = null;
                     if (state.stat == "instructions:u") {
                         yAxis = "CPU instructions";
@@ -332,7 +332,10 @@
                         yAxis = "CPU cycles";
                         yAxisUnit = "count";
                     } else if (state.stat == "cpu-clock") {
-                        yAxis = "CPU time";
+                        yAxis = "CPU clock";
+                        yAxisUnit = "seconds";
+                    } else if (state.stat == "task-clock") {
+                        yAxis = "Task clock";
                         yAxisUnit = "seconds";
                     } else if (state.stat == "wall-time") {
                         yAxis = "Wall time";

--- a/site/static/index.html
+++ b/site/static/index.html
@@ -324,23 +324,33 @@
                     cacheStateNames.sort();
 
                     let yAxis = "Value";
+                    let yAxisUnit = null;
                     if (state.stat == "instructions:u") {
                         yAxis = "Number of CPU instructions";
                     } else if (state.stat == "cycles:u") {
                         yAxis = "Number of CPU cycles";
                     } else if (state.stat == "cpu-clock") {
-                        yAxis = "Wall time execution (seconds)";
+                        yAxis = "Wall time execution";
+                        yAxisUnit = "seconds";
                     } else if (state.stat == "wall-time") {
-                        yAxis = "Wall time execution (seconds)";
+                        yAxis = "Wall time execution";
+                        yAxisUnit = "seconds";
                     } else if (state.stat == "max-rss") {
-                        yAxis = "Maximum resident set size (kb)";
+                        yAxis = "Maximum resident set size";
+                        yAxisUnit = "kb";
                     } else if (state.stat == "faults") {
                         yAxis = "Faults";
                     }
-                    if (!state.absolute) {
-                        yAxis = "% change from baseline";
+
+                    if (state.kind == "raw" && benchName == "Summary") {
+                        yAxisUnit = "relative";
+                    } else if (state.kind == "percentfromfirst") {
+                        yAxisUnit = "% change from baseline";
+                    } else if (state.kind == "percentrelative") {
+                        yAxisUnit = "% change from previous";
                     }
 
+                    yAxis = yAxisUnit ? `${yAxis} (${yAxisUnit})` : yAxis;
                     let yAxisLabel = i == 0 ? yAxis : null;
 
                     let seriesOpts = [{}];

--- a/site/static/index.html
+++ b/site/static/index.html
@@ -326,26 +326,29 @@
                     let yAxis = "Value";
                     let yAxisUnit = null;
                     if (state.stat == "instructions:u") {
-                        yAxis = "Number of CPU instructions";
+                        yAxis = "CPU instructions";
+                        yAxisUnit = "count";
                     } else if (state.stat == "cycles:u") {
-                        yAxis = "Number of CPU cycles";
+                        yAxis = "CPU cycles";
+                        yAxisUnit = "count";
                     } else if (state.stat == "cpu-clock") {
-                        yAxis = "Wall time execution";
+                        yAxis = "CPU time";
                         yAxisUnit = "seconds";
                     } else if (state.stat == "wall-time") {
-                        yAxis = "Wall time execution";
+                        yAxis = "Wall time";
                         yAxisUnit = "seconds";
                     } else if (state.stat == "max-rss") {
                         yAxis = "Maximum resident set size";
-                        yAxisUnit = "kb";
+                        yAxisUnit = "kB";
                     } else if (state.stat == "faults") {
                         yAxis = "Faults";
+                        yAxisUnit = "count";
                     }
 
                     if (state.kind == "raw" && benchName == "Summary") {
                         yAxisUnit = "relative";
                     } else if (state.kind == "percentfromfirst") {
-                        yAxisUnit = "% change from baseline";
+                        yAxisUnit = "% change from first";
                     } else if (state.kind == "percentrelative") {
                         yAxisUnit = "% change from previous";
                     }


### PR DESCRIPTION
The graphs page selects the axis label based on `state.absolute`, but at some point that went away, so the label always reads "% change from baseline", even when absolute values are shown. I've changed it to select based on `state.kind`, and did some other stuff along the way:
* cpu-clock now labeled as "CPU time" instead of "Wall time execution"
* wall-time now just "Wall time" instead of "Wall time execution"
* "Number of" replaced by "(count)"
* max-rss unit changed to "kB" instead of "kb", which could be misunderstood to mean "kilobit"
* "baseline" clarified as "first"

Some of these are also partly because uPlot doesn't support multi-line axis labels (see: https://github.com/leeoniya/uPlot/issues/675), so I tried to make them a bit shorter to fit better.