### PR TITLE
Add data aggregations to compare page

### DIFF
--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -277,18 +277,10 @@
                 <button @click="resetFilter">Reset filters</button>
             </div>
         </fieldset>
-        <fieldset id="aggregations" class="collapsible-section">
-            <legend id="aggregations-toggle" class="section-heading">Aggregations<span class="toggle-indicator" id="aggregations-toggle-indicator"></span>
-            </legend>
-            <div id="aggregations-content" v-if="data">
-                <aggregations :cases="testCases"></aggregations>
-            </div>
-        </fieldset>
         <p v-if="dataLoading && !data">Loading ...</p>
-        <div v-if="data" id="content" style="margin-top: 15px">
-            <div id="main-summary">
-                <summary-table :summary="filteredSummary"></summary-table>
-                <div style="position: absolute; right: 5px; top: 5px;">
+        <div v-if="data" id="main-summary">
+            <summary-table :summary="filteredSummary"></summary-table>
+            <div style="position: absolute; right: 5px; top: 5px;">
                     <span class="tooltip" style="margin-right: 1em;">?
                         <span class="tooltiptext">
                             The table shows summaries of regressions, improvements and all changes
@@ -296,8 +288,16 @@
                             active filters).
                         </span>
                     </span>
-                </div>
             </div>
+        </div>
+        <fieldset id="aggregations" class="collapsible-section">
+            <legend id="aggregations-toggle" class="section-heading">Aggregations<span class="toggle-indicator" id="aggregations-toggle-indicator"></span>
+            </legend>
+            <div id="aggregations-content" v-if="data">
+                <aggregations :cases="testCases"></aggregations>
+            </div>
+        </fieldset>
+        <div v-if="data" id="content" style="margin-top: 15px">
             <div v-if="data.new_errors.length">
                 <p><b>Newly broken benchmarks</b>:</p>
                 <details v-for="[crate, error] in data.new_errors">
@@ -306,7 +306,6 @@
                 </details>
                 <hr />
             </div>
-
             <test-cases-table
                 title="Primary"
                 :cases="testCases.filter(c => c.category === 'primary')"

--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -21,7 +21,7 @@
     <div id="app">
         <fieldset id="settings">
             <legend id="search-toggle" class="section-heading">Do another comparison<span
-                    id="search-toggle-indicator"></span></legend>
+                class="toggle-indicator" id="search-toggle-indicator"></span></legend>
             <div id="search-content">
                 <div id="commits" class="section">
                     <div class="section-heading">Commits</div>
@@ -83,8 +83,8 @@
                 <a v-bind:href="compareLink">🔎 compare commits</a>
             </div>
         </div>
-        <fieldset id="filters">
-            <legend id="filters-toggle" class="section-heading">Filters<span id="filters-toggle-indicator"></span>
+        <fieldset id="filters" class="collapsible-section">
+            <legend id="filters-toggle" class="section-heading">Filters<span class="toggle-indicator" id="filters-toggle-indicator"></span>
             </legend>
             <div id="filters-content" style="display: none;">
                 <div class="section">
@@ -277,10 +277,17 @@
                 <button @click="resetFilter">Reset filters</button>
             </div>
         </fieldset>
+        <fieldset id="aggregations" class="collapsible-section">
+            <legend id="aggregations-toggle" class="section-heading">Aggregations<span class="toggle-indicator" id="aggregations-toggle-indicator"></span>
+            </legend>
+            <div id="aggregations-content" v-if="data">
+                <aggregations :cases="testCases"></aggregations>
+            </div>
+        </fieldset>
         <p v-if="dataLoading && !data">Loading ...</p>
         <div v-if="data" id="content" style="margin-top: 15px">
             <div id="main-summary">
-                <summary-table :cases="filteredSummary"></summary-table>
+                <summary-table :summary="filteredSummary"></summary-table>
                 <div style="position: absolute; right: 5px; top: 5px;">
                     <span class="tooltip" style="margin-right: 1em;">?
                         <span class="tooltiptext">

