### PR TITLE
Make `--include` and `--exclude` use exact matching.

### DIFF
--- a/collector/README.md
+++ b/collector/README.md
@@ -109,15 +109,15 @@ The following options alter the behaviour of the `bench_local` subcommand.
   supports postgres as a backend and the URL can be specified (beginning with
   `postgres://`), but this is unlikely to be useful for local collection.
 - `--exclude <EXCLUDE>`: this is used to run a subset of the benchmarks. The
-  argument is a comma-separated list of benchmark names. When this option is
-  specified, a benchmark is excluded from the run if its name matches one or
-  more of the given names.
+  argument is a comma-separated list of benchmark prefixes. When this option is
+  specified, a benchmark is excluded from the run if its name matches one of
+  the given prefixes.
 - `--id <ID>` the identifier that will be used to identify the results in the
   database.
 - `--include <INCLUDE>`: the inverse of `--exclude`. The argument is a
-  comma-separated list of benchmark names. When this option is specified, a
-  benchmark is included in the run only if its name matches one or more of the
-  given names.
+  comma-separated list of benchmark prefixes. When this option is specified, a
+  benchmark is included in the run only if its name matches one of the given
+  prefixes.
 - `--profiles <PROFILES>`: the profiles to be benchmarked. The possible choices
   are one or more (comma-separated) of `Check`, `Debug`, `Doc`, `Opt`, and
   `All`. The default is `Check,Debug,Opt`.


### PR DESCRIPTION
In #1138 I changed `--include`/`--exclude` to do exact matching of
benchmark names. This was a good idea at the time, but since then we
have renamed many benchmarks. There is now no benchmark with a name that
is a prefix of another benchmark's name. Also, we now have version
numbers in many benchmark names, which are a pain to remember and type.

This commit lets you specify a benchmark name by prefix. E.g.
`--include=stm` will match `stm32f4-0.14.0`.