### PR TITLE
Exclude the rust src directory from inclusion in the rustc-perf workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = ["collector", "site", "database", "intern"]
-exclude = ["collector/benchmarks"]
+exclude = ["collector/benchmarks", "rust/src"]
 
 [profile.release.package.site]
 debug = 1


### PR DESCRIPTION
This should fix the build error in the collector for the rustc benchmark, hopefully.

cc @jyn514 

