### PR TITLE
Fix typo. `credentail` to `creadential`

### DIFF
--- a/collector/benchmarks/cargo-0.60.0/src/cargo/sources/git/utils.rs
+++ b/collector/benchmarks/cargo-0.60.0/src/cargo/sources/git/utils.rs
@@ -517,7 +517,7 @@ where
         //
         // If ssh-agent authentication fails, libgit2 will keep calling this
         // callback asking for other authentication methods to try. Check
-        // cred_helper_bad to make sure we only try the git credentail helper
+        // cred_helper_bad to make sure we only try the git credential helper
         // once, to avoid looping forever.
         if allowed.contains(git2::CredentialType::USER_PASS_PLAINTEXT) && cred_helper_bad.is_none()
         {


### PR DESCRIPTION
`git credential` is correct?