### PR TITLE
Use a separate column for benchmark profile in compare page

### DIFF
--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -930,7 +930,8 @@
 <table v-else class="benches compare">
     <thead>
         <tr>
-            <th>Benchmark & Profile</th>
+            <th>Benchmark</th>
+            <th>Profile</th>
             <th>Scenario</th>
             <th>% Change</th>
             <th>
@@ -951,7 +952,8 @@
     <tbody>
         <template v-for="testCase in cases">
             <tr>
-                <td>{{ testCase.benchmark }} {{ testCase.profile }}</td>
+                <td>{{ testCase.benchmark }}</td>
+                <td>{{ testCase.profile }}</td>
                 <td>{{ testCase.scenario }}</td>
                 <td>
                     <a v-bind:href="percentLink(commitB, commitA, testCase)">


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/4539057/160595674-4e76eaf0-9dbd-4528-888f-e4c131187666.png)

After:
![image](https://user-images.githubusercontent.com/4539057/160595552-38ee9441-cd52-4e75-a7ed-279815f7ab25.png)