### PR TITLE
Do not post summary table to PR if both categories are not relevant

### DIFF
--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -713,11 +713,13 @@ async fn categorize_benchmark(
     );
     write!(result, "\n\n").unwrap();
 
-    let (primary, secondary) = (
-        primary.unwrap_or_else(|| ComparisonSummary::empty()),
-        secondary.unwrap_or_else(|| ComparisonSummary::empty()),
-    );
-    write_summary_table(&primary, &secondary, &mut result);
+    if primary_direction.is_some() || secondary_direction.is_some() {
+        let (primary, secondary) = (
+            primary.unwrap_or_else(|| ComparisonSummary::empty()),
+            secondary.unwrap_or_else(|| ComparisonSummary::empty()),
+        );
+        write_summary_table(&primary, &secondary, &mut result);
+    }
 
     write!(result, "\n{}", DISAGREEMENT).unwrap();
 


### PR DESCRIPTION
Without this check, something like [this](https://github.com/rust-lang/rust/pull/95509#issuecomment-1086594868) could happen, which seems confusing to readers. Nothing was relevant, yet the table was shown.