### PR TITLE
Always include next steps in GitHub message

### DIFF
--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -612,7 +612,7 @@ async fn summarize_run(ctxt: &SiteCtxt, commit: QueuedCommit, is_master_commit: 
     if !primary.is_relevant() && !secondary.is_relevant() {
         write!(
             &mut message,
-            "This benchmark run did not return any relevant results.\n\n{footer}"
+            "This benchmark run did not return any relevant results.\n"
         )
         .unwrap();
     } else {
@@ -630,11 +630,11 @@ async fn summarize_run(ctxt: &SiteCtxt, commit: QueuedCommit, is_master_commit: 
         .unwrap();
 
         write_summary_table(&primary, &secondary, true, &mut message);
-
-        let direction = primary.direction().or(secondary.direction());
-        let next_steps = next_steps(primary, secondary, direction, is_master_commit);
-        write!(&mut message, "\n{footer}\n{next_steps}").unwrap();
     }
+
+    let direction = primary.direction().or(secondary.direction());
+    let next_steps = next_steps(primary, secondary, direction, is_master_commit);
+    write!(&mut message, "\n{footer}\n{next_steps}").unwrap();
 
     message
 }


### PR DESCRIPTION
Fixes #1307 

Before this change, the next steps instructions (which include label changes and bors directives) were only showed if the results were relevant. However, we should always show next steps even if the results aren't relevant. 

This has a few interesting changes to current behavior:
* The `S-waiting-on-perf` label will be removed when the try run finishes
* Even PRs that show no relevant perf changes will still be labeled as `@bors rollup=never`
* The `perf-regression` label will be removed if the run returns no relevant perf results

All these changes are how things worked in the past, and I believe are the right behavior. 