### PR TITLE
Change `deserves_attention` algorithm

### DIFF
--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -359,13 +359,13 @@ pub(crate) fn deserves_attention(
 ) -> bool {
     match (primary.largest_change(), secondary.largest_change()) {
         (Some(c), _) if c.magnitude() >= Magnitude::Medium => true,
-        (_, Some(c)) if c.magnitude() >= Magnitude::Medium => true,
+        (_, Some(c)) if c.magnitude() >= Magnitude::Large => true,
         _ => {
             // How we determine whether a group of small changes deserves attention is and always will be arbitrary,
             // but this feels good enough for now. We may choose in the future to become more sophisticated about it.
             let primary_n = primary.num_changes();
             let secondary_n = secondary.num_changes();
-            (primary_n * 2 + secondary_n) >= 6
+            (primary_n * 3 + secondary_n) >= 9
         }
     }
 }


### PR DESCRIPTION
This changes the `deserves_attention` algorithm in two ways:
* Before one "medium" sized result in secondary benchmarks would be considered deserving of attention. Now, the threshold is "large" sized results.
* Before, primary benchmark changes were considered twice as important as secondary. Now they are three times as important.

This was motivated by @pnkfelix's struggle with a *lot* of changes in the [2022-04-19 triage](https://github.com/rust-lang/rustc-perf/blob/master/triage/2022-04-19.md). 

Under this change there would be
* 4 less regressions
* 4 less improvements
* 7 less mixed
* 8 less rollups 

Unfortunately, this still would have likely been a nightmare for @pnkfelix as there still would have been 17 mixed results to go through... 

*Note*: the regressions and mixed results (11 in total) would also not receive a `perf-regression` label either. Spot checking, it seems like most of these were found to be ignorable after investigation, so this change likely would only save time and not lead to actual regressions sneaking in. 

For details on which PRs would no longer be included, see below:

<details>

## Regressions 

