### PR TITLE
Store try commit dates into the DB properly

### DIFF
--- a/collector/src/api.rs
+++ b/collector/src/api.rs
@@ -1,7 +1,9 @@
 pub mod next_commit {
+    use database::Commit;
+
     #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-    pub struct Commit {
-        pub sha: String,
+    pub struct NextCommit {
+        pub commit: Commit,
         pub include: Option<String>,
         pub exclude: Option<String>,
         pub runs: Option<i32>,
@@ -9,6 +11,6 @@ pub mod next_commit {
 
     #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
     pub struct Response {
-        pub commit: Option<Commit>,
+        pub commit: Option<NextCommit>,
     }
 }

--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -1008,12 +1008,11 @@ fn main_result() -> anyhow::Result<i32> {
                 // no missing commits
                 return Ok(0);
             };
-            let commit = get_commit_or_fake_it(&next.sha)?;
 
             let pool = database::Pool::open(&db.db);
 
-            let sysroot = Sysroot::install(commit.sha.to_string(), &target_triple)
-                .with_context(|| format!("failed to install sysroot for {:?}", commit))?;
+            let sysroot = Sysroot::install(next.commit.sha.to_string(), &target_triple)
+                .with_context(|| format!("failed to install sysroot for {:?}", next.commit))?;
 
             let mut benchmarks = get_benchmarks(
                 &benchmark_dir,
@@ -1025,7 +1024,7 @@ fn main_result() -> anyhow::Result<i32> {
             let res = bench(
                 &mut rt,
                 pool,
-                &ArtifactId::Commit(commit),
+                &ArtifactId::Commit(next.commit),
                 &Profile::all(),
                 &Scenario::all(),
                 bench_rustc.bench_rustc,

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -23,6 +23,7 @@ pub struct QueuedCommit {
     pub include: Option<String>,
     pub exclude: Option<String>,
     pub runs: Option<i32>,
+    pub commit_date: Option<Date>,
 }
 
 #[derive(Debug, Hash, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -102,7 +102,13 @@ pub trait Connection: Send + Sync {
         runs: Option<i32>,
     );
     /// Returns true if this PR was queued waiting for a commit
-    async fn pr_attach_commit(&self, pr: u32, sha: &str, parent_sha: &str) -> bool;
+    async fn pr_attach_commit(
+        &self,
+        pr: u32,
+        sha: &str,
+        parent_sha: &str,
+        commit_date: Option<DateTime<Utc>>,
+    ) -> bool;
     async fn queued_commits(&self) -> Vec<QueuedCommit>;
     async fn mark_complete(&self, sha: &str) -> Option<QueuedCommit>;
 

--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -189,8 +189,13 @@ pub async fn enqueue_shas(
         };
         let queued = {
             let conn = ctxt.conn().await;
-            conn.pr_attach_commit(pr_number, &try_commit.sha, &try_commit.parent_sha)
-                .await
+            conn.pr_attach_commit(
+                pr_number,
+                &try_commit.sha,
+                &try_commit.parent_sha,
+                Some(commit_response.commit.committer.date),
+            )
+            .await
         };
         if queued {
             if !msg.is_empty() {

--- a/site/src/github/client.rs
+++ b/site/src/github/client.rs
@@ -1,4 +1,5 @@
 use anyhow::Context;
+use chrono::{DateTime, Utc};
 use http::header::USER_AGENT;
 
 use crate::{api::github::Issue, load::SiteCtxt};
@@ -253,6 +254,12 @@ pub struct InnerCommit {
     #[serde(default)]
     pub message: String,
     pub tree: CommitTree,
+    pub committer: Committer,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct Committer {
+    pub date: DateTime<Utc>,
 }
 
 #[derive(Debug, Clone, serde::Deserialize)]

--- a/site/src/load.rs
+++ b/site/src/load.rs
@@ -306,6 +306,7 @@ fn calculate_missing_from(
         include,
         exclude,
         runs,
+        commit_date,
     } in queued_pr_commits
         .into_iter()
         // filter out any queued PR master commits (leaving only try commits)
@@ -322,7 +323,7 @@ fn calculate_missing_from(
         queue.push((
             Commit {
                 sha: sha.to_string(),
-                date: Date::ymd_hms(2001, 01, 01, 0, 0, 0),
+                date: commit_date.unwrap_or(Date::empty()),
                 r#type: CommitType::Try,
             },
             MissingReason::Try {
@@ -499,6 +500,7 @@ mod tests {
                 include: None,
                 exclude: None,
                 runs: None,
+                commit_date: None,
             },
             QueuedCommit {
                 sha: "b".into(),
@@ -507,6 +509,7 @@ mod tests {
                 include: None,
                 exclude: None,
                 runs: None,
+                commit_date: None,
             },
             QueuedCommit {
                 sha: "a".into(),
@@ -515,6 +518,7 @@ mod tests {
                 include: None,
                 exclude: None,
                 runs: None,
+                commit_date: None,
             },
         ];
         let in_progress_artifacts = vec![];
@@ -606,6 +610,7 @@ mod tests {
                 include: None,
                 exclude: None,
                 runs: None,
+                commit_date: None,
             },
             // A try run
             QueuedCommit {
@@ -615,6 +620,7 @@ mod tests {
                 include: None,
                 exclude: None,
                 runs: None,
+                commit_date: None,
             },
         ];
         let in_progress_artifacts = vec![];

--- a/site/src/request_handlers/next_commit.rs
+++ b/site/src/request_handlers/next_commit.rs
@@ -18,7 +18,10 @@ pub async fn handle_next_commit(ctxt: Arc<SiteCtxt>) -> next_commit::Response {
             // TODO: add capability of doing the following in one step
             // to avoid possibile illegal inbetween states.
             conn.queue_pr(pr, None, None, None).await;
-            if !conn.pr_attach_commit(pr, &commit.sha, parent_sha).await {
+            if !conn
+                .pr_attach_commit(pr, &commit.sha, parent_sha, None)
+                .await
+            {
                 log::error!("failed to attach commit {} to PR queue", commit.sha);
             }
         }

--- a/site/src/request_handlers/next_commit.rs
+++ b/site/src/request_handlers/next_commit.rs
@@ -49,8 +49,8 @@ pub async fn handle_next_commit(ctxt: Arc<SiteCtxt>) -> next_commit::Response {
             commit.sha,
             missing_reason_dbg
         );
-        Some(next_commit::Commit {
-            sha: commit.sha,
+        Some(next_commit::NextCommit {
+            commit,
             include,
             exclude,
             runs,


### PR DESCRIPTION
This PR is another follow-up to https://github.com/rust-lang/rustc-perf/pull/1357 and https://github.com/rust-lang/rustc-perf/pull/1393. It makes the following changes:
1) `/perf/next_commit` now returns the actual commit that can be inserted (or used as a lookup) into the DB as-is.
2) The `pull_request_build` table got a new column named `commit_date`, which stores the date at which the `bors_sha` was committed.

With these two changes, the actual build dates of `try` commits should now be hopefully propagated to the `artifact` table and thus to the 30-day graphs.

The `commit_date` column is currently optional (nullable) and set to `NULL` for master commits, as we don't need the dates for them.