### PR TITLE
Update test_profiling CI runner to Ubuntu 22.04 to re-enable DHAT copy mode test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,11 +131,22 @@ jobs:
           toolchain: beta
           override: true
 
-      - name: Install profilers
+      # We build a specific version of Valgrind because the one from the Ubuntu 22.04 repositories
+      # has problems with Rust debuginfo.
+      - name: Install Valgrind
         run: |
-          sudo apt-get update
-          sudo apt-get install -y valgrind
-          cargo install --version 0.4.12 cargo-llvm-lines
+          git clone git://sourceware.org/git/valgrind.git
+          cd valgrind
+          # Version from May 2022
+          git checkout 74e180e3c4d9e6bb4b2a9cd22eca7703412c5d42
+          ./autogen.sh
+          ./configure --prefix=${PWD}/build
+          make -j2
+          make install
+          echo "${PWD}/build/bin" >> $GITHUB_PATH
+
+      - name: Install profilers
+        run: cargo install --version 0.4.12 cargo-llvm-lines
 
       - name: Configure environment
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
 
   test_profiling:
     name: Test profiling
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout the source code
         uses: actions/checkout@v2

--- a/ci/check-profiling.sh
+++ b/ci/check-profiling.sh
@@ -95,16 +95,16 @@ grep -q "dhatFileVersion" results/dhout-Test-helloworld-Check-Full
 # DHAT (copy mode).
 # FIXME: CI currently runs Ubuntu 20.04 LTS, which has a Valgrind that is too
 # old to run with `--mode=copy`. When CI is upgraded to 22.04, uncomment this.
-#RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=debug \
-#    cargo run -p collector --bin collector -- \
-#    profile_local dhat-copy $bindir/rustc \
-#        --id Test \
-#        --profiles Check \
-#        --cargo $bindir/cargo \
-#        --include helloworld \
-#        --scenarios Full
-#test -f results/dhcopy-Test-helloworld-Check-Full
-#grep -q "dhatFileVersion" results/dhcopy-Test-helloworld-Check-Full
+RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=debug \
+    cargo run -p collector --bin collector -- \
+    profile_local dhat-copy $bindir/rustc \
+        --id Test \
+        --profiles Check \
+        --cargo $bindir/cargo \
+        --include helloworld \
+        --scenarios Full
+test -f results/dhcopy-Test-helloworld-Check-Full
+grep -q "dhatFileVersion" results/dhcopy-Test-helloworld-Check-Full
 
 # Massif.
 RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=debug \


### PR DESCRIPTION
Let's see if this works.