### PR TITLE
Add a bit more documentation about using `rustc` commits for benchmarking directly

### DIFF
--- a/collector/README.md
+++ b/collector/README.md
@@ -81,7 +81,11 @@ The following arguments are mandatory.
   should choose consistently. **Alternatively**, it can be a `+`-prefixed
   toolchain specifier such as `+nightly` or
   `+f7bb8e3677ba4277914e85a3060e5d69151aed44` in which case `rustup` will be
-  used to obtain the toolchain, downloading it if necessary.
+  used to obtain the toolchain, downloading it if necessary. The commit SHA
+  of the toolchain does not need to be in the `rustc` `master` branch, it can be e.g.
+  the result of a `try` CI run. You will need to have
+  [`rustup-toolchain-install-master`](https://github.com/kennytm/rustup-toolchain-install-master)
+  installed in order for this to work.
 
 The identifier under which the results will be put into the database varies.
 - If the `--id` option is specified, that identifer will be used.


### PR DESCRIPTION
I didn't know that this was an option at all. It needs `rustup-toolchain-install-master` to be installed though, which wasn't specified in the docs.