--- a/site/static/compare/script.js
+++ b/site/static/compare/script.js
@@ -445,7 +445,10 @@ app.component('summary-table', {
         }
     },
     template: `
-<table class="summary-table">
+<div v-if="summary.all.count === 0" style="flex-grow: 1; display: flex; flex-direction: column; justify-content: center;">
+  <span>No results</span>
+</div>
+<table v-else class="summary-table">
     <thead v-if="withLegend">
       <th><!-- icon --></th>
       <th>Range</th>
@@ -455,15 +458,25 @@ app.component('summary-table', {
     <tbody>
         <tr class="positive">
             <td title="Regressions" v-if="withLegend">❌</td>
-            <td><SummaryRange :range="summary.regressions.range" /></td>
-            <td><SummaryPercentValue :value="summary.regressions.average" /></td>
-            <td><SummaryCount :cases="summary.regressions.count" :benchmarks="summary.regressions.benchmarks" /></td>
+            <template v-if="summary.regressions.count !== 0">
+                <td><SummaryRange :range="summary.regressions.range" /></td>
+                <td><SummaryPercentValue :value="summary.regressions.average" /></td>
+                <td><SummaryCount :cases="summary.regressions.count" :benchmarks="summary.regressions.benchmarks" /></td>
+            </template>
+            <template v-else>
+              <td colspan="3" style="text-align: center;">No regressions</td>
+            </template>
         </tr>
         <tr class="negative">
             <td title="Improvements" v-if="withLegend">✅</td>
-            <td><SummaryRange :range="summary.improvements.range" /></td>
-            <td><SummaryPercentValue :value="summary.improvements.average" /></td>
-            <td><SummaryCount :cases="summary.improvements.count" :benchmarks="summary.improvements.benchmarks" /></td>
+            <template v-if="summary.improvements.count !== 0">
+                <td><SummaryRange :range="summary.improvements.range" /></td>
+                <td><SummaryPercentValue :value="summary.improvements.average" /></td>
+                <td><SummaryCount :cases="summary.improvements.count" :benchmarks="summary.improvements.benchmarks" /></td>
+            </template>
+            <template v-else>
+              <td colspan="3" style="text-align: center;">No improvements</td>
+            </template>
         </tr>
         <tr>
             <td title="All changes" v-if="withLegend">❌,✅</td>

--- a/site/static/compare/script.js
+++ b/site/static/compare/script.js
@@ -454,7 +454,7 @@ app.component('summary-table', {
     </thead>
     <tbody>
         <tr class="positive">
-            <td title="Regresions" v-if="withLegend">❌</td>
+            <td title="Regressions" v-if="withLegend">❌</td>
             <td><SummaryRange :range="summary.regressions.range" /></td>
             <td><SummaryPercentValue :value="summary.regressions.average" /></td>
             <td><SummaryCount :cases="summary.regressions.count" :benchmarks="summary.regressions.benchmarks" /></td>

--- a/site/static/compare/style.css
+++ b/site/static/compare/style.css
@@ -17,7 +17,7 @@ ul li input {
 
 }
 
-#search-toggle-indicator {
+.toggle-indicator {
     cursor: pointer;
 }
 
@@ -56,10 +56,6 @@ ul li input {
     margin-left: 52px;
 }
 
-#filters-toggle {
-    cursor: pointer;
-}
-
 .section-heading {
     font-size: 16px;
 }
@@ -68,7 +64,7 @@ ul li input {
     font-size: 16px;
 }
 
-#filters {
+.collapsible-section {
     border: 1px black;
     border-style: dotted;
     margin: 12px 0px;
@@ -307,4 +303,28 @@ input[type="checkbox"] {
 .summary-table td, .summary-table th {
     padding: 2px 5px;
     vertical-align: middle;
+}
+
+.aggregation-section > .header {
+    margin-top: 5px;
+    font-size: 16px;
+    text-align: center;
+}
+.aggregation-section > .groups {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+.aggregation-section .group {
+    min-width: 45%;
+    border: 1px dotted black;
+    padding: 5px;
+    margin: 10px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+.aggregation-section .group-header {
+    margin-bottom: 5px;
+    font-weight: bold;
 }


### PR DESCRIPTION
This PR is based on https://github.com/rust-lang/rustc-perf/pull/1404, and adds additional aggregations for profiles, scenarios and categories, so that users can quickly see the effect on the various subgroups.

The tables have legends (icons and header) removed to conserve space. This section is designed for experts, and the legend is already located in the main summary, so I think that this is OK.

![image](https://user-images.githubusercontent.com/4539057/184984166-8797de12-eed9-45ad-98d5-32318bf4d76b.png)