### PR TITLE
Add blank line before markdown table

### DIFF
--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -93,7 +93,7 @@ pub async fn handle_triage(
                 let (primary, secondary) = summary_comparison
                     .clone()
                     .summarize_by_category(&benchmark_map);
-                let mut result = String::from("**Summary**:\n");
+                let mut result = String::from("**Summary**:\n\n");
                 write_summary_table(&primary, &secondary, false, &mut result);
                 result
             }
@@ -401,7 +401,7 @@ async fn write_triage_summary(
     let start = &comparison.a.artifact;
     let end = &comparison.b.artifact;
     let link = &compare_link(start, end);
-    write!(&mut result, " [(Comparison Link)]({})\n", link).unwrap();
+    write!(&mut result, " [(Comparison Link)]({})\n\n", link).unwrap();
 
     write_summary_table(&primary, &secondary, false, &mut result);
 


### PR DESCRIPTION
In many markdown implementations, a blank line is required before a table. This change adds that blank line, making the output compatible with more environments.

[We found this in the This Week in Rust repo](https://github.com/rust-lang/this-week-in-rust/issues/3220), where the output was pasted and failed to format correctly. @Mark-Simulacrum requested I try to add the fix here as well.