### PR TITLE
Use a summary table for PR comments

### DIFF
--- a/collector/src/category.rs
+++ b/collector/src/category.rs
@@ -1,0 +1,49 @@
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, clap::ArgEnum)]
+#[serde(rename_all = "kebab-case")]
+pub enum Category {
+    Primary,
+    Secondary,
+    Stable,
+}
+
+impl Category {
+    pub fn is_stable(self) -> bool {
+        self == Category::Stable
+    }
+
+    pub fn is_primary_or_secondary(self) -> bool {
+        self == Category::Primary || self == Category::Secondary
+    }
+
+    // Within the DB, `Category` is represented in two fields:
+    // - a `supports_stable` bool,
+    // - a `category` which is either "primary" or "secondary".
+    pub fn db_representation(self) -> (bool, String) {
+        match self {
+            Category::Primary => (false, "primary".to_string()),
+            Category::Secondary => (false, "secondary".to_string()),
+            Category::Stable => (true, "primary".to_string()),
+        }
+    }
+
+    pub fn from_db_representation(text: &str) -> anyhow::Result<Self> {
+        match text {
+            "primary" => Ok(Self::Primary),
+            "secondary" => Ok(Self::Secondary),
+            _ => Err(anyhow::anyhow!("Unknown category {text}")),
+        }
+    }
+}
+
+impl fmt::Display for Category {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Category::Primary => f.write_str("primary"),
+            Category::Secondary => f.write_str("secondary"),
+            Category::Stable => f.write_str("stable"),
+        }
+    }
+}

--- a/collector/src/execute.rs
+++ b/collector/src/execute.rs
@@ -2,12 +2,12 @@
 
 use crate::{Compiler, Profile, Scenario};
 use anyhow::{bail, Context};
+use collector::category::Category;
 use collector::command_output;
 use collector::etw_parser;
 use database::{PatchName, QueryLabel};
 use futures::stream::FuturesUnordered;
 use futures::stream::StreamExt;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::env;
 use std::fmt;
@@ -105,45 +105,6 @@ fn touch_all(path: &Path) -> anyhow::Result<()> {
     }
 
     Ok(())
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, clap::ArgEnum)]
-#[serde(rename_all = "kebab-case")]
-pub enum Category {
-    Primary,
-    Secondary,
-    Stable,
-}
-
-impl Category {
-    pub fn is_stable(self) -> bool {
-        self == Category::Stable
-    }
-
-    pub fn is_primary_or_secondary(self) -> bool {
-        self == Category::Primary || self == Category::Secondary
-    }
-
-    // Within the DB, `Category` is represented in two fields:
-    // - a `supports_stable` bool,
-    // - a `category` which is either "primary" or "secondary".
-    pub fn db_representation(self) -> (bool, String) {
-        match self {
-            Category::Primary => (false, "primary".to_string()),
-            Category::Secondary => (false, "secondary".to_string()),
-            Category::Stable => (true, "primary".to_string()),
-        }
-    }
-}
-
-impl fmt::Display for Category {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Category::Primary => f.write_str("primary"),
-            Category::Secondary => f.write_str("secondary"),
-            Category::Stable => f.write_str("stable"),
-        }
-    }
 }
 
 fn default_runs() -> usize {

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -6,6 +6,7 @@ use std::fmt;
 use std::process::{self, Command};
 
 pub mod api;
+pub mod category;
 pub mod etw_parser;
 mod read2;
 pub mod self_profile;

--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -2,6 +2,7 @@
 
 use anyhow::{bail, Context};
 use clap::Parser;
+use collector::category::Category;
 use database::{ArtifactId, Commit};
 use log::debug;
 use std::collections::HashSet;
@@ -18,7 +19,7 @@ use tokio::runtime::Runtime;
 mod execute;
 mod sysroot;
 
-use execute::{BenchProcessor, Benchmark, BenchmarkName, Category, ProfileProcessor, Profiler};
+use execute::{BenchProcessor, Benchmark, BenchmarkName, ProfileProcessor, Profiler};
 use sysroot::Sysroot;
 
 #[derive(Debug, Copy, Clone)]


### PR DESCRIPTION
This PR implements a new design for reporting performance summaries on PRs.

It looks something like this:
| | Regressions 😿 <br />(primary) | Regressions 😿 <br />(secondary) | Improvements 🎉 <br />(primary) | Improvements 🎉 <br />(secondary) | All 😿 🎉 <br />(primary) |
|:---:|:---:|:---:|:---:|:---:|:---:|
| count[^1] | 2 | 1 | 2 | 1 | 4 |
| mean[^2] | 150.0% | 100.0% | -62.5% | -66.7% | 43.8% |
| max | 200.0% | 100.0% | -75.0% | -66.7% | 200.0% |

[^1]: *number of relevant changes*
[^2]: *the arithmetic mean of the percent change*

Should the table also be used in the weekly triage or not? (will be left for another PR).

Closes: https://github.com/rust-lang/rustc-perf/issues/1214