### PR TITLE
When looking at commits look at the ci repo

### DIFF
--- a/site/src/load.rs
+++ b/site/src/load.rs
@@ -10,7 +10,6 @@ use chrono::{Duration, Utc};
 use log::error;
 use serde::{Deserialize, Serialize};
 
-use crate::api::github;
 use crate::db;
 use collector::{category::Category, Bound, MasterCommit};
 use database::Date;
@@ -60,11 +59,10 @@ impl MissingReason {
     }
 }
 
-#[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TryCommit {
     pub sha: String,
     pub parent_sha: String,
-    pub issue: github::Issue,
 }
 
 impl TryCommit {


### PR DESCRIPTION
`enqueu_sha` previously assumed that the commit it was to enqueue lived in the same repo as where the `Issue` event was originating from. This has until now always been the case. However, now that we are creating commits on rust-lang-ci/rust that do not exist on rust-lang/rust, we need to be careful to always fetch commits from rust-lang-ci/rust but still post comments to rust-lang/rust. 