### PR TITLE
Add the metric in question to markdown table

### DIFF
--- a/site/src/github/comparison_summary.rs
+++ b/site/src/github/comparison_summary.rs
@@ -214,7 +214,7 @@ fn write_metric_summary(
         )
         .unwrap();
 
-        write_summary_table(&primary, &secondary, true, message);
+        write_summary_table(&primary, &secondary, true, false, message);
 
         if hidden {
             message.push_str("</details>\n");


### PR DESCRIPTION
As was brought up in [Zulip](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202022-08-11/near/292944011), it would be helpful to specify which metric is being summarized in the markdown summary tables. 

This looks at the first result in either the primary or secondary results for the metric name. We may want to consider some way of modeling that summaries should never have mixed metric kinds. 

