### PR TITLE
Align numeric columns to right in compare table

### DIFF
--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -206,11 +206,11 @@
             height: 10px;
         }
 
-        #content td {
+        #bootstrap th {
             text-align: center;
         }
 
-        #bootstrap th {
+        #bootstrap td {
             text-align: center;
         }
 
@@ -227,9 +227,12 @@
             width: 25%;
             min-width: 50px;
         }
-
-        .benches th+td {
+        .benches td {
+            text-align: center;
             width: 25%;
+        }
+        .benches td.numeric {
+            text-align: right;
         }
 
         .benchmark-name {
@@ -1053,12 +1056,12 @@
                 <td>
                     {{ testCase.significanceFactor ? testCase.significanceFactor.toFixed(2) + "x" : "-" }}
                 </td>
-                <td v-if="showRawData">
+                <td v-if="showRawData" class="numeric">
                   <a v-bind:href="detailedQueryLink(commitA, testCase)">
                     <abbr :title="testCase.datumA">{{ testCase.datumA.toFixed(2) }}</abbr>
                   </a>
                 </td>
-                <td v-if="showRawData">
+                <td v-if="showRawData" class="numeric">
                   <a v-bind:href="detailedQueryLink(commitB, testCase)">
                     <abbr :title="testCase.datumB">{{ testCase.datumB.toFixed(2) }}</abbr>
                   </a>


### PR DESCRIPTION
Continuation of https://github.com/rust-lang/rustc-perf/pull/1254.
![image](https://user-images.githubusercontent.com/4539057/160781286-20d4d984-7d24-4ecf-92e2-39b63b7f5a50.png)
![image](https://user-images.githubusercontent.com/4539057/160781309-cef04faf-d084-4e30-9ae7-108576583305.png)

The `% Change` header looks a bit weird. This is how it looks right aligned:
![image](https://user-images.githubusercontent.com/4539057/160781474-3dc893e7-5464-4539-8854-153f4be7b6b9.png)

`#content td` was removed, since it was overwriting specificity of other rules and it was only really used in benches and bootstrap (there is no other `<td>`).