Rollup of 7 pull requests [#95966](https://github.com/rust-lang/rust/pull/95966) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=4e1927db3c399fa34dc71992bd5dbec09f945c3d&end=2a83fbc42a9bb6bfdb8d3fb4ecce83fb410d7642&stat=instructions:u)
| | Regressions 😿 <br />(primary) | Regressions 😿 <br />(secondary) | Improvements 🎉 <br />(primary) | Improvements 🎉 <br />(secondary) | All 😿 🎉 <br />(primary) |
|:---:|:---:|:---:|:---:|:---:|:---:|
| count | 2 | 2 | 0 | 0 | 2 |
| mean | 0.2% | 0.3% | N/A | N/A | 0.2% |
| max | 0.2% | 0.4% | N/A | N/A | 0.2% | 

Rollup of 4 pull requests [#95999](https://github.com/rust-lang/rust/pull/95999) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=1491e5cc148391f7679542b8e9b4e6d2430a7b69&end=b768f248e99688a2d7649731a99b2f2ad962abf5&stat=instructions:u)
| | Regressions 😿 <br />(primary) | Regressions 😿 <br />(secondary) | Improvements 🎉 <br />(primary) | Improvements 🎉 <br />(secondary) | All 😿 🎉 <br />(primary) |
|:---:|:---:|:---:|:---:|:---:|:---:|
| count | 0 | 3 | 0 | 0 | 0 |
| mean | N/A | 1.0% | N/A | N/A | N/A |
| max | N/A | 1.2% | N/A | N/A | N/A |

Rollup of 7 pull requests [#96123](https://github.com/rust-lang/rust/pull/96123) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=2fa9789f596dd7639e1a242d466637b53179f4d1&end=878c7833f6c1ff10e2fd89074e5bd4ef5ff15936&stat=instructions:u)
| | Regressions 😿 <br />(primary) | Regressions 😿 <br />(secondary) | Improvements 🎉 <br />(primary) | Improvements 🎉 <br />(secondary) | All 😿 🎉 <br />(primary) |
|:---:|:---:|:---:|:---:|:---:|:---:|
| count | 0 | 6 | 0 | 0 | 0 |
| mean | N/A | 0.4% | N/A | N/A | N/A |
| max | N/A | 0.5% | N/A | N/A | N/A |

Add slice::remainder [#92287](https://github.com/rust-lang/rust/pull/92287) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=311e2683e1bad87715b1558f7900e294d24ce491&end=d5ae66c12c6bdf1a5739ae1fce8057fd76ba0f47&stat=instructions:u)
| | Regressions 😿 <br />(primary) | Regressions 😿 <br />(secondary) | Improvements 🎉 <br />(primary) | Improvements 🎉 <br />(secondary) | All 😿 🎉 <br />(primary) |
|:---:|:---:|:---:|:---:|:---:|:---:|
| count | 0 | 2 | 0 | 0 | 0 |
| mean | N/A | 1.2% | N/A | N/A | N/A |
| max | N/A | 1.2% | N/A | N/A | N/A |

## Improvements 

Rollup of 5 pull requests [#95974](https://github.com/rust-lang/rust/pull/95974) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=2a83fbc42a9bb6bfdb8d3fb4ecce83fb410d7642&end=327caac4d01aef74d6577b87c295270608be09fa&stat=instructions:u)
| | Regressions 😿 <br />(primary) | Regressions 😿 <br />(secondary) | Improvements 🎉 <br />(primary) | Improvements 🎉 <br />(secondary) | All 😿 🎉 <br />(primary) |
|:---:|:---:|:---:|:---:|:---:|:---:|
| count | 0 | 0 | 0 | 7 | 0 |
| mean | N/A | N/A | N/A | -0.3% | N/A |
| max | N/A | N/A | N/A | -0.6% | N/A |

Allow self-profiler to only record potentially costly arguments when argument recording is turned on [#95689](https://github.com/rust-lang/rust/pull/95689) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=c8422403f775126c40d558838d321c063554c822&end=febce1fc316f5618d5bb8f05d19e2e3ba868c007&stat=instructions:u)
| | Regressions 😿 <br />(primary) | Regressions 😿 <br />(secondary) | Improvements 🎉 <br />(primary) | Improvements 🎉 <br />(secondary) | All 😿 🎉 <br />(primary) |
|:---:|:---:|:---:|:---:|:---:|:---:|
| count | 0 | 0 | 0 | 3 | 0 |
| mean | N/A | N/A | N/A | -1.1% | N/A |
| max | N/A | N/A | N/A | -1.1% | N/A |

Fix `x test --doc --stage 0 library/std` [#95993](https://github.com/rust-lang/rust/pull/95993) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=d9b3ff7d34335c5bc0b2afed640b65d64a85fe03&end=2fa9789f596dd7639e1a242d466637b53179f4d1&stat=instructions:u)
| | Regressions 😿 <br />(primary) | Regressions 😿 <br />(secondary) | Improvements 🎉 <br />(primary) | Improvements 🎉 <br />(secondary) | All 😿 🎉 <br />(primary) |
|:---:|:---:|:---:|:---:|:---:|:---:|
| count | 0 | 0 | 0 | 5 | 0 |
| mean | N/A | N/A | N/A | -1.1% | N/A |
| max | N/A | N/A | N/A | -1.2% | N/A |

Rollup of 6 pull requests [#96134](https://github.com/rust-lang/rust/pull/96134) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=563ef23529ae800b2b136cabdc71a81d86a75f58&end=2c28b0eaf9843ec0f493fca2dba506fe4d9174fb&stat=instructions:u)
| | Regressions 😿 <br />(primary) | Regressions 😿 <br />(secondary) | Improvements 🎉 <br />(primary) | Improvements 🎉 <br />(secondary) | All 😿 🎉 <br />(primary) |
|:---:|:---:|:---:|:---:|:---:|:---:|
| count | 0 | 0 | 0 | 3 | 0 |
| mean | N/A | N/A | N/A | -1.1% | N/A |
| max | N/A | N/A | N/A | -1.1% | N/A |

## Mixed 

Skip `Lazy` for some metadata tables [#95867](https://github.com/rust-lang/rust/pull/95867) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=327caac4d01aef74d6577b87c295270608be09fa&end=de56c295c394349a68f293039481c3aa6402f9c6&stat=instructions:u)
| | Regressions 😿 <br />(primary) | Regressions 😿 <br />(secondary) | Improvements 🎉 <br />(primary) | Improvements 🎉 <br />(secondary) | All 😿 🎉 <br />(primary) |
|:---:|:---:|:---:|:---:|:---:|:---:|
| count | 0 | 5 | 0 | 1 | 0 |
| mean | N/A | 0.4% | N/A | -0.7% | N/A |
| max | N/A | 0.5% | N/A | -0.7% | N/A |

Rollup of 6 pull requests [#96015](https://github.com/rust-lang/rust/pull/96015) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=ab33f71a8be01a93d4d14ee5755beeefe38f1946&end=0d13f6afeba4935499abe0c9a07426c94492c94e&stat=instructions:u)
| | Regressions 😿 <br />(primary) | Regressions 😿 <br />(secondary) | Improvements 🎉 <br />(primary) | Improvements 🎉 <br />(secondary) | All 😿 🎉 <br />(primary) |
|:---:|:---:|:---:|:---:|:---:|:---:|
| count | 0 | 6 | 0 | 2 | 0 |
| mean | N/A | 0.7% | N/A | -0.3% | N/A |
| max | N/A | 1.1% | N/A | -0.4% | N/A |

Update cargo [#96031](https://github.com/rust-lang/rust/pull/96031) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=f9d4d12b6ab97fae8b9a6f607473fe149f38f6bd&end=e371eeb778c293cc85ce396cec5d6372fe1ef8b7&stat=instructions:u)
| | Regressions 😿 <br />(primary) | Regressions 😿 <br />(secondary) | Improvements 🎉 <br />(primary) | Improvements 🎉 <br />(secondary) | All 😿 🎉 <br />(primary) |
|:---:|:---:|:---:|:---:|:---:|:---:|
| count | 0 | 3 | 0 | 1 | 0 |
| mean | N/A | 1.1% | N/A | -0.4% | N/A |
| max | N/A | 1.1% | N/A | -0.4% | N/A |

Only check the compiler and standard library before documenting them (take 2) [#95450](https://github.com/rust-lang/rust/pull/95450) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=bb1a03c4fcbe547168fab128fa39b08d1122a1c2&end=27490eb4232ceebc4f5e1e11b529b55994cf0333&stat=instructions:u)
| | Regressions 😿 <br />(primary) | Regressions 😿 <br />(secondary) | Improvements 🎉 <br />(primary) | Improvements 🎉 <br />(secondary) | All 😿 🎉 <br />(primary) |
|:---:|:---:|:---:|:---:|:---:|:---:|
| count | 1 | 1 | 0 | 2 | 1 |
| mean | 0.9% | 0.4% | N/A | -1.2% | 0.9% |
| max | 0.9% | 0.4% | N/A | -1.2% | 0.9% |

Rollup of 9 pull requests [#96108](https://github.com/rust-lang/rust/pull/96108) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=07bb916d44a66d2caba427c7ee132bbeb245977b&end=c8422403f775126c40d558838d321c063554c822&stat=instructions:u)
| | Regressions 😿 <br />(primary) | Regressions 😿 <br />(secondary) | Improvements 🎉 <br />(primary) | Improvements 🎉 <br />(secondary) | All 😿 🎉 <br />(primary) |
|:---:|:---:|:---:|:---:|:---:|:---:|
| count | 0 | 3 | 0 | 2 | 0 |
| mean | N/A | 1.1% | N/A | -0.5% | N/A |
| max | N/A | 1.1% | N/A | -0.7% | N/A |

Rollup of 7 pull requests [#96117](https://github.com/rust-lang/rust/pull/96117) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=febce1fc316f5618d5bb8f05d19e2e3ba868c007&end=d9b3ff7d34335c5bc0b2afed640b65d64a85fe03&stat=instructions:u)
| | Regressions 😿 <br />(primary) | Regressions 😿 <br />(secondary) | Improvements 🎉 <br />(primary) | Improvements 🎉 <br />(secondary) | All 😿 🎉 <br />(primary) |
|:---:|:---:|:---:|:---:|:---:|:---:|
| count | 0 | 3 | 0 | 1 | 0 |
| mean | N/A | 1.1% | N/A | -0.4% | N/A |
| max | N/A | 1.1% | N/A | -0.4% | N/A |

Fix rustdoc duplicated blanket impls [#96091](https://github.com/rust-lang/rust/pull/96091) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=1ec2c136b35bd4660cba778346f8df7daf2ab173&end=ad4e98ed7dc535d161886b17f7792501baa82c9b&stat=instructions:u)
| | Regressions 😿 <br />(primary) | Regressions 😿 <br />(secondary) | Improvements 🎉 <br />(primary) | Improvements 🎉 <br />(secondary) | All 😿 🎉 <br />(primary) |
|:---:|:---:|:---:|:---:|:---:|:---:|
| count | 0 | 3 | 0 | 3 | 0 |
| mean | N/A | 1.1% | N/A | -1.1% | N/A |
| max | N/A | 1.2% | N/A | -1.1% | N/A |


</details>