### PR TITLE
Only label PRs as perf regressions if we're confident enough

### DIFF
--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -337,6 +337,14 @@ impl ComparisonSummary {
     pub fn is_relevant(&self) -> bool {
         !self.is_empty()
     }
+
+    pub fn num_changes(&self) -> usize {
+        self.relevant_comparisons.len()
+    }
+
+    pub fn largest_change(&self) -> Option<&TestResultComparison> {
+        self.relevant_comparisons.first()
+    }
 }
 
 async fn write_triage_summary(
@@ -984,7 +992,7 @@ impl TestResultComparison {
     ///
     /// This is the average of the absolute magnitude of the change
     /// and the amount above the significance threshold.
-    fn magnitude(&self) -> Magnitude {
+    pub fn magnitude(&self) -> Magnitude {
         let change = self.relative_change().abs();
         let threshold = self.significance_threshold();
         let over_threshold = if change < threshold * 1.5 {

--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -1066,7 +1066,7 @@ impl std::hash::Hash for TestResultComparison {
 }
 
 // The direction of a performance change
-#[derive(PartialEq, Eq, Hash, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 pub enum Direction {
     Improvement,
     Regression,


### PR DESCRIPTION
Similar to #1282, this limits what we label as a `perf-regression`. Currently this uses the same logic as #1282 to determine confidence. Additionally, it only shows the "next steps" message (explaining how to mark a perf regression as triaged) if we actually label the PR as triaged. 

Most of this is just code rearrangement, I've added a comment at the location where there is a change in logic. 