### PR TITLE
Insert try commit date into DB

### DIFF
--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -760,11 +760,7 @@ where
         let (name, date, ty) = match artifact {
             ArtifactId::Commit(commit) => (
                 commit.sha.to_string(),
-                if commit.is_try() {
-                    None
-                } else {
-                    Some(commit.date.0)
-                },
+                Some(commit.date.0),
                 if commit.is_try() { "try" } else { "master" },
             ),
             ArtifactId::Tag(a) => (a.clone(), None, "release"),


### PR DESCRIPTION
This is a follow-up to https://github.com/rust-lang/rustc-perf/pull/1357, it looks like I missed one place where `try` commit dates were not being inserted into the database.