### PR TITLE
Mark revert rollup PR as a draft so that rustbot does not ping

### DIFF
--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -64,6 +64,7 @@ pub async fn pr_and_try_for_rollup(
 r? @ghost",
             origin_url, branch.rolled_up_pr_number
         ),
+        true,
     )
     .await
     .context("Created PR")?;
@@ -247,6 +248,7 @@ struct CreatePrRequest<'a> {
     base: &'a str,
     #[serde(rename = "body")]
     description: &'a str,
+    draft: bool,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -264,6 +266,7 @@ pub async fn create_pr(
     head: &str,
     base: &str,
     description: &str,
+    draft: bool,
 ) -> anyhow::Result<CreatePrResponse> {
     let timer_token = ctxt
         .config
@@ -279,6 +282,7 @@ pub async fn create_pr(
             head,
             base,
             description,
+            draft,
         })
         .header(USER_AGENT, "perf-rust-lang-org-server")
         .basic_auth("rust-timer", Some(timer_token))


### PR DESCRIPTION
Currently, when trying to revert a PR from a rollup for perf testing, rustbot pings a bunch of people due too code they are in charge of changing (this problem was similarly outlined here: https://github.com/rust-lang/triagebot/issues/1637).

In https://github.com/rust-lang/triagebot/pull/1638 functionality was added to ignore a PR if it's in draft status. This changes makes the PR that we create for reverting a rolled up change a draft PR.

This will make sure that situations like in https://github.com/rust-lang/rust/pull/99897 are avoided in the future.