### PR TITLE
Add a metric containing the size of generated documentation

### DIFF
--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -231,6 +231,12 @@ pub enum Metric {
     LlvmBitcodeSize,
     #[serde(rename = "size:llvm_ir")]
     LlvmIrSize,
+    /// Total bytes of a generated documentation directory
+    #[serde(rename = "size:doc_bytes")]
+    DocByteSize,
+    /// Number of files inside a generated documentation directory.
+    #[serde(rename = "size:doc_files_count")]
+    DocFilesCount,
 }
 
 impl Metric {
@@ -260,6 +266,8 @@ impl Metric {
             Metric::AssemblyFileSize => "size:assembly_file",
             Metric::LlvmBitcodeSize => "size:llvm_bitcode",
             Metric::LlvmIrSize => "size:llvm_ir",
+            Metric::DocByteSize => "size:doc_bytes",
+            Metric::DocFilesCount => "size:doc_files_count",
         }
     }
 


### PR DESCRIPTION
This week's triage report said something like "we don't track the size of generated documentation in rustc-perf". Well, I figured, why don't we? It seems easy enough.

CC @GuillaumeGomez @jsha Is this metric interesting for `rustdoc` developers? Currently I store the size of the whole `target/doc` directory, should we store something else?