### PR TITLE
Store artifact sizes into the database

### DIFF
--- a/collector/src/execute.rs
+++ b/collector/src/execute.rs
@@ -835,7 +835,11 @@ impl<'a> Processor for BenchProcessor<'a> {
         output: process::Output,
     ) -> anyhow::Result<Retry> {
         match process_stat_output(output) {
-            Ok(res) => {
+            Ok(mut res) => {
+                if let Some(ref profile) = res.1 {
+                    store_artifact_sizes_into_stats(&mut res.0, profile);
+                }
+
                 match data.scenario {
                     Scenario::Full => {
                         self.insert_stats(database::Scenario::Empty, data.profile, res);
@@ -878,6 +882,14 @@ impl<'a> Processor for BenchProcessor<'a> {
                 panic!("process_perf_stat_output failed: {:?}", e);
             }
         }
+    }
+}
+
+fn store_artifact_sizes_into_stats(stats: &mut Stats, profile: &SelfProfile) {
+    for artifact in profile.artifact_sizes.iter() {
+        stats
+            .stats
+            .insert(format!("size:{}", artifact.label), artifact.size as f64);
     }
 }
 
@@ -1709,6 +1721,14 @@ impl Patch {
 #[derive(serde::Deserialize, Clone)]
 pub struct SelfProfile {
     pub query_data: Vec<QueryData>,
+    pub artifact_sizes: Vec<ArtifactSize>,
+}
+
+#[derive(serde::Deserialize, Clone)]
+pub struct ArtifactSize {
+    pub label: QueryLabel,
+    #[serde(rename = "value")]
+    pub size: u64,
 }
 
 #[derive(serde::Deserialize, Clone)]

--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -206,6 +206,18 @@ pub enum Metric {
     TaskClockUser,
     #[serde(rename = "wall-time")]
     WallTime,
+    #[serde(rename = "size:codegen_unit_size_estimate")]
+    CodegenUnitSize,
+    #[serde(rename = "size:dep_graph")]
+    DepGraphSize,
+    #[serde(rename = "size:linked_artifact")]
+    LinkedArtifactSize,
+    #[serde(rename = "size:object_file")]
+    ObjectFileSize,
+    #[serde(rename = "size:query_cache")]
+    QueryCacheSize,
+    #[serde(rename = "size:work_product_index")]
+    WorkProductIndexSize,
 }
 
 impl Metric {
@@ -222,6 +234,12 @@ impl Metric {
             Metric::TaskClock => "task-clock",
             Metric::TaskClockUser => "task-clock:u",
             Metric::WallTime => "wall-time",
+            Metric::CodegenUnitSize => "size:codegen_unit_size_estimate",
+            Metric::DepGraphSize => "size:dep_graph",
+            Metric::LinkedArtifactSize => "size:linked_artifact",
+            Metric::ObjectFileSize => "size:object_file",
+            Metric::QueryCacheSize => "size:query_cache",
+            Metric::WorkProductIndexSize => "size:work_product_index",
         }
     }
 


### PR DESCRIPTION
It would be really nice to track the size of generated artifacts (especially the size of binaries) over time. There are a lot of things that we could do in this direction, but probably the simplest one to begin with is to generate stats corresponding to the artifact sizes that are produced by the self profiler.

With this small change, we can start tracking artifact sizes for the currently existing benchmarks. This is just a small first step, of course, but it should already provide us with interesting data.

I used the `size:` prefix for the stats, to differentiate these values from the existing metrics. Maybe we could add some unified prefix to the compile time metrics? Later we can add yet another prefix for metrics gathered from compiled binaries.

Related issue: https://github.com/rust-lang/rustc-perf/issues/145