### PR TITLE
Use last 30 days in compare page graph link

### DIFF
--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -1004,8 +1004,8 @@
                 },
                 graphLink(commit, stat, testCase) {
                     let date = new Date(commit.date);
-                    // Move to `two weeks ago` to display history of the test case
-                    date.setUTCDate(date.getUTCDate() - 14);
+                    // Move to `30 days ago` to display history of the test case
+                    date.setUTCDate(date.getUTCDate() - 30);
                     let year = date.getUTCFullYear();
                     let month = (date.getUTCMonth() + 1).toString().padStart(2, '0');
                     let day = date.getUTCDate().toString().padStart(2, '0');


### PR DESCRIPTION
The default for the compare page is last 30 days (I checked the code and it is indeed `-30 days` and not `-1 month`), so I changed it here to match that.