### PR TITLE
Add branch-misses and cache-misses to stats collected by `perf stat`

### DIFF
--- a/collector/src/rustc-fake.rs
+++ b/collector/src/rustc-fake.rs
@@ -83,7 +83,7 @@ fn main() {
                     .env("LC_NUMERIC", "C")
                     .arg("-x;")
                     .arg("-e")
-                    .arg("instructions:u,cycles:u,task-clock,cpu-clock,faults,context-switches")
+                    .arg("instructions:u,cycles:u,task-clock,cpu-clock,faults,context-switches,branch-misses,cache-misses")
                     .arg("--log-fd")
                     .arg("1")
                     .arg("setarch")

--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -207,6 +207,10 @@ pub enum Metric {
     TaskClockUser,
     #[serde(rename = "wall-time")]
     WallTime,
+    #[serde(rename = "branch-misses")]
+    BranchMisses,
+    #[serde(rename = "cache-misses")]
+    CacheMisses,
     #[serde(rename = "size:codegen_unit_size_estimate")]
     CodegenUnitSize,
     #[serde(rename = "size:dep_graph")]
@@ -245,6 +249,8 @@ impl Metric {
             Metric::TaskClock => "task-clock",
             Metric::TaskClockUser => "task-clock:u",
             Metric::WallTime => "wall-time",
+            Metric::BranchMisses => "branch-misses",
+            Metric::CacheMisses => "cache-misses",
             Metric::CodegenUnitSize => "size:codegen_unit_size_estimate",
             Metric::DepGraphSize => "size:dep_graph",
             Metric::LinkedArtifactSize => "size:linked_artifact",


### PR DESCRIPTION
These metrics are quite fundamental in my opinion, and I think that adding them to `perf stat` shouldn't really affect a lot of things, since it already gathers a lot of other stats. Even though these metrics will probably be quite noisy, I think that they can still be useful in the dashboard.

`branch-misses` and `cache-misses` are in fact aliases for `perf`, which chooses some inner metric to calculate these. I think that these alises should be available on the perf runner.