### PR TITLE
Properly display incr-patched benchmarks in aggregation table in comp…

### DIFF
--- a/site/static/compare/script.js
+++ b/site/static/compare/script.js
@@ -529,7 +529,7 @@ app.component("aggregations", {
         calculateSummary(keyAttribute, keyValue) {
             const benchmarks = [];
             for (const benchmark of this.cases) {
-                if (benchmark[keyAttribute] === keyValue) {
+                if (benchmark[keyAttribute].startsWith(keyValue)) {
                     benchmarks.push(benchmark);
                 }
             }


### PR DESCRIPTION
The tables added in https://github.com/rust-lang/rustc-perf/pull/1410 didn't work properly for `incr-patched` scenarios, because the scenarios did not match `incr-patched` exactly. This PR changes the data filter so that it checks the prefix instead. I didn't notice this before because I only added a proper visualisation for missing data late in the PR. Well, this at least proves that "No results" is very visible! :D

Before it caused this:
![image](https://user-images.githubusercontent.com/4539057/185420789-2aacb33d-87fd-46fd-903d-3561d4ce0e47.png)