### PR TITLE
Do not add undefined parameters to URL in compare page

### DIFF
--- a/site/static/compare/script.js
+++ b/site/static/compare/script.js
@@ -494,9 +494,15 @@ function makeData(state, app) {
 
 function createSearchParamsForMetric(stat, start, end) {
     let params = new URLSearchParams();
-    params.append("start", start);
-    params.append("end", end);
-    params.append("stat", stat);
+    if (start !== undefined) {
+        params.append("start", start);
+    }
+    if (end !== undefined) {
+        params.append("end", end);
+    }
+    if (stat !== undefined) {
+        params.append("stat", stat);
+    }
     return params.toString();
 }
 


### PR DESCRIPTION
Follow-up to https://github.com/rust-lang/rustc-perf/pull/1400. The quick links didn't work properly on the main dashboard page, when there were no `start`/`end` bounds. Ah, the joy of Javascript.