### PR TITLE
Add benchmark/scenario/profile filters to graphs page and graph history link to compare page

### DIFF
--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -74,6 +74,9 @@ pub mod graphs {
         pub end: Bound,
         pub stat: String,
         pub kind: GraphKind,
+        pub benchmark: Option<String>,
+        pub scenario: Option<String>,
+        pub profile: Option<String>,
     }
 
     #[derive(Debug, PartialEq, Copy, Clone, Serialize, Deserialize)]

--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -612,8 +612,9 @@
                 title="Primary"
                 :cases="testCases.filter(c => c.category === 'primary')"
                 :show-raw-data="showRawData"
-                :commit-a="data.a.commit"
-                :commit-b="data.b.commit"
+                :commit-a="data.a"
+                :commit-b="data.b"
+                :stat="stat"
                 :before="before"
                 :after="after"></test-cases-table>
             <hr />
@@ -621,8 +622,9 @@
                 title="Secondary"
                 :cases="testCases.filter(c => c.category === 'secondary')"
                 :show-raw-data="showRawData"
-                :commit-a="data.a.commit"
-                :commit-b="data.b.commit"
+                :commit-a="data.a"
+                :commit-b="data.b"
+                :stat="stat"
                 :before="before"
                 :after="after"></test-cases-table>
             <br />
@@ -989,16 +991,28 @@
         });
 
         app.component('test-cases-table', {
-            props: ['cases', 'showRawData', 'commitA', 'commitB', 'before', 'after', 'title'],
+            props: ['cases', 'showRawData', 'commitA', 'commitB', 'before', 'after', 'title', 'stat'],
             methods: {
                 detailedQueryLink(commit, testCase) {
-                    return `/detailed-query.html?commit=${commit}&benchmark=${testCase.benchmark + "-" + testCase.profile}&scenario=${testCase.scenario}`;
+                    return `/detailed-query.html?commit=${commit.commit}&benchmark=${testCase.benchmark + "-" + testCase.profile}&scenario=${testCase.scenario}`;
                 },
                 percentLink(commit, baseCommit, testCase) {
-                    return `/detailed-query.html?commit=${commit}&base_commit=${baseCommit}&benchmark=${testCase.benchmark + "-" + testCase.profile}&scenario=${testCase.scenario}`;
+                    return `/detailed-query.html?commit=${commit.commit}&base_commit=${baseCommit.commit}&benchmark=${testCase.benchmark + "-" + testCase.profile}&scenario=${testCase.scenario}`;
                 },
                 benchmarkLink(benchmark) {
                     return "https://github.com/rust-lang/rustc-perf/tree/master/collector/benchmarks/" + benchmark;
+                },
+                graphLink(commit, stat, testCase) {
+                    let date = new Date(commit.date);
+                    // Move to `two weeks ago` to display history of the test case
+                    date.setUTCDate(date.getUTCDate() - 14);
+                    let year = date.getUTCFullYear();
+                    let month = (date.getUTCMonth() + 1).toString().padStart(2, '0');
+                    let day = date.getUTCDate().toString().padStart(2, '0');
+                    let start = `${year}-${month}-${day}`;
+
+                    let end = commit.commit;
+                    return `/index.html?start=${start}&end=${end}&benchmark=${testCase.benchmark}&profile=${testCase.profile}&scenario=${testCase.scenario}&stat=${stat}`;
                 }
             },
             template: `
@@ -1039,7 +1053,11 @@
                      {{ testCase.benchmark }}
                  </a>
                 </td>
-                <td>{{ testCase.profile }}</td>
+                <td>
+                  <a v-bind:href="graphLink(commitB, stat, testCase)" target="_blank" class="silent-link">
+                    {{ testCase.profile }}
+                  </a>
+                </td>
                 <td>{{ testCase.scenario }}</td>
                 <td>
                     <a v-bind:href="percentLink(commitB, commitA, testCase)">

--- a/site/static/index.html
+++ b/site/static/index.html
@@ -102,6 +102,7 @@
 
         const otherCacheStateColors = ["#8085e9", "#f15c80", "#e4d354", "#2b908f", "#f45b5b", "#91e8e1"];
         const interpolatedColor = "#fcb0f1";
+        const basicProfiles = ["Check", "Debug", "Opt"];
 
         function tooltipPlugin({ onclick, commits, isInterpolated, absoluteMode, shiftX = 10, shiftY = 10 }) {
             let tooltipLeftOffset = 0;
@@ -380,6 +381,8 @@
                         });
                     }
 
+                    let indices = cacheStates[Object.keys(cacheStates)[0]].interpolated_indices;
+
                     let plotOpts = genPlotOpts({
                         title: benchName + "-" + benchKind,
                         width: Math.floor(window.innerWidth / 3) - 16,
@@ -389,7 +392,7 @@
                         commits: data.commits,
                         stat: state.stat,
                         isInterpolated(dataIdx) {
-                            return cacheStates.full.interpolated_indices.has(dataIdx);
+                            return indices.has(dataIdx);
                         },
                         absoluteMode: state.kind == "raw",
                     });
@@ -414,19 +417,19 @@
             let benchmarks = {};
 
             function optInterpolated(profile) {
-                for (let cacheState in profile)
-                    profile[cacheState].interpolated_indices = new Set(profile[cacheState].interpolated_indices);
+                for (let scenario in profile)
+                    profile[scenario].interpolated_indices = new Set(profile[scenario].interpolated_indices);
 
                 return profile;
             }
 
             sortedBenchNames.forEach(name => {
-                const { Check, Debug, Opt } = data.benchmarks[name];
+                benchmarks[name] = {};
 
-                benchmarks[name] = {
-                    check: optInterpolated(Check),
-                    debug: optInterpolated(Debug),
-                    opt: optInterpolated(Opt),
+                for (let profile of basicProfiles) {
+                    if (data.benchmarks[name].hasOwnProperty(profile)) {
+                        benchmarks[name][profile.toLowerCase()] = optInterpolated(data.benchmarks[name][profile]);
+                    }
                 }
             });
 


### PR DESCRIPTION
Based on suggestions mentioned in [this](https://rust-lang.zulipchat.com/#narrow/stream/247081-t-compiler.2Fperformance/topic/interactive.20graph.20UX) Zulip thread.

This PR basically does three things:
1) Add the option to filter by `benchmark`, `scenario` and `profile` in the `/graphs` endpoint.
2) Fixes up the `graphs` page so that it works if the returned data does not contain all scenarios/profiles
(basically a continuation of https://github.com/rust-lang/rustc-perf/pull/1196).
3) Adds a link to the compare page which shows 2 week history chart for the specific benchmark/scenario/profile/stat combination. I wasn't sure where to put the link, so right now I just put it on the `Profile` column (that's temporary).

Currently, the changes from 1) are not exposed in the `graphs` UI, the filters can only be entered via GET parameters.

I'm not sure what is the best way to present the specific graph on the compare page. Maybe it should be rendered instead on the detailed query page (this would probably require some refactoring of the current code, so that we can share the chart code better) or we can also just include a link to the chart from the detailed query (but then it would require two clicks to get to it).

![graphs](https://user-images.githubusercontent.com/4539057/164325229-7ce99264-d323-4464-b4db-4b298770b103.gif)