### PR TITLE
Add missing newline and remove duplicate header from PR summary

### DIFF
--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -706,11 +706,12 @@ async fn categorize_benchmark(
         generate_short_summary(secondary.as_ref(), is_master_commit);
 
     let mut result = format!(
-        r#"Summary:
+        r#"
 - Primary benchmarks: {primary_short_summary}
 - Secondary benchmarks: {secondary_short_summary}
 "#
     );
+    write!(result, "\n\n").unwrap();
 
     let (primary, secondary) = (
         primary.unwrap_or_else(|| ComparisonSummary::empty()),


### PR DESCRIPTION
Fixes [this](https://github.com/rust-lang/rust/pull/95171#issuecomment-1085849415).

I'm pretty sure that the main problem was missing newline after the short summary.