### PR TITLE
Increase tracelog buffer sizes

### DIFF
--- a/collector/src/rustc-fake.rs
+++ b/collector/src/rustc-fake.rs
@@ -150,6 +150,12 @@ fn main() {
                     "CSWITCH+PROC_THREAD+LOADER",
                     "-PMC",
                     "InstructionRetired,TotalCycles:CSWITCH",
+                    "-b",
+                    "1024",
+                    "-min",
+                    "512",
+                    "-max",
+                    "2048",
                 ]);
                 let status = cmd.status().expect("failed to spawn tracelog");
                 assert!(status.success(), "tracelog did not complete successfully");


### PR DESCRIPTION
Otherwise a lot of the benchmarks trigger errors and warnings about lost
events while profiling https://github.com/rust-lang/rust/pull/96978, for example (pardon my french ...xperf):

```
xperf: error: rustc-perf-counters: Le nom d'instance passé n'a pas été
reconnu valide par un fournisseur de données WMI. (0x1069).
xperf: warning: Session "rustc-perf-counters" lost 5204 events.
```

I'm not sure if that's an artifact of the box I have access to, or if e. g. @wesleywiser you've seen this happen in your benchmarking endeavours as well ?

(~~I'm also not sure if increasing both xperf and tracelog buffers is necessary or if only one or the other would suffice. Tracelog at the very least should be IIRC~~ update: this PR now only changes the tracelog buffers)