### PR TITLE
Move the `piston-image` benchmark from primary to stable

### DIFF
--- a/collector/benchmarks/README.md
+++ b/collector/benchmarks/README.md
@@ -34,7 +34,6 @@ They mostly consist of real-world crates.
 - **image-0.24.1**: Basic image processing functions and methods for 
   converting to and from various image formats. Used often in graphics 
   programming.
-- **piston-image**: A modular game engine. An interesting Rust program.
 - **regex-1.5.5**: A regular expression parser. Used by many Rust programs.
 - **ripgrep-13.0.0**: A line-oriented search tool. A widely-used utility.
 - **serde**: A serialization/deserialization crate. Used by many other
@@ -138,7 +137,7 @@ Rust code being written today.
   a very large function containing many locals and basic blocks, similar to
   `keccak` but less extreme.
 - **regex**: See above. This is an older version of the crate.
-- **piston-image**: See above.
+- **piston-image**: See above. This is an older version of the `image` crate.
 - **style-servo**: An old version of Servo's `style` crate. A large crate, and
   one used by old versions of Firefox.
 - **syn**: See above.

--- a/collector/benchmarks/piston-image/perf-config.json
+++ b/collector/benchmarks/piston-image/perf-config.json
@@ -1,4 +1,4 @@
 {
     "runs": 1,
-    "category": "primary-and-stable"
+    "category": "stable"
 }


### PR DESCRIPTION
`image-0.24.1` is now a primary benchmark, and so we can move `piston-image` to just be a stable benchmark. 