### PR TITLE
Move syn from primary-and-stable to stable

### DIFF
--- a/collector/benchmarks/syn/perf-config.json
+++ b/collector/benchmarks/syn/perf-config.json
@@ -1,4 +1,4 @@
 {
     "touch_file": "src/lib.rs",
-    "category": "primary-and-stable"
+    "category": "stable"
 }


### PR DESCRIPTION
The readme was already updated in #1240 to reflect this. 