### PR TITLE
Explicitly mark commits as being try or master instead of relying on their date

### DIFF
--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -3,7 +3,7 @@
 use anyhow::{bail, Context};
 use clap::Parser;
 use collector::category::Category;
-use database::{ArtifactId, Commit};
+use database::{ArtifactId, Commit, CommitType};
 use log::debug;
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use std::collections::HashMap;
@@ -1376,12 +1376,14 @@ pub fn get_commit_or_fake_it(sha: &str) -> anyhow::Result<Commit> {
         .map(|c| Commit {
             sha: c.sha.as_str().into(),
             date: c.time.into(),
+            r#type: CommitType::Master,
         })
         .unwrap_or_else(|| {
             log::warn!("utilizing fake commit!");
             Commit {
                 sha: sha.into(),
                 date: database::Date::ymd_hms(2000, 01, 01, 0, 0, 0),
+                r#type: CommitType::Master,
             }
         }))
 }

--- a/database/src/bin/ingest-json.rs
+++ b/database/src/bin/ingest-json.rs
@@ -880,11 +880,7 @@ async fn ingest<T: Ingesting>(conn: &T, caches: &mut IdCache, path: &Path) {
     let (name, date, ty, benchmarks) = match res {
         Res::Commit(cd) => (
             cd.commit.sha.to_string(),
-            if cd.commit.is_try() {
-                None
-            } else {
-                Some(cd.commit.date.0)
-            },
+            Some(cd.commit.date.0),
             if cd.commit.is_try() { "try" } else { "master" },
             cd.benchmarks,
         ),

--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -12,6 +12,7 @@ use collector::category::Category;
 use collector::Bound;
 use serde::{Deserialize, Serialize};
 
+use database::CommitType;
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::error::Error;
@@ -753,6 +754,7 @@ fn previous_commits(
                 let new = ArtifactId::Commit(database::Commit {
                     sha: c.sha.clone(),
                     date: database::Date(c.time),
+                    r#type: CommitType::Master,
                 });
                 from = new.clone();
                 prevs.push(new);

--- a/site/src/load.rs
+++ b/site/src/load.rs
@@ -12,9 +12,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::db;
 use collector::{category::Category, Bound, MasterCommit};
-use database::Date;
 use database::Pool;
 pub use database::{ArtifactId, Benchmark, Commit};
+use database::{CommitType, Date};
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub enum MissingReason {
@@ -284,6 +284,7 @@ fn calculate_missing_from(
                 Commit {
                     sha: c.sha,
                     date: Date(c.time),
+                    r#type: CommitType::Master,
                 },
                 // All recent master commits should have an associated PR
                 MissingReason::Master {
@@ -322,6 +323,7 @@ fn calculate_missing_from(
             Commit {
                 sha: sha.to_string(),
                 date: Date::ymd_hms(2001, 01, 01, 0, 0, 0),
+                r#type: CommitType::Try,
             },
             MissingReason::Try {
                 pr,
@@ -524,6 +526,7 @@ mod tests {
                 Commit {
                     sha: "b".into(),
                     date: database::Date(time),
+                    r#type: CommitType::Master,
                 },
                 MissingReason::Master {
                     pr: 1,
@@ -535,6 +538,7 @@ mod tests {
                 Commit {
                     sha: "a".into(),
                     date: database::Date(time),
+                    r#type: CommitType::Master,
                 },
                 MissingReason::Master {
                     pr: 2,
@@ -546,6 +550,7 @@ mod tests {
                 Commit {
                     sha: "try-on-a".into(),
                     date: database::Date(time),
+                    r#type: CommitType::Try,
                 },
                 MissingReason::Try {
                     pr: 3,
@@ -625,6 +630,7 @@ mod tests {
                 Commit {
                     sha: "123".into(),
                     date: database::Date(time),
+                    r#type: CommitType::Master,
                 },
                 MissingReason::Master {
                     pr: 11,
@@ -636,6 +642,7 @@ mod tests {
                 Commit {
                     sha: "foo".into(),
                     date: database::Date(time),
+                    r#type: CommitType::Master,
                 },
                 MissingReason::Master {
                     pr: 77,
@@ -647,6 +654,7 @@ mod tests {
                 Commit {
                     sha: "baz".into(),
                     date: database::Date(time),
+                    r#type: CommitType::Try,
                 },
                 MissingReason::Try {
                     pr: 101,

--- a/site/src/request_handlers/self_profile.rs
+++ b/site/src/request_handlers/self_profile.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use bytes::Buf;
+use database::CommitType;
 use headers::{ContentType, Header};
 use hyper::StatusCode;
 
@@ -494,6 +495,7 @@ pub async fn handle_self_profile_raw(
             ArtifactId::Commit(database::Commit {
                 sha: body.commit.clone(),
                 date: database::Date::empty(),
+                r#type: CommitType::Master,
             }),
             bench_name,
             profile,


### PR DESCRIPTION
This should help with providing more accurate data in the dashboard and also enable seeing the 30 day metric graph for PRs.
I'm not sure of all the consequences of this change though.