### PR TITLE
Move `regex` to stable category

### DIFF
--- a/collector/benchmarks/regex/perf-config.json
+++ b/collector/benchmarks/regex/perf-config.json
@@ -1,4 +1,4 @@
 {
     "touch_file": "src/lib.rs",
-    "category": "primary-and-stable"
+    "category": "stable"
 }


### PR DESCRIPTION
All other references to `regex` have been updated as a part of #1231. 