### PR TITLE
Prefer the term metric over stat

### DIFF
--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -130,7 +130,7 @@ pub mod bootstrap {
 }
 
 pub mod comparison {
-    use crate::comparison::Stat;
+    use crate::comparison::Metric;
     use collector::Bound;
     use database::{BenchmarkData, Date};
     use serde::{Deserialize, Serialize};
@@ -140,7 +140,7 @@ pub mod comparison {
     pub struct Request {
         pub start: Bound,
         pub end: Bound,
-        pub stat: Stat,
+        pub stat: Metric,
     }
 
     #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
Currently, the code uses the term "stat" ambiguously. Sometimes it refers to a specific number statistic (e.g., 57,341,606,128 instruction counts recorded), and sometimes it refers to a class of statistic (e.g., "instruction counts"). [The glossary](https://github.com/rust-lang/rustc-perf/blob/master/docs/glossary.md) disambiguates these two using the term "stat(istic)" for the former and "metric" for the later. This PR brings the code into alignment with the glossary. 

Note: the API still uses "stat" for what is now called "metric". Since change the API is a little more error prone, I suggest we save that for a follow-up. 