### PR TITLE
Comparison page table tweaks and fixes

### DIFF
--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -219,7 +219,7 @@
         }
 
         .benches th {
-            text-align: left;
+            text-align: center;
             word-break: break-word;
             width: 25%;
             min-width: 50px;

--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -554,14 +554,18 @@
                 :cases="testCases.filter(c => c.category === 'primary')"
                 :show-raw-data="showRawData"
                 :commit-a="data.a.commit"
-                :commit-b="data.b.commit"></test-cases-table>
+                :commit-b="data.b.commit"
+                :before="before"
+                :after="after"></test-cases-table>
             <hr />
             <test-cases-table
                 title="Secondary"
                 :cases="testCases.filter(c => c.category === 'secondary')"
                 :show-raw-data="showRawData"
                 :commit-a="data.a.commit"
-                :commit-b="data.b.commit"></test-cases-table>
+                :commit-b="data.b.commit"
+                :before="before"
+                :after="after"></test-cases-table>
             <br />
             <hr />
             <div>
@@ -631,7 +635,7 @@
             }
         });
         Vue.component('test-cases-table', {
-            props: ['cases', 'showRawData', 'commitA', 'commitB', 'title'],
+            props: ['cases', 'showRawData', 'commitA', 'commitB', 'before', 'after', 'title'],
             methods: {
                 detailedQueryLink(commit, testCase) {
                     return `/detailed-query.html?commit=${commit}&benchmark=${testCase.benchmark + "-" + testCase.profile}&scenario=${testCase.scenario}`;
@@ -664,8 +668,8 @@
                     </span>
                 </span>
             </th>
-            <th v-if="showRawData">{{before}}</th>
-            <th v-if="showRawData">{{after}}</th>
+            <th v-if="showRawData">{{ before }}</th>
+            <th v-if="showRawData">{{ after }}</th>
         </tr>
     </thead>
     <tbody>

--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -220,7 +220,6 @@
 
         .benches th {
             text-align: center;
-            word-break: break-word;
             width: 25%;
             min-width: 50px;
         }


### PR DESCRIPTION
This fixes two issues in the comparison page:
* The headings for the table weren't centered but the data was. It looks off IMO
* The labels for the raw data columns were not rendering correctly.

### Before
![image](https://user-images.githubusercontent.com/1327285/160400136-9fd0d1e6-5664-40da-ae57-7c1dd7964bc7.png)

### After
![image](https://user-images.githubusercontent.com/1327285/160399992-cc70f6d4-fde9-4764-93e8-afab17632f82.png)
