### PR TITLE
Add extended stats to GH summary table

### DIFF
--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -130,6 +130,7 @@ pub mod bootstrap {
 }
 
 pub mod comparison {
+    use crate::comparison::Stat;
     use collector::Bound;
     use database::{BenchmarkData, Date};
     use serde::{Deserialize, Serialize};
@@ -139,7 +140,7 @@ pub mod comparison {
     pub struct Request {
         pub start: Bound,
         pub end: Bound,
-        pub stat: String,
+        pub stat: Stat,
     }
 
     #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -416,21 +416,6 @@ pub(crate) fn deserves_attention_icount(
     }
 }
 
-pub(crate) fn deserves_attention_maxrss(
-    primary: &ArtifactComparisonSummary,
-    secondary: &ArtifactComparisonSummary,
-) -> bool {
-    let primary_big_changes = primary
-        .improvements()
-        .filter(|comparison| comparison.magnitude() >= Magnitude::Large)
-        .count();
-    let secondary_big_changes = secondary
-        .improvements()
-        .filter(|comparison| comparison.magnitude() >= Magnitude::Large)
-        .count();
-    primary_big_changes >= 10 || secondary_big_changes >= 20
-}
-
 async fn write_triage_summary(
     comparison: &ArtifactComparison,
     primary: &ArtifactComparisonSummary,

--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -17,6 +17,7 @@ use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::hash::Hash;
 use std::sync::Arc;
+use std::fmt::Write;
 
 type BoxedError = Box<dyn Error + Send + Sync>;
 
@@ -388,7 +389,6 @@ async fn write_triage_summary(
     primary: &ArtifactComparisonSummary,
     secondary: &ArtifactComparisonSummary,
 ) -> String {
-    use std::fmt::Write;
     let mut result = if let Some(pr) = comparison.b.pr {
         let title = github::pr_title(pr).await;
         format!(
@@ -415,8 +415,6 @@ pub fn write_summary_table(
     with_footnotes: bool,
     result: &mut String,
 ) {
-    use std::fmt::Write;
-
     fn render_stat<F: FnOnce() -> Option<f64>>(count: usize, calculate: F) -> String {
         let value = if count > 0 { calculate() } else { None };
         value
@@ -538,16 +536,16 @@ pub fn write_summary_table(
         }),
         largest_change,
     ]);
+}
 
-    if with_footnotes {
-        writeln!(
-            result,
-            r#"
+pub fn write_summary_table_footer(result: &mut String) {
+    writeln!(
+        result,
+        r#"
 [^1]: *number of relevant changes*
 [^2]: *the arithmetic mean of the percent change*"#
-        )
+    )
         .unwrap();
-    }
 }
 
 /// Compare two bounds on a given stat
@@ -1272,9 +1270,6 @@ mod tests {
 | count[^1]  | 3                              | 0                                | 0                               | 0                                 | 3                        |
 | mean[^2]   | 146.7%                         | N/A                              | N/A                             | N/A                               | 146.7%                   |
 | max        | 200.0%                         | N/A                              | N/A                             | N/A                               | 200.0%                   |
-
-[^1]: *number of relevant changes*
-[^2]: *the arithmetic mean of the percent change*
 "#
             .trim_start(),
         );
@@ -1294,9 +1289,6 @@ mod tests {
 | count[^1]  | 0                              | 0                                | 3                               | 0                                 | 3                        |
 | mean[^2]   | N/A                            | N/A                              | -71.7%                          | N/A                               | -71.7%                   |
 | max        | N/A                            | N/A                              | -80.0%                          | N/A                               | -80.0%                   |
-
-[^1]: *number of relevant changes*
-[^2]: *the arithmetic mean of the percent change*
 "#
             .trim_start(),
         );
@@ -1316,9 +1308,6 @@ mod tests {
 | count[^1]  | 0                              | 0                                | 0                               | 3                                 | 0                        |
 | mean[^2]   | N/A                            | N/A                              | N/A                             | -71.7%                            | N/A                      |
 | max        | N/A                            | N/A                              | N/A                             | -80.0%                            | N/A                      |
-
-[^1]: *number of relevant changes*
-[^2]: *the arithmetic mean of the percent change*
 "#
                 .trim_start(),
         );
@@ -1338,9 +1327,6 @@ mod tests {
 | count[^1]  | 0                              | 3                                | 0                               | 0                                 | 0                        |
 | mean[^2]   | N/A                            | 146.7%                           | N/A                             | N/A                               | N/A                      |
 | max        | N/A                            | 200.0%                           | N/A                             | N/A                               | N/A                      |
-
-[^1]: *number of relevant changes*
-[^2]: *the arithmetic mean of the percent change*
 "#
                 .trim_start(),
         );
@@ -1361,9 +1347,6 @@ mod tests {
 | count[^1]  | 2                              | 0                                | 2                               | 0                                 | 4                        |
 | mean[^2]   | 150.0%                         | N/A                              | -62.5%                          | N/A                               | 43.8%                    |
 | max        | 200.0%                         | N/A                              | -75.0%                          | N/A                               | 200.0%                   |
-
-[^1]: *number of relevant changes*
-[^2]: *the arithmetic mean of the percent change*
 "#
             .trim_start(),
         );
@@ -1386,9 +1369,6 @@ mod tests {
 | count[^1]  | 2                              | 1                                | 2                               | 1                                 | 4                        |
 | mean[^2]   | 150.0%                         | 100.0%                           | -62.5%                          | -66.7%                            | 43.8%                    |
 | max        | 200.0%                         | 100.0%                           | -75.0%                          | -66.7%                            | 200.0%                   |
-
-[^1]: *number of relevant changes*
-[^2]: *the arithmetic mean of the percent change*
 "#
                 .trim_start(),
         );
@@ -1407,9 +1387,6 @@ mod tests {
 | count[^1]  | 1                              | 0                                | 1                               | 0                                 | 2                        |
 | mean[^2]   | 20.0%                          | N/A                              | -50.0%                          | N/A                               | -15.0%                   |
 | max        | 20.0%                          | N/A                              | -50.0%                          | N/A                               | -50.0%                   |
-
-[^1]: *number of relevant changes*
-[^2]: *the arithmetic mean of the percent change*
 "#
                 .trim_start(),
         );
@@ -1428,9 +1405,6 @@ mod tests {
 | count[^1]  | 1                              | 0                                | 1                               | 0                                 | 2                        |
 | mean[^2]   | 100.0%                         | N/A                              | -16.7%                          | N/A                               | 41.7%                    |
 | max        | 100.0%                         | N/A                              | -16.7%                          | N/A                               | 100.0%                   |
-
-[^1]: *number of relevant changes*
-[^2]: *the arithmetic mean of the percent change*
 "#
                 .trim_start(),
         );

--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -15,9 +15,9 @@ use serde::Serialize;
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::error::Error;
+use std::fmt::Write;
 use std::hash::Hash;
 use std::sync::Arc;
-use std::fmt::Write;
 
 type BoxedError = Box<dyn Error + Send + Sync>;
 
@@ -545,7 +545,7 @@ pub fn write_summary_table_footer(result: &mut String) {
 [^1]: *number of relevant changes*
 [^2]: *the arithmetic mean of the percent change*"#
     )
-        .unwrap();
+    .unwrap();
 }
 
 /// Compare two bounds on a given stat

--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -630,6 +630,7 @@ async fn summarize_run(ctxt: &SiteCtxt, commit: QueuedCommit, is_master_commit: 
         .unwrap();
 
         write_summary_table(&primary, &secondary, true, &mut message);
+        write_summary_table_footer(&mut message);
     }
 
     let direction = primary.direction().or(secondary.direction());


### PR DESCRIPTION
This is an attempt to improve the (currently non-existing) display of secondary performance stats (like max RSS or cycles) in GH summary reports. This corresponds to the "better UI/UX" item from the performance roadmap.

Sometimes changes in icounts are virtually just noise, but some other metric changes in significant ways (typically max RSS, but sometimes also cycles). This can be missed by onlookers, since to show these secondary steps, you have to manually switch to them in the compare page, which is sometimes neglected.

I think that it would be nice if we could show the information in the summary, if we find that the changes are reasonably large (this part will be difficult, as always). The PR currently shows the same summary table that is currently used for icounts also for Max RSS, if we find that there have been large changes (TODO: define what does this mean). We can also do something different than showing the full table, like saying "Watch out, it seems that RSS has changed significantly, check this link to find more.".

The first commit is just small cleanup that enables using multiple summary tables in a single PR without duplicating footer with the footnote definition.