### PR TITLE
On Demand self profile data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,17 +69,15 @@ dependencies = [
 
 [[package]]
 name = "analyzeme"
-version = "10.0.0"
-source = "git+https://github.com/rust-lang/measureme?branch=stable#6129647e1727be1f9855f0158be4a0a538298514"
+version = "10.1.0"
+source = "git+https://github.com/rust-lang/measureme?branch=analysis-in-analyzeme#5ee583bd9e2db6da161c0698fb569f3e30212aed"
 dependencies = [
  "analyzeme 9.2.0",
- "byteorder",
  "decodeme",
- "measureme 10.0.0",
+ "measureme 10.1.0",
  "memchr",
  "rustc-hash",
  "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -459,10 +457,10 @@ dependencies = [
 
 [[package]]
 name = "decodeme"
-version = "10.0.0"
-source = "git+https://github.com/rust-lang/measureme?branch=stable#6129647e1727be1f9855f0158be4a0a538298514"
+version = "10.1.0"
+source = "git+https://github.com/rust-lang/measureme?branch=analysis-in-analyzeme#5ee583bd9e2db6da161c0698fb569f3e30212aed"
 dependencies = [
- "measureme 10.0.0",
+ "measureme 10.1.0",
  "memchr",
  "rustc-hash",
  "serde",
@@ -1095,20 +1093,20 @@ dependencies = [
  "log",
  "memmap2",
  "parking_lot",
- "perf-event-open-sys",
+ "perf-event-open-sys 1.0.1",
  "rustc-hash",
  "smallvec",
 ]
 
 [[package]]
 name = "measureme"
-version = "10.0.0"
-source = "git+https://github.com/rust-lang/measureme?branch=stable#6129647e1727be1f9855f0158be4a0a538298514"
+version = "10.1.0"
+source = "git+https://github.com/rust-lang/measureme?branch=analysis-in-analyzeme#5ee583bd9e2db6da161c0698fb569f3e30212aed"
 dependencies = [
  "log",
  "memmap2",
  "parking_lot",
- "perf-event-open-sys",
+ "perf-event-open-sys 3.0.0",
  "rustc-hash",
  "smallvec",
 ]
@@ -1377,6 +1375,15 @@ name = "perf-event-open-sys"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce9bedf5da2c234fdf2391ede2b90fabf585355f33100689bc364a3ea558561a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "perf-event-open-sys"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b29be2ba35c12c6939f6bc73187f728bba82c3c062ecdc5fa90ea739282a1f58"
 dependencies = [
  "libc",
 ]
@@ -1918,7 +1925,7 @@ checksum = "cbce6d4507c7e4a3962091436e56e95290cb71fa302d0d270e32130b75fbff27"
 name = "site"
 version = "0.1.0"
 dependencies = [
- "analyzeme 10.0.0",
+ "analyzeme 10.1.0",
  "anyhow",
  "arc-swap",
  "async-trait",

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -690,6 +690,18 @@ impl Index {
     ) -> impl Iterator<Item = &'_ (Benchmark, Profile, Scenario, Metric)> + '_ {
         self.pstat_series.map.keys()
     }
+
+    pub fn artifact_id_for_commit(&self, commit: &str) -> Option<ArtifactId> {
+        self.commits()
+            .into_iter()
+            .find(|c| c.sha == *commit)
+            .map(|c| ArtifactId::Commit(c))
+            .or_else(|| {
+                self.artifacts()
+                    .find(|a| *a == commit)
+                    .map(|a| ArtifactId::Tag(a.to_owned()))
+            })
+    }
 }
 
 #[derive(Debug)]

--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -1,5 +1,5 @@
 use crate::{ArtifactId, ArtifactIdNumber, BenchmarkData};
-use crate::{CollectionId, Index, Profile, QueryDatum, QueuedCommit, Scenario, Step};
+use crate::{CollectionId, Index, Profile, QueuedCommit, Scenario, Step};
 use chrono::{DateTime, Utc};
 use hashbrown::HashMap;
 use std::sync::{Arc, Mutex};
@@ -58,7 +58,7 @@ pub trait Connection: Send + Sync {
         profile: Profile,
         scenario: Scenario,
         query: &str,
-        qd: QueryDatum,
+        qd: crate::QueryDatum,
     );
     async fn record_error(&self, artifact: ArtifactIdNumber, krate: &str, error: &str);
     async fn record_rustc_crate(
@@ -92,18 +92,6 @@ pub trait Connection: Send + Sync {
         pstat_series_row_ids: &[u32],
         artifact_row_id: &[Option<ArtifactIdNumber>],
     ) -> Vec<Vec<Option<f64>>>;
-    async fn get_self_profile(
-        &self,
-        artifact_row_id: ArtifactIdNumber,
-        crate_: &str,
-        profile: &str,
-        cache: &str,
-    ) -> HashMap<crate::QueryLabel, QueryDatum>;
-    async fn get_self_profile_query(
-        &self,
-        series: u32,
-        artifact_row_id: ArtifactIdNumber,
-    ) -> Option<QueryDatum>;
     async fn get_error(&self, artifact_row_id: ArtifactIdNumber) -> HashMap<String, String>;
 
     async fn queue_pr(

--- a/site/Cargo.toml
+++ b/site/Cargo.toml
@@ -39,7 +39,7 @@ async-trait = "0.1"
 database = { path = "../database" }
 bytes = "1.0"
 url = "2"
-analyzeme = { git = "https://github.com/rust-lang/measureme", branch = "stable" }
+analyzeme = { git = "https://github.com/rust-lang/measureme", branch = "analysis-in-analyzeme" }
 tar = "0.4"
 inferno = { version="0.10", default-features = false }
 mime = "0.3"

--- a/site/src/request_handlers/self_profile.rs
+++ b/site/src/request_handlers/self_profile.rs
@@ -595,17 +595,8 @@ pub async fn handle_self_profile(
     // Helper for finding an `ArtifactId` based on a commit sha
     let find_aid = |commit: &str| {
         index
-            .commits()
-            .into_iter()
-            .find(|c| c.sha == *commit)
-            .map(|c| ArtifactId::Commit(c))
-            .or_else(|| {
-                index
-                    .artifacts()
-                    .find(|a| *a == commit)
-                    .map(|a| ArtifactId::Tag(a.to_owned()))
-            })
-            .ok_or(format!("could not find artifact {}", body.commit))
+            .artifact_id_for_commit(commit)
+            .ok_or(format!("could not find artifact {}", commit))
     };
 
     let mut commits = vec![find_aid(&body.commit)?];


### PR DESCRIPTION
This moves fetching of self profile data from the database to s3. The self query data is still written to the database so that if we want/need to revert this, no data is lost. 

This requires changes to the analyzeme crate (here https://github.com/rust-lang/measureme/pull/200) which we may want to merge first before merging this. 