### PR TITLE
Add summary table to compare page

### DIFF
--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -274,6 +274,7 @@
                     </div>
                     <input type="checkbox" v-model="showRawData" style="margin-left: 20px;" />
                 </div>
+                <button @click="resetFilter">Reset filters</button>
             </div>
         </fieldset>
         <p v-if="dataLoading && !data">Loading ...</p>

--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -262,7 +262,7 @@
                             </span>
                         </span>
                     </div>
-                    <input type="checkbox" v-model="filter.showNonRelevant" style="margin-left: 20px;" />
+                    <input type="checkbox" v-model="filter.nonRelevant" style="margin-left: 20px;" />
                 </div>
                 <div class="section">
                     <div class="section-heading"><span>Display raw data</span>
@@ -278,48 +278,16 @@
         </fieldset>
         <p v-if="dataLoading && !data">Loading ...</p>
         <div v-if="data" id="content" style="margin-top: 15px">
-            <div id="summary">
-                <div style="display: flex; justify-content: end;">
+            <div id="main-summary">
+                <summary-table :cases="filteredSummary"></summary-table>
+                <div style="position: absolute; right: 5px; top: 5px;">
                     <span class="tooltip" style="margin-right: 1em;">?
                         <span class="tooltiptext">
-                            The percents show arithmetic mean amongst regressions, amongst improvements
-                            and finally amongst all benchmarks in each category (all benchmarks or
-                            filtered benchmarks).
+                            The table shows summaries of regressions, improvements and all changes
+                            calculated from data that is currently visible (data that passes the
+                            active filters).
                         </span>
                     </span>
-                </div>
-                <div v-for="summaryPair in Object.entries(summary)" class="summary-container">
-                    <span style="font-weight: bold; margin-left: 5px; text-transform: capitalize;">{{
-                        summaryPair[0] }}:</span>
-                    <div class="summary-values">
-                        <span class="summary summary-wide positive">
-                            {{summaryPair[1].regressions.toString().padStart(3, "&nbsp;")}}
-                            <svg style="width:18px;height:18px" viewBox="0 0 24 24">
-                                <path
-                                    d="M16,6L18.29,8.29L13.41,13.17L9.41,9.17L2,16.59L3.41,18L9.41,12L13.41,16L19.71,9.71L22,12V6H16Z">
-                                </path>
-                            </svg>
-                            &nbsp;(+{{(summaryPair[1].regressions_avg).toFixed(2)}}%)
-                        </span>
-                        <span class="summary">
-                            {{summaryPair[1].unchanged.toString().padStart(3, "&nbsp;")}}
-                            <svg style="width:18px;height:18px" viewBox="0 0 24 24">
-                                <path d="M22,12L18,8V11H3V13H18V16L22,12Z"></path>
-                            </svg>
-                        </span>
-                        <span class="summary summary-wide negative">
-                            {{summaryPair[1].improvements.toString().padStart(3, "&nbsp;")}}
-                            <svg style="width:18px;height:18px" viewBox="0 0 24 24">
-                                <path
-                                    d="M16,18L18.29,15.71L13.41,10.83L9.41,14.83L2,7.41L3.41,6L9.41,12L13.41,8L19.71,14.29L22,12V18H16Z">
-                                </path>
-                            </svg>
-                            &nbsp;({{(summaryPair[1].improvements_avg).toFixed(2)}}%)
-                        </span>
-                        <span class="summary" v-bind:class="percentClass(summaryPair[1].average)">
-                            &nbsp;{{ signIfPositive(summaryPair[1].average) }}{{ (summaryPair[1].average).toFixed(2) }}%
-                        </span>
-                    </div>
                 </div>
             </div>
             <div v-if="data.new_errors.length">

--- a/site/static/compare/script.js
+++ b/site/static/compare/script.js
@@ -282,6 +282,9 @@ const app = Vue.createApp({
 
             return createUrlFromParams(createSearchParamsForMetric(metric, start, end));
         },
+        resetFilter() {
+            this.filter = createDefaultFilter();
+        }
     },
 });
 

--- a/site/static/compare/script.js
+++ b/site/static/compare/script.js
@@ -6,6 +6,29 @@ function findQueryParam(name) {
     }
 }
 
