### PR TITLE
Make raw data numbers in compare page more readable

### DIFF
--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -1013,7 +1013,10 @@
 
                     let end = commit.commit;
                     return `/index.html?start=${start}&end=${end}&benchmark=${testCase.benchmark}&profile=${testCase.profile}&scenario=${testCase.scenario}&stat=${stat}`;
-                }
+                },
+                prettifyRawNumber(number) {
+                    return number.toLocaleString();
+                },
             },
             template: `
 <div class="bench-table">
@@ -1071,12 +1074,12 @@
                 </td>
                 <td v-if="showRawData" class="numeric">
                   <a v-bind:href="detailedQueryLink(commitA, testCase)">
-                    <abbr :title="testCase.datumA">{{ testCase.datumA.toFixed(2) }}</abbr>
+                    <abbr :title="testCase.datumA">{{ prettifyRawNumber(testCase.datumA) }}</abbr>
                   </a>
                 </td>
                 <td v-if="showRawData" class="numeric">
                   <a v-bind:href="detailedQueryLink(commitB, testCase)">
-                    <abbr :title="testCase.datumB">{{ testCase.datumB.toFixed(2) }}</abbr>
+                    <abbr :title="testCase.datumB">{{ prettifyRawNumber(testCase.datumB) }}</abbr>
                   </a>
                 </td>
             </tr>


### PR DESCRIPTION
To make the number more readable, we probably want to skip unnecessary decimal part (if it's zero anyway) and add separators. Currently, I used a locale-specific implementation that is built into JS. If you don't like that it is locale-specific, I can hand-code some variant that uses some fixed separators.

In any case, it now looks much more readable, especially when combined with the right alignment.

Before:
![image](https://user-images.githubusercontent.com/4539057/164454237-172993e7-3cf2-4e6a-9d65-a61eba32b807.png)

After (on my Czech locale):
![image](https://user-images.githubusercontent.com/4539057/164454195-4232ea81-4428-436d-904c-0740571c9377.png)