### PR TITLE
Switch the `stm32f4` benchmark to a quicker default feature

### DIFF
--- a/collector/benchmarks/README.md
+++ b/collector/benchmarks/README.md
@@ -38,6 +38,8 @@ They mostly consist of real-world crates.
 - **serde-1.0.136**: A serialization/deserialization crate. Used by many other
   Rust programs.
 - **stm32f4-0.14.0**: A crate that has many thousands of blanket impl blocks.
+  It uses cargo features to enable large portions of its structure and is
+  built with `--features stm32f410` to have faster benchmarking times.
 - **syn-1.0.89**: A library for parsing Rust code. An important part of the Rust
   ecosystem.
 - **unicode-normalization-0.1.19**: Unicode character composition and decomposition

--- a/collector/benchmarks/stm32f4-0.14.0/perf-config.json
+++ b/collector/benchmarks/stm32f4-0.14.0/perf-config.json
@@ -1,4 +1,4 @@
 {
-  "cargo_opts": "--features=stm32f405",
+  "cargo_opts": "--features=stm32f410",
   "category": "primary"
 }


### PR DESCRIPTION
As [mentioned on zulip](https://rust-lang.zulipchat.com/#narrow/stream/247081-t-compiler.2Fperformance/topic/Time.20for.20secondary.20benchmarks/near/277067707), the current `stm32f4` rustdoc benchmark takes around 10 minutes.

The crate is divided into many features to selectively enable which hardware it targets, and switching from `stm32f405` to `stm32f410` roughly halves the amount of code to compile, and more importantly also halves the time it takes to run the benchmark for me. 

Changing this thing after the crate has been benchmarked for a few days is likely going to look weird on graphs, the weekly report, and perfbot runs. Reducing the time this benchmark takes is probably worth this one-time annoyance.