### PR TITLE
Improve summary table and GitHub messaging

### DIFF
--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -155,7 +155,7 @@ async fn populate_report(
                     .entry(confidence.is_definitely_relevant().then(|| direction))
                     .or_default();
 
-                entry.push(write_summary(ctxt, comparison).await)
+                entry.push(write_triage_summary(ctxt, comparison).await)
             }
         }
     }
@@ -372,7 +372,7 @@ impl ComparisonSummary {
     }
 }
 
-async fn write_summary(ctxt: &SiteCtxt, comparison: &Comparison) -> String {
+async fn write_triage_summary(ctxt: &SiteCtxt, comparison: &Comparison) -> String {
     use std::fmt::Write;
     let mut result = if let Some(pr) = comparison.b.pr {
         let title = github::pr_title(pr).await;
@@ -393,7 +393,7 @@ async fn write_summary(ctxt: &SiteCtxt, comparison: &Comparison) -> String {
     let primary = primary.unwrap_or_else(ComparisonSummary::empty);
     let secondary = secondary.unwrap_or_else(ComparisonSummary::empty);
 
-    write_summary_table(&primary, &secondary, &mut result);
+    write_summary_table(&primary, &secondary, false, &mut result);
 
     result
 }
@@ -402,6 +402,7 @@ async fn write_summary(ctxt: &SiteCtxt, comparison: &Comparison) -> String {
 pub fn write_summary_table(
     primary: &ComparisonSummary,
     secondary: &ComparisonSummary,
+    with_footnotes: bool,
     result: &mut String,
 ) {
     use std::fmt::Write;
@@ -421,7 +422,8 @@ pub fn write_summary_table(
     .unwrap();
     writeln!(
         result,
-        "| count[^1] | {} | {} | {} | {} | {} |",
+        "| count{} | {} | {} | {} | {} | {} |",
+        if with_footnotes { "[^1]" } else { "" },
         primary.num_regressions,
         secondary.num_regressions,
         primary.num_improvements,
@@ -432,7 +434,8 @@ pub fn write_summary_table(
 
     writeln!(
         result,
-        "| mean[^2] | {} | {} | {} | {} | {} |",
+        "| mean{} | {} | {} | {} | {} | {} |",
+        if with_footnotes { "[^2]" } else { "" },
         render_stat(primary.num_regressions, || Some(
             primary.arithmetic_mean_of_regressions()
         )),
@@ -511,13 +514,15 @@ pub fn write_summary_table(
         .unwrap();
     }
 
-    writeln!(
-        result,
-        r#"
+    if with_footnotes {
+        writeln!(
+            result,
+            r#"
 [^1]: *number of relevant changes*
 [^2]: *the arithmetic mean of the percent change*"#
-    )
-    .unwrap();
+        )
+        .unwrap();
+    }
 }
 
 /// The amount of confidence we have that a comparison actually represents a real
@@ -1275,15 +1280,12 @@ fn compare_link(start: &ArtifactId, end: &ArtifactId) -> String {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     use collector::category::Category;
     use std::collections::HashSet;
 
     use database::{ArtifactId, Profile, Scenario};
-
-    use crate::comparison::{
-        write_summary_table, ArtifactDescription, Comparison, ComparisonSummary,
-        TestResultComparison,
-    };
 
     #[test]
     fn summary_table_only_regressions_primary() {
@@ -1487,7 +1489,7 @@ mod tests {
         let secondary = create_summary(secondary_statistics);
 
         let mut result = String::new();
-        write_summary_table(&primary, &secondary, &mut result);
+        write_summary_table(&primary, &secondary, true, &mut result);
         assert_eq!(result, expected);
     }
 

--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -755,7 +755,7 @@ pub struct Comparison {
     pub b: ArtifactDescription,
     /// Statistics based on test case
     pub statistics: HashSet<TestResultComparison>,
-    /// A map from benchmark name to an error which occured when building `b` but `a`.
+    /// A map from benchmark name to an error which occured when building `b` but not `a`.
     pub new_errors: HashMap<String, String>,
 }
 

--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -320,6 +320,10 @@ impl ComparisonSummary {
         self.comparisons.is_empty()
     }
 
+    pub fn errors_in(&self) -> &[String] {
+        &self.errors_in
+    }
+
     fn arithmetic_mean<'a>(
         &'a self,
         changes: impl Iterator<Item = &'a TestResultComparison>,
@@ -499,20 +503,6 @@ pub fn write_summary_table(
         largest_change
     )
     .unwrap();
-
-    if !primary.errors_in.is_empty() {
-        write!(
-            result,
-            "\nThe following benchmark(s) failed to build:\n{}\n",
-            primary
-                .errors_in
-                .iter()
-                .map(|benchmark| format!("- {benchmark}"))
-                .collect::<Vec<_>>()
-                .join("\n")
-        )
-        .unwrap();
-    }
 
     if with_footnotes {
         writeln!(

--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -700,7 +700,7 @@ async fn categorize_benchmark(
             primary.unwrap_or_else(|| ComparisonSummary::empty()),
             secondary.unwrap_or_else(|| ComparisonSummary::empty()),
         );
-        write_summary_table(&primary, &secondary, &mut result);
+        write_summary_table(&primary, &secondary, true, &mut result);
     }
 
     write!(result, "\n{}", DISAGREEMENT).unwrap();

--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -761,7 +761,7 @@ fn generate_short_summary(
             } else {
                 (
                     format!(
-                        "no relevant changes found. {} results were found to be statistically significant but too small to be relevant.",
+                        "changes not relevant. {} results were found to be statistically significant but the changes were too small to be relevant.",
                         summary.num_significant_changes(),
                     ),
                     None

--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -701,6 +701,24 @@ async fn categorize_benchmark(
             secondary.unwrap_or_else(|| ComparisonSummary::empty()),
         );
         write_summary_table(&primary, &secondary, true, &mut result);
+
+        if !primary.errors_in().is_empty() || !secondary.errors_in().is_empty() {
+            let list_errored_benchmarks = |summary: ComparisonSummary| {
+                summary
+                    .errors_in()
+                    .iter()
+                    .map(|benchmark| format!("- {benchmark}"))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            };
+            write!(
+                result,
+                "\nThe following benchmark(s) failed to build:\n{}{}\n",
+                list_errored_benchmarks(primary),
+                list_errored_benchmarks(secondary)
+            )
+            .unwrap();
+        }
     }
 
     write!(result, "\n{}", DISAGREEMENT).unwrap();


### PR DESCRIPTION
This includes several small tweaks:
* Don't include footnotes defining terms in the triage report. Overall, it looks off, and if we decide we really need to define terms we should do it once per triage report.
* Only show errored benchmark runs in the GitHub message (it's not really relevant for the triage report). 
* Show both primary and secondary benchmarks that error (we were previously only showing primary).
* Tweak the GitHub message when there are not enough changes to be significant. It is possible that there are individual changes that on their own are deemed relevant, but the comparison as a whole isn't relevant. The new messaging makes this a bit clearer by saying the "changes [are] not relevant" (i.e., point to the whole) rather than "no relevant changes". 