### PR TITLE
Refactor handling of historical data

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -35,11 +35,10 @@ The following is a glossary of domain specific terminology. Although benchmarks 
 ## Analysis
 
 * **test result delta**: the difference between two test results for the same metric and test case.
-* **significant test result delta**: a test result delta that is above some threshold that we have determined to be an actual change in performance and not noise. 
-* **noisy test case**: a test case for which the non-significant test result deltas are on average above some threshold. Non-noisy data tends to be very close to zero, and so a test case that produces non-significant test result deltas that are not close enough to zero on average are classified as noisy.
+* **significance threshold**: the threshold at which a test result delta is considered "significant" (i.e., a real change in performance and not just noise). This is calculated using some statistical measure (see the code for how this is currently being done).
+* **significant test result delta**: a test result delta above the significance threshold.
+* **dodgy test case**: a test case for which the significance threshold is significantly large indicating a high amount of variability in the test and thus making it necessary to be somewhat skeptical of any results too close to the significance threshold.
 * **relevant test result delta**: a synonym for *significant test result delta* in situations where the term "significant" might be ambiguous and readers may potentially interpret *significant* as "large" or "statistically significant". For example, in try run results, we use the term relevant instead of significant.
-* **highly variable test case**: a test case that frequently produces (over some threshold) significant test result deltas. This differs from sensitive benchmarks in that the deltas aren't necessarily large, they just happen more frequently than one would expect, and it is unclear why the significant deltas are happening. Note: highly variable test cases can be classified as noisy. They are different from classically noisy benchmarks in that they often produce deltas that are above the significance threshold. We cannot therefore be 100% if they are variable because they are noisy or because parts of the compiler being exercised by these benchmarks are just being changed very often. 
-* **highly sensitive benchmark**: a test case that tends to produce large (over some threshold) significant test result deltas. This differs from highly variable test cases in that it is usually clear what type of changes tend to result in significant test result deltas. For example, some of the stress tests are highly sensitive; they produce significant test result deltas when parts of the compiler that they are stressing change and the percentage change is typically quite large. 
 
 ## Other 
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -35,8 +35,8 @@ The following is a glossary of domain specific terminology. Although benchmarks 
 ## Analysis
 
 * **test result delta**: the difference between two test results for the same metric and test case.
-* **significance threshold**: the threshold at which a test result delta is considered "significant" (i.e., a real change in performance and not just noise). This is calculated using some statistical measure (see the code for how this is currently being done).
-* **significant test result delta**: a test result delta above the significance threshold.
+* **significance threshold**: the threshold at which a test result delta is considered "significant" (i.e., a real change in performance and not just noise). This is calculated using [the upper IQR fence](https://www.statisticshowto.com/upper-and-lower-fences/#:~:text=Upper%20and%20lower%20fences%20cordon,%E2%80%93%20(1.5%20*%20IQR)) as seen [here](https://github.com/rust-lang/rustc-perf/blob/8ba845644b4cfcffd96b909898d7225931b55557/site/src/comparison.rs#L935-L941).
+* **significant test result delta**: a test result delta above the significance threshold. Significant test result deltas can be thought of as "statistically significant".
 * **dodgy test case**: a test case for which the significance threshold is significantly large indicating a high amount of variability in the test and thus making it necessary to be somewhat skeptical of any results too close to the significance threshold.
 * **relevant test result delta**: a synonym for *significant test result delta* in situations where the term "significant" might be ambiguous and readers may potentially interpret *significant* as "large" or "statistically significant". For example, in try run results, we use the term relevant instead of significant.
 


### PR DESCRIPTION
This refactor came from realizing that we weren't using the `BenchmarkVarianceDescription` at all and that what we were calling `BenchmarkVariances` is actually just historical data we use for many different calculations (some related to variance and others not). 

We now more appropriately label this data as "historical" which makes the code much easier to read. 

I also updated the glossary to remove terms for concepts we don't use any more and added terms for things we do use. 