### PR TITLE
Add link to benchmark code in summary page

### DIFF
--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -291,6 +291,10 @@
             margin: 10px;
             text-align: center;
         }
+
+        .silent-link {
+            color: inherit;
+        }
     </style>
     <script src="https://cdn.jsdelivr.net/npm/vue@3/dist/vue.global.prod.js"></script>
 </head>
@@ -993,6 +997,9 @@
                 percentLink(commit, baseCommit, testCase) {
                     return `/detailed-query.html?commit=${commit}&base_commit=${baseCommit}&benchmark=${testCase.benchmark + "-" + testCase.profile}&scenario=${testCase.scenario}`;
                 },
+                benchmarkLink(benchmark) {
+                    return "https://github.com/rust-lang/rustc-perf/tree/master/collector/benchmarks/" + benchmark;
+                }
             },
             template: `
 <div class="bench-table">
@@ -1025,7 +1032,13 @@
     <tbody>
         <template v-for="testCase in cases">
             <tr>
-                <td>{{ testCase.benchmark }}</td>
+                <td>
+                  <a v-bind:href="benchmarkLink(testCase.benchmark)"
+                     class="silent-link"
+                     target="_blank">
+                     {{ testCase.benchmark }}
+                 </a>
+                </td>
                 <td>{{ testCase.profile }}</td>
                 <td>{{ testCase.scenario }}</td>
                 <td>


### PR DESCRIPTION
This should make the benchmarks more discoverable and should provide easy answer to ponderings such as "is this a binary or a library crate?" (which btw could also be shown directly in the summary page).

There is a slight problem with this approach, because if the benchmark gets out of date, the link will result in 404. But I don't think that it's such a big deal, as usually you look at a recent perf. result and for that the link should be fine. If we wanted to solve this, we would need to embed the version of `rustc-perf` that produced this specific perf. run into the link, but I'm not sure if that's readily available (and it wouldn't work if you compared two commits benchmarked by a different `rustc-perf` version anyway).

![link](https://user-images.githubusercontent.com/4539057/163476912-0e70ec92-7828-4074-8141-5eea0b735e7e.gif)