### PR TITLE
Simplify artifact comparison relevance

### DIFF
--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -153,9 +153,7 @@ async fn populate_report(
     // Get the combined direction of the primary and secondary summaries
     let direction = match (primary.direction(), secondary.direction()) {
         (Some(d1), Some(d2)) if d1 != d2 => Direction::Mixed,
-        (Some(Direction::Improvement), Some(_) | None) => Direction::Improvement,
-        (Some(Direction::Regression), Some(_) | None) => Direction::Regression,
-        (Some(Direction::Mixed), Some(_) | None) => Direction::Mixed,
+        (Some(d), Some(_) | None) => d,
         (None, Some(d)) => d,
         (None, None) => return,
     };


### PR DESCRIPTION
Based on [discussion](https://github.com/rust-lang/rustc-perf/pull/1277#issuecomment-1090142028) in #1277, this PR drastically simplifies how we think about relevance of an artifact comparison. If there are any relevant test result comparisons, then the artifact comparison as a whole is deemed relevant. 

We should expect that more items will appear on the triage report. 

@nnethercote - I like this change for the GitHub messages we post, but I'm less keen on this for the triage report. Perhaps for the triage report we can be a bit smarter. For example, if the primary summary has any comparisons OR the secondary summary has any medium or above test result comparison or 10 or more small ones. This would at least mean the triage filer doesn't need to filter out those that are just composed of small changes to secondary benchmarks. Thoughts?