+function createDefaultFilter() {
+    return {
+        name: null,
+        nonRelevant: false,
+        profile: {
+            check: true,
+            debug: true,
+            opt: true,
+            doc: true
+        },
+        scenario: {
+            full: true,
+            incrFull: true,
+            incrUnchanged: true,
+            incrPatched: true
+        },
+        category: {
+            primary: true,
+            secondary: true
+        }
+    };
+}
+
 const app = Vue.createApp({
     mounted() {
         const app = this;
@@ -20,26 +43,7 @@ const app = Vue.createApp({
     },
     data() {
         return {
-            filter: {
-                name: null,
-                showNonRelevant: false,
-                profile: {
-                    check: true,
-                    debug: true,
-                    opt: true,
-                    doc: true
-                },
-                scenario: {
-                    full: true,
-                    incrFull: true,
-                    incrUnchanged: true,
-                    incrPatched: true
-                },
-                category: {
-                    primary: true,
-                    secondary: true
-                }
-            },
+            filter: createDefaultFilter(),
             showRawData: false,
             data: null,
             dataLoading: false
@@ -103,7 +107,7 @@ const app = Vue.createApp({
                 let nameFilter = filter.name && filter.name.trim();
                 nameFilter = !nameFilter || name.includes(nameFilter);
 
-                const relevanceFilter = filter.showNonRelevant ? true : testCase.isRelevant;
+                const relevanceFilter = filter.nonRelevant ? true : testCase.isRelevant;
 
                 return (
                     profileFilter(testCase.profile) &&
@@ -219,56 +223,9 @@ const app = Vue.createApp({
         stat() {
             return findQueryParam("stat") || "instructions:u";
         },
-        summary() {
-            // Create object with each test case that is not filtered out as a key
-            const filtered = this.testCases.reduce((sum, next) => {
-                sum[testCaseString(next)] = true;
-                return sum;
-            }, {});
-            const newCount = {
-                regressions: 0,
-                regressions_avg: 0,
-                improvements: 0,
-                improvements_avg: 0,
-                unchanged: 0,
-                average: 0
-            };
-
-            const addDatum = (result, datum, percent) => {
-                if (percent > 0 && datum.is_relevant) {
-                    result.regressions += 1;
-                    result.regressions_avg += percent;
-                } else if (percent < 0 && datum.is_relevant) {
-                    result.improvements += 1;
-                    result.improvements_avg += percent;
-                } else {
-                    result.unchanged += 1;
-                }
-                result.average += percent;
-            };
-
-            let result = {all: {...newCount}, filtered: {...newCount}}
-            for (let d of this.data.comparisons) {
-                const testCase = testCaseString(d)
-                const datumA = d.statistics[0];
-                const datumB = d.statistics[1];
-                let percent = 100 * ((datumB - datumA) / datumA);
-                addDatum(result.all, d, percent);
-                if (filtered[testCase]) {
-                    addDatum(result.filtered, d, percent);
-                }
-            }
-
-            const computeAvg = (result) => {
-                result.improvements_avg /= Math.max(result.improvements, 1);
-                result.regressions_avg /= Math.max(result.regressions, 1);
-                result.average /= Math.max(result.regressions + result.improvements + result.unchanged, 1);
-            };
-            computeAvg(result.all);
-            computeAvg(result.filtered);
-
-            return result;
-
+        // Returns summary of currently filtered data
+        filteredSummary() {
+            return computeSummary(this.testCases);
         },
         benchmarkMap() {
             if (!this.data) return {};
@@ -288,12 +245,6 @@ const app = Vue.createApp({
         },
         prLink(pr) {
             return `https://github.com/rust-lang/rust/pull/${pr}`;
-        },
-        signIfPositive(pct) {
-            if (pct >= 0) {
-                return "+";
-            }
-            return "";
         },
         diffClass(diff) {
             let klass = "";
@@ -433,6 +384,86 @@ app.component('test-cases-table', {
 </div>
 `
 });
+
+const SummaryPercentValue = {
+    props: {
+        value: Number,
+        padWidth: {
+            type: Number,
+            default: null
+        }
+    },
+    template: `
+<span><span v-html="padSpaces" />{{ formattedValue }}%</span>
+`,
+    computed: {
+        formattedValue() {
+            return `${this.signIfPositive(this.value)}${this.value.toFixed(2)}`;
+        },
+        padSpaces() {
+            let value = this.formattedValue;
+            if (value.length < this.padWidth) {
+                return "&nbsp;".repeat(this.padWidth - value.length);
+            }
+            return "";
+        }
+    }
+};
+const SummaryRange = {
+    props: {
+        range: Array,
+    },
+    template: `
+<div v-if="range.length > 0">
+  [<SummaryPercentValue :value="range[0]" :padWidth="6" />, <SummaryPercentValue :value="range[1]" :padWidth="6" />]
+</div>
+<div v-else>-</div>
+`, components: {SummaryPercentValue}
+};
+const SummaryCount = {
+    props: {
+        cases: Number,
+        benchmarks: Number
+    },
+    template: `
+<span :title="cases + ' test case(s), ' + benchmarks + ' unique benchmark(s)'">{{ cases }} ({{ benchmarks }})</span>
+`
+};
+
+app.component('summary-table', {
+    props: ['cases'],
+    template: `
+<table class="summary-table">
+    <thead>
+      <th><!-- icon --></th>
+      <th>Range</th>
+      <th>Mean</th>
+      <th>Count</th>
+    </thead>
+    <tbody>
+        <tr class="positive">
+            <td title="Regresions">❌</td>
+            <td><SummaryRange :range="cases.regressions.range" /></td>
+            <td><SummaryPercentValue :value="cases.regressions.average" /></td>
+            <td><SummaryCount :cases="cases.regressions.count" :benchmarks="cases.regressions.benchmarks" /></td>
+        </tr>
+        <tr class="negative">
+            <td title="Improvements">✅</td>
+            <td><SummaryRange :range="cases.improvements.range" /></td>
+            <td><SummaryPercentValue :value="cases.improvements.average" /></td>
+            <td><SummaryCount :cases="cases.improvements.count" :benchmarks="cases.improvements.benchmarks" /></td>
+        </tr>
+        <tr>
+            <td title="All changes">❌,✅</td>
+            <td><SummaryRange :range="cases.all.range" /></td>
+            <td><SummaryPercentValue :value="cases.all.average" /></td>
+            <td><SummaryCount :cases="cases.all.count" :benchmarks="cases.all.benchmarks" /></td>
+        </tr>
+    </tbody>
+</table>
+`,
+    components: {SummaryRange, SummaryPercentValue, SummaryCount}
+});
 app.mixin({
     methods: {
         percentClass(pct) {
@@ -447,6 +478,12 @@ app.mixin({
                 klass = 'slightly-negative';
             }
             return klass;
+        },
+        signIfPositive(pct) {
+            if (pct >= 0) {
+                return "+";
+            }
+            return "";
         },
     }
 });
@@ -468,6 +505,69 @@ toggleFilters("search-content", "search-toggle-indicator");
 
 function testCaseString(testCase) {
     return testCase.benchmark + "-" + testCase.profile + "-" + testCase.scenario;
+}
+
+/**
+ * Computes summaries of improvements, regressions and all changes from the given `comparisons`.
+ * Returns a dictionary {improvements, regressions, all}.
+ */
+function computeSummary(testCases) {
+    const regressions = {
+        values: [],
+        benchmarks: new Set(),
+    };
+    const improvements = {
+        values: [],
+        benchmarks: new Set(),
+    };
+    const all = {
+        values: [],
+        benchmarks: new Set(),
+    };
+
+    const handleTestCase = (items, testCase) => {
+        items.benchmarks.add(testCase.benchmark);
+        items.values.push(testCase.percent);
+    };
+
+    for (const testCase of testCases) {
+        if (testCase.percent > 0) {
+            handleTestCase(regressions, testCase);
+        } else if (testCase.percent < 0) {
+            handleTestCase(improvements, testCase);
+        }
+        handleTestCase(all, testCase);
+    }
+
+    const computeSummary = (data) => {
+        const values = data.values;
+        const benchmarks = data.benchmarks;
+
+        const count = values.length;
+        let range = [];
+        if (count > 0) {
+            range = [
+                Math.min.apply(null, values),
+                Math.max.apply(null, values),
+            ];
+        }
+
+        const sum = values.reduce((acc, item) => acc + item, 0);
+        const average = sum / Math.max(count, 1);
+
+        return {
+            count,
+            benchmarks: benchmarks.size,
+            average,
+            range,
+        }
+    };
+
+    return {
+        improvements: computeSummary(improvements),
+        regressions: computeSummary(regressions),
+        all: computeSummary(all)
+    };
 }
 
 function unique(arr) {

--- a/site/static/compare/style.css
+++ b/site/static/compare/style.css
@@ -232,10 +232,14 @@ input[type="checkbox"] {
     margin-top: 10px;
 }
 
-#summary {
+#main-summary {
     border: 1px dashed;
     padding: 4px;
     border-radius: 6px;
+
+    display: flex;
+    justify-content: center;
+    position: relative;
 }
 
 .summary-container {
@@ -295,4 +299,12 @@ input[type="checkbox"] {
 }
 .quick-links .active {
     font-weight: bold;
+}
+
+.summary-table th {
+    text-align: center;
+}
+.summary-table td, .summary-table th {
+    padding: 2px 5px;
+    vertical-align: middle;
 }


### PR DESCRIPTION
I moved the compare page JS, CSS and HTML to individual pages in https://github.com/rust-lang/rustc-perf/pull/1400 to make it easier to modify the compare page. It's still pretty annoying to do large changes, since it's written in JS (Typescript would be really nice!), but I think that we can do some incremental changes.

Inspired by https://github.com/rust-lang/rustc-perf/pull/1335, this PR adds a summary table component that is now used on the compare page instead of the previous `all`/`filtered` summary lines. I think that the `all`/`filtered` distinction was mostly useless and that it's much simpler to have a single summary + a `Reset filters` button, which this PR adds.

The new table contains min/max range and the number of unique benchmarks affected. I'm not sure which icon to use for the "all" (last) row, maybe some globe? Or no icon at all.

The first row shows regressions, the second row shows improvements, and the third row shows all changes (regressions + improvements).

As a follow-up, I would like to add a collapsible section with various axis aggregations, e.g. per-scenario, per-profile, per-category, and use this new summary table in the aggregations to easily display the results.

![image](https://user-images.githubusercontent.com/4539057/184676876-bf79e287-3d7a-4b6a-b980-652b2cb0ce59.png)

Related issue: https://github.com/rust-lang/rustc-perf/issues/1328