### PR TITLE
Remove Database Round Trip Testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,21 +200,3 @@ jobs:
 
       - name: Export empty SQLite DB to Postgres
         run: ./target/debug/sqlite-to-postgres "$(mktemp)" 'postgresql://postgres:postgres@localhost:5432/postgres'
-
-      - name: Roundtrip export
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y wget python3-snappy sqlite3
-
-            timeout 60s wget -q 'http://perf-data.rust-lang.org/export.db.sz'
-            python3 -m snappy -d export.db.sz > before.db
-
-            ./target/debug/sqlite-to-postgres before.db 'postgresql://postgres:postgres@localhost:5432/postgres'
-            sqlite3 before.db .dump > before.dump
-
-            rm before.db
-
-            ./target/debug/postgres-to-sqlite 'postgresql://postgres:postgres@localhost:5432/postgres' after.db
-            sqlite3 after.db .dump > after.dump
-
-            diff -w before.dump after.dump

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,7 @@ jobs:
             sudo apt-get update
             sudo apt-get install -y wget python3-snappy sqlite3
 
-            wget -q 'http://perf-data.rust-lang.org/export.db.sz'
+            timeout 60s wget -q 'http://perf-data.rust-lang.org/export.db.sz'
             python3 -m snappy -d export.db.sz > before.db
 
             ./target/debug/sqlite-to-postgres before.db 'postgresql://postgres:postgres@localhost:5432/postgres'


### PR DESCRIPTION
The ["Database Check"](https://github.com/rust-lang/rustc-perf/runs/7618321996?check_suite_focus=true) is taking over an hour to eventually timeout. ~~It's most likely that this is due to some failure to download the exported database (which is quite large). I'm not sure why this doesn't just cause the job to fail, but hopefully this timeout will shed some light on this.~~

This removes the round trip testing until we can figure out a way for it to not take so long that it times out. 