### PR TITLE
Fix toolchain auto installation through rustup-toolchain-install-master

### DIFF
--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -430,7 +430,7 @@ fn get_local_toolchain(
             .context("failed to run `rustup which rustc`")?;
 
         // Looks like a commit hash? Try to install it...
-        if output.status.code() == Some(101) && toolchain.len() == 40 {
+        if !output.status.success() && toolchain.len() == 40 {
             // No such toolchain exists, so let's try to install it with
             // rustup-toolchain-install-master.
 


### PR DESCRIPTION
rustup no longer uses 101 exit code when it fails to locate the toolchain:

```console
$ rustup which rustc --toolchain f426146460c5446bb41ac0b677bbfe5b6ff502ba
error: toolchain 'f426146460c5446bb41ac0b677bbfe5b6ff502ba' is not installed
$ echo $?
1
```