### PR TITLE
Add artifact size to compare page quick links

### DIFF
--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -48,10 +48,11 @@
         <div class="quick-links">
             <div>Quick links:</div>
             <div v-for="metric in [
-                ['Instructions', 'instructions:u'],
-                ['Cycles', 'cycles:u'],
-                ['Max RSS', 'max-rss']
-            ]" :class="{ active: stat === metric[1] }">
+                ['Instructions', 'instructions:u', 'Number of executed instructions'],
+                ['Cycles', 'cycles:u', 'Number of executed cycles'],
+                ['Max RSS', 'max-rss', 'Highest amount of total allocated memory during the course of the compilation'],
+                ['Binary size', 'size:linked_artifact', 'Size of the generated binary artifact']
+            ]" :class="{ active: stat === metric[1] }" :title="metric[2]">
                 <a :href="createUrlForMetric(metric[1])">{{ metric[0] }}</a>
             </div>
         </div>


### PR DESCRIPTION
Also adds a short summary of the metric. I don't think that it's obvious to most people what metric corresponds to the artifact (binary) size of the compiled crate (well, I got it wrong :D ), so we might as well add it to the quick links.

![image](https://user-images.githubusercontent.com/4539057/185637292-97aae354-f0df-4342-81bc-70645339a817.png)