### PR TITLE
Teach rustc-fake to tell the truth about subprocess exit statuses

### DIFF
--- a/collector/src/rustc-fake.rs
+++ b/collector/src/rustc-fake.rs
@@ -468,8 +468,7 @@ fn process_self_profile_output(prof_out_dir: PathBuf, args: &[OsString]) {
 fn exec(cmd: &mut Command) {
     let cmd_d = format!("{:?}", cmd);
     match cmd.status() {
-        Ok(status) if !status.success() => std::process::exit(1),
-        Ok(_) => {},
+        Ok(status) => std::process::exit(status.code().unwrap_or(1)),
         Err(e) => panic!("failed to execute `{}`: {}", cmd_d, e),
     }
 }

--- a/collector/src/rustc-fake.rs
+++ b/collector/src/rustc-fake.rs
@@ -467,8 +467,10 @@ fn process_self_profile_output(prof_out_dir: PathBuf, args: &[OsString]) {
 #[cfg(windows)]
 fn exec(cmd: &mut Command) {
     let cmd_d = format!("{:?}", cmd);
-    if let Err(e) = cmd.status() {
-        panic!("failed to execute `{}`: {}", cmd_d, e);
+    match cmd.status() {
+        Ok(status) if !status.success() => std::process::exit(1),
+        Ok(_) => {},
+        Err(e) => panic!("failed to execute `{}`: {}", cmd_d, e),
     }
 }
 

--- a/collector/src/rustc-fake.rs
+++ b/collector/src/rustc-fake.rs
@@ -469,7 +469,7 @@ fn exec(cmd: &mut Command) {
     let cmd_d = format!("{:?}", cmd);
     match cmd.status() {
         Ok(status) => std::process::exit(status.code().unwrap_or(1)),
-        Err(e) => panic!("failed to execute `{}`: {}", cmd_d, e),
+        Err(e) => panic!("failed to spawn `{}`: {}", cmd_d, e),
     }
 }
 


### PR DESCRIPTION
This resolves the ci failure observed in https://github.com/rust-lang/rust/pull/99431

turns out the impl of `fn exec()` in rustc-perf's `rustc-fake` is incorrect on windows and only reports a failure when the subprocess fails to spawn, but if it spawns correctly it always reports success rather than checking the exit status of the subprocess. This causes the probe in anyhow to succeed and enable `#[cfg(backtrace)]` which then causes anyhow to fail to compile, but because it was inside of `rustc-fake` it reports success and continues! This happens quite a bit and we get some very exciting compiler errors when `RUST_LOG=collector=trace` is set.