### PR TITLE
Take all commits that look like rollup merges

### DIFF
--- a/site/src/request_handlers/github.rs
+++ b/site/src/request_handlers/github.rs
@@ -51,8 +51,7 @@ async fn handle_push(ctxt: Arc<SiteCtxt>, push: github::Push) -> ServerResult<gi
         let rollup_merges = commits
             .iter()
             .rev()
-            .skip(1) // skip the head commit
-            .take_while(|c| c.message.starts_with("Rollup merge of "));
+            .filter(|c| c.message.starts_with("Rollup merge of #"));
         let result = unroll_rollup(
             ci_client,
             main_repo_client,


### PR DESCRIPTION
Fixes #1390 

Previously the handler for unrolling rollups assumed that the commits were ordered bor's auto merge, all roll up merges, all individual commits (in reverse order), but this is not always true. In https://github.com/rust-lang/rust/pull/100356 for example, an individual commit made it in between roll up merge commits.

This simplifies the code to not make this assumption. 