### PR TITLE
Just check rustup for non-success when running 'which --toolchain'

### DIFF
--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -430,7 +430,7 @@ fn get_local_toolchain(
             .context("failed to run `rustup which rustc`")?;
 
         // Looks like a commit hash? Try to install it...
-        if output.status.code() == Some(101) && toolchain.len() == 40 {
+        if !output.status.success() && toolchain.len() == 40 {
             // No such toolchain exists, so let's try to install it with
             // rustup-toolchain-install-master.
 


### PR DESCRIPTION
```
$ rustup --version
rustup 1.25.1 (bb60b1e89 2022-07-12)
$ rustup which rustc --toolchain foo
error: toolchain 'foo' is not installed
$ echo $?
1 # Failure now returns 1 and not 101
```