### PR TITLE
Add option to parallelize profiling across benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,6 +294,7 @@ dependencies = [
  "log",
  "miow",
  "num_cpus",
+ "rayon",
  "reqwest",
  "semver",
  "serde",
@@ -340,6 +341,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
 ]
 
 [[package]]
@@ -1093,6 +1129,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1545,6 +1590,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "rayon"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd249e82c21598a9a426a4e00dd7adc1d640b22445ec8545feef801d1a74c221"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f51245e1e62e1f1629cbfec37b5793bbabcaeb90f30e94d2ba03564687353e4"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
 ]
 
 [[package]]

--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -32,6 +32,7 @@ snap = "1"
 filetime = "0.2.14"
 walkdir = "2"
 flate2 = { version = "1.0.22", features = ["rust_backend"] }
+rayon = "1.5.2"
 
 [target.'cfg(windows)'.dependencies]
 miow = "0.3"

--- a/collector/README.md
+++ b/collector/README.md
@@ -425,6 +425,8 @@ The following options alter the behaviour of the `profile_local` subcommand.
   diff files will also be produced.
 - `--rustdoc <RUSTDOC>` as for `bench_local`.
 - `--scenarios <SCENARIOS>`: as for `bench_local`.
+- `--jobs <JOB-COUNT>`: execute `<JOB-COUNT>` benchmarks in parallel. This is only allowed for certain
+profilers whose results are not affected by system noise (e.g. `callgrind` or `eprintln`).
 
 `RUST_LOG=debug` can be specified to enable verbose logging, which is useful
 for debugging `collector` itself.

--- a/collector/src/execute.rs
+++ b/collector/src/execute.rs
@@ -177,6 +177,25 @@ pub enum Profiler {
     LlvmIr,
 }
 
+impl Profiler {
+    /// Returns true if this profiler can be executed
+    /// in parallel without distorting the profile results.
+    pub fn supports_parallel_execution(&self) -> bool {
+        matches!(
+            self,
+            Profiler::Cachegrind
+                | Profiler::Callgrind
+                | Profiler::Dhat
+                | Profiler::DhatCopy
+                | Profiler::Eprintln
+                | Profiler::LlvmLines
+                | Profiler::LlvmIr
+                | Profiler::MonoItems
+                | Profiler::DepGraph
+        )
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum PerfTool {
     BenchTool(Bencher),


### PR DESCRIPTION
Suggested by @nnethercote [here](https://rust-lang.zulipchat.com/#narrow/stream/247081-t-compiler.2Fperformance/topic/Tasks.20for.20contributors/near/279351053).

This PR adds simple parallelization of local profiling over benchmarks (it doesn't parallelize individual profiles/scenarios etc.). The benchmark runner already support parallelism "inside" each benchmark execution, however it's just does some directory and basic preparation (AFAIK), so I don't think that it matters much if this is overlaid with parallelism over benchmarks. And on SSDs the added parallelism will probably help for preparing the directories.

For simplicity of implementation, I always execute the benchmarks under `rayon`, but set the number of threads to `1` if parallel execution isn't demanded.