### PR TITLE
Add support for benchmarking published artifacts in `BenchNext`

### DIFF
--- a/collector/src/api.rs
+++ b/collector/src/api.rs
@@ -1,9 +1,9 @@
-pub mod next_commit {
-    use database::Commit;
+pub mod next_artifact {
+    use database::ArtifactId;
 
     #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-    pub struct NextCommit {
-        pub commit: Commit,
+    pub struct NextArtifact {
+        pub artifact: ArtifactId,
         pub include: Option<String>,
         pub exclude: Option<String>,
         pub runs: Option<i32>,
@@ -11,6 +11,6 @@ pub mod next_commit {
 
     #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
     pub struct Response {
-        pub commit: Option<NextCommit>,
+        pub artifact: Option<NextArtifact>,
     }
 }

--- a/collector/src/api.rs
+++ b/collector/src/api.rs
@@ -1,12 +1,15 @@
 pub mod next_artifact {
-    use database::ArtifactId;
+    use database::Commit;
 
     #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-    pub struct NextArtifact {
-        pub artifact: ArtifactId,
-        pub include: Option<String>,
-        pub exclude: Option<String>,
-        pub runs: Option<i32>,
+    pub enum NextArtifact {
+        Release(String),
+        Commit {
+            commit: Commit,
+            include: Option<String>,
+            exclude: Option<String>,
+            runs: Option<i32>,
+        },
     }
 
     #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -2,8 +2,9 @@
 
 use anyhow::{bail, Context};
 use clap::Parser;
+use collector::api::next_artifact::NextArtifact;
 use collector::category::Category;
-use database::{ArtifactId, Commit, CommitType};
+use database::{ArtifactId, Commit, CommitType, Pool};
 use log::debug;
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use std::collections::HashMap;
@@ -834,7 +835,7 @@ enum Commands {
         self_profile: SelfProfileOption,
     },
 
-    /// Benchmarks the next commit for perf.rust-lang.org
+    /// Benchmarks the next commit or release for perf.rust-lang.org
     BenchNext {
         /// Site URL
         site_url: String,
@@ -995,113 +996,66 @@ fn main_result() -> anyhow::Result<i32> {
             bench_rustc,
             self_profile,
         } => {
-            println!("processing commits");
+            println!("processing artifacts");
             let client = reqwest::blocking::Client::new();
-            let response: collector::api::next_commit::Response = client
-                .get(&format!("{}/perf/next_commit", site_url))
+            let response: collector::api::next_artifact::Response = client
+                .get(&format!("{}/perf/next_artifact", site_url))
                 .send()?
                 .json()?;
-            let next = if let Some(c) = response.commit {
+            let next = if let Some(c) = response.artifact {
                 c
             } else {
-                println!("no commit to benchmark");
-                // no missing commits
+                println!("no artifact to benchmark");
+                // no missing artifacts
                 return Ok(0);
             };
 
             let pool = database::Pool::open(&db.db);
 
-            let sysroot = Sysroot::install(next.commit.sha.to_string(), &target_triple)
-                .with_context(|| format!("failed to install sysroot for {:?}", next.commit))?;
+            if let NextArtifact {
+                artifact: ArtifactId::Tag(tag),
+                ..
+            } = next
+            {
+                bench_published_artifact(tag, pool, &mut rt, &target_triple, &benchmark_dir)?;
+            } else if let NextArtifact {
+                artifact: ArtifactId::Commit(commit),
+                exclude,
+                include,
+                runs,
+            } = next
+            {
+                let sysroot = Sysroot::install(commit.sha.to_string(), &target_triple)
+                    .with_context(|| format!("failed to install sysroot for {:?}", commit))?;
 
-            let mut benchmarks = get_benchmarks(
-                &benchmark_dir,
-                next.include.as_deref(),
-                next.exclude.as_deref(),
-            )?;
-            benchmarks.retain(|b| b.category().is_primary_or_secondary());
+                let mut benchmarks =
+                    get_benchmarks(&benchmark_dir, include.as_deref(), exclude.as_deref())?;
+                benchmarks.retain(|b| b.category().is_primary_or_secondary());
 
-            let res = bench(
-                &mut rt,
-                pool,
-                &ArtifactId::Commit(next.commit),
-                &Profile::all(),
-                &Scenario::all(),
-                bench_rustc.bench_rustc,
-                Compiler::from_sysroot(&sysroot),
-                &benchmarks,
-                next.runs.map(|v| v as usize),
-                self_profile.self_profile,
-            );
+                let res = bench(
+                    &mut rt,
+                    pool,
+                    &ArtifactId::Commit(commit),
+                    &Profile::all(),
+                    &Scenario::all(),
+                    bench_rustc.bench_rustc,
+                    Compiler::from_sysroot(&sysroot),
+                    &benchmarks,
+                    runs.map(|v| v as usize),
+                    self_profile.self_profile,
+                );
 
-            client.post(&format!("{}/perf/onpush", site_url)).send()?;
+                client.post(&format!("{}/perf/onpush", site_url)).send()?;
 
-            res.fail_if_nonzero()?;
+                res.fail_if_nonzero()?;
+            }
+
             Ok(0)
         }
 
         Commands::BenchPublished { toolchain, db } => {
-            let status = Command::new("rustup")
-                .args(&["install", "--profile=minimal", &toolchain])
-                .status()
-                .context("rustup install")?;
-            if !status.success() {
-                anyhow::bail!("failed to install toolchain for {}", toolchain);
-            }
-
             let pool = database::Pool::open(&db.db);
-
-            let profiles = if collector::version_supports_doc(&toolchain) {
-                Profile::all()
-            } else {
-                Profile::all_non_doc()
-            };
-            let scenarios = if collector::version_supports_incremental(&toolchain) {
-                Scenario::all()
-            } else {
-                Scenario::all_non_incr()
-            };
-
-            let which = |tool| {
-                String::from_utf8(
-                    Command::new("rustup")
-                        .arg("which")
-                        .arg("--toolchain")
-                        .arg(&toolchain)
-                        .arg(tool)
-                        .output()
-                        .context(format!("rustup which {}", tool))?
-                        .stdout,
-                )
-                .context("utf8")
-            };
-            let rustc = which("rustc")?;
-            let rustdoc = which("rustdoc")?;
-            let cargo = which("cargo")?;
-
-            // Exclude benchmarks that don't work with a stable compiler.
-            let mut benchmarks = get_benchmarks(&benchmark_dir, None, None)?;
-            benchmarks.retain(|b| b.category().is_stable());
-
-            let res = bench(
-                &mut rt,
-                pool,
-                &ArtifactId::Tag(toolchain),
-                &profiles,
-                &scenarios,
-                /* bench_rustc */ false,
-                Compiler {
-                    rustc: Path::new(rustc.trim()),
-                    rustdoc: Some(Path::new(rustdoc.trim())),
-                    cargo: Path::new(cargo.trim()),
-                    is_nightly: false,
-                    triple: &target_triple,
-                },
-                &benchmarks,
-                Some(3),
-                /* is_self_profile */ false,
-            );
-            res.fail_if_nonzero()?;
+            bench_published_artifact(toolchain, pool, &mut rt, &target_triple, &benchmark_dir)?;
             Ok(0)
         }
 
@@ -1246,6 +1200,75 @@ fn main_result() -> anyhow::Result<i32> {
             Ok(0)
         }
     }
+}
+
+fn bench_published_artifact(
+    toolchain: String,
+    pool: Pool,
+    rt: &mut Runtime,
+    target_triple: &str,
+    benchmark_dir: &Path,
+) -> anyhow::Result<()> {
+    let status = Command::new("rustup")
+        .args(&["install", "--profile=minimal", &toolchain])
+        .status()
+        .context("rustup install")?;
+    if !status.success() {
+        anyhow::bail!("failed to install toolchain for {}", toolchain);
+    }
+
+    let profiles = if collector::version_supports_doc(&toolchain) {
+        Profile::all()
+    } else {
+        Profile::all_non_doc()
+    };
+    let scenarios = if collector::version_supports_incremental(&toolchain) {
+        Scenario::all()
+    } else {
+        Scenario::all_non_incr()
+    };
+
+    let which = |tool| {
+        String::from_utf8(
+            Command::new("rustup")
+                .arg("which")
+                .arg("--toolchain")
+                .arg(&toolchain)
+                .arg(tool)
+                .output()
+                .context(format!("rustup which {}", tool))?
+                .stdout,
+        )
+        .context("utf8")
+    };
+    let rustc = which("rustc")?;
+    let rustdoc = which("rustdoc")?;
+    let cargo = which("cargo")?;
+
+    // Exclude benchmarks that don't work with a stable compiler.
+    let mut benchmarks = get_benchmarks(&benchmark_dir, None, None)?;
+    benchmarks.retain(|b| b.category().is_stable());
+
+    let res = bench(
+        rt,
+        pool,
+        &ArtifactId::Tag(toolchain),
+        &profiles,
+        &scenarios,
+        /* bench_rustc */ false,
+        Compiler {
+            rustc: Path::new(rustc.trim()),
+            rustdoc: Some(Path::new(rustdoc.trim())),
+            cargo: Path::new(cargo.trim()),
+            is_nightly: false,
+            triple: &target_triple,
+        },
+        &benchmarks,
+        Some(3),
+        /* is_self_profile */ false,
+    );
+    res.fail_if_nonzero()?;
+    Ok(())
 }
 
 fn add_perf_config(directory: &PathBuf, category: Category) {

--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -1013,14 +1013,11 @@ fn main_result() -> anyhow::Result<i32> {
             let pool = database::Pool::open(&db.db);
 
             match next {
-                NextArtifact {
-                    artifact: ArtifactId::Tag(tag),
-                    ..
-                } => {
+                NextArtifact::Release(tag) => {
                     bench_published_artifact(tag, pool, &mut rt, &target_triple, &benchmark_dir)?;
                 }
-                NextArtifact {
-                    artifact: ArtifactId::Commit(commit),
+                NextArtifact::Commit {
+                    commit,
                     include,
                     exclude,
                     runs,

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -487,7 +487,7 @@ pub struct ArtifactIdNumber(pub u32);
 pub struct Index {
     /// Id look for a commit
     commits: Indexed<Commit>,
-    /// Id lookup of the errors for a crate
+    /// Id lookup of published release artifacts
     artifacts: Indexed<Box<str>>,
     /// Id lookup of the errors for a crate
     errors: Indexed<Benchmark>,

--- a/site/src/load.rs
+++ b/site/src/load.rs
@@ -215,7 +215,7 @@ impl SiteCtxt {
         )
     }
 
-    /// Returns the not yet tested published artifacts, sorted from oldest to newest.
+    /// Returns the not yet tested published artifacts, sorted from newest to oldest.
     pub async fn missing_artifacts(&self) -> anyhow::Result<Vec<String>> {
         let artifact_list: String = reqwest::get("https://static.rust-lang.org/manifests.txt")
             .await?
@@ -242,7 +242,7 @@ impl SiteCtxt {
 
         // Gather published artifacts that are not yet tested and are not in progress
         let mut artifacts: Vec<String> = vec![];
-        for line in artifact_list.lines() {
+        for line in artifact_list.lines().rev() {
             if let Some(artifact) = parse_published_artifact_tag(&line) {
                 if !tested_artifacts.contains(artifact.as_str())
                     && !in_progress_artifacts.contains(&artifact)
@@ -250,7 +250,12 @@ impl SiteCtxt {
                     artifacts.push(artifact);
                 }
             }
+            // Ignore too old artifacts
+            if artifacts.len() == 10 {
+                break;
+            }
         }
+
         Ok(artifacts)
     }
 

--- a/site/src/load.rs
+++ b/site/src/load.rs
@@ -244,13 +244,16 @@ impl SiteCtxt {
         let mut artifacts: Vec<String> = vec![];
 
         // Ignore too old artifacts
-        for line in artifact_list.lines().rev().take(50) {
-            if let Some(artifact) = parse_published_artifact_tag(&line) {
-                if !tested_artifacts.contains(artifact.as_str())
-                    && !in_progress_artifacts.contains(&artifact)
-                {
-                    artifacts.push(artifact);
-                }
+        for artifact in artifact_list
+            .lines()
+            .rev()
+            .filter_map(parse_published_artifact_tag)
+            .take(20)
+        {
+            if !tested_artifacts.contains(artifact.as_str())
+                && !in_progress_artifacts.contains(&artifact)
+            {
+                artifacts.push(artifact);
             }
         }
 

--- a/site/src/load.rs
+++ b/site/src/load.rs
@@ -242,17 +242,15 @@ impl SiteCtxt {
 
         // Gather published artifacts that are not yet tested and are not in progress
         let mut artifacts: Vec<String> = vec![];
-        for line in artifact_list.lines().rev() {
+
+        // Ignore too old artifacts
+        for line in artifact_list.lines().rev().take(50) {
             if let Some(artifact) = parse_published_artifact_tag(&line) {
                 if !tested_artifacts.contains(artifact.as_str())
                     && !in_progress_artifacts.contains(&artifact)
                 {
                     artifacts.push(artifact);
                 }
-            }
-            // Ignore too old artifacts
-            if artifacts.len() == 10 {
-                break;
             }
         }
 

--- a/site/src/load.rs
+++ b/site/src/load.rs
@@ -7,7 +7,9 @@ use std::time::Instant;
 
 use arc_swap::{ArcSwap, Guard};
 use chrono::{Duration, Utc};
+use lazy_static::lazy_static;
 use log::error;
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 use crate::db;
@@ -213,6 +215,45 @@ impl SiteCtxt {
         )
     }
 
+    /// Returns the not yet tested published artifacts, sorted from oldest to newest.
+    pub async fn missing_artifacts(&self) -> anyhow::Result<Vec<String>> {
+        let artifact_list: String = reqwest::get("https://static.rust-lang.org/manifests.txt")
+            .await?
+            .text()
+            .await?;
+
+        lazy_static! {
+            static ref VERSION_REGEX: Regex = Regex::new(r"(\d+\.\d+.\d+)").unwrap();
+        }
+
+        let conn = self.conn().await;
+
+        let index = self.index.load();
+        let tested_artifacts: HashSet<_> = index.artifacts().collect();
+        let in_progress_artifacts: HashSet<_> = conn
+            .in_progress_artifacts()
+            .await
+            .into_iter()
+            .filter_map(|artifact| match artifact {
+                ArtifactId::Commit(_) => None,
+                ArtifactId::Tag(tag) => Some(tag),
+            })
+            .collect();
+
+        // Gather published artifacts that are not yet tested and are not in progress
+        let mut artifacts: Vec<String> = vec![];
+        for line in artifact_list.lines() {
+            if let Some(artifact) = parse_published_artifact_tag(&line) {
+                if !tested_artifacts.contains(artifact.as_str())
+                    && !in_progress_artifacts.contains(&artifact)
+                {
+                    artifacts.push(artifact);
+                }
+            }
+        }
+        Ok(artifacts)
+    }
+
     pub async fn get_benchmark_category_map(&self) -> HashMap<Benchmark, Category> {
         let benchmarks = self.pool.connection().await.get_benchmarks().await;
         benchmarks
@@ -248,6 +289,32 @@ impl SiteCtxt {
 
         commits
     }
+}
+
+/// Parses an artifact tag like `1.63.0` or `beta-2022-08-19` from a line taken from
+/// `https://static.rust-lang.org/manifests.txt`.
+fn parse_published_artifact_tag(line: &str) -> Option<String> {
+    lazy_static! {
+        static ref VERSION_REGEX: Regex = Regex::new(r"(\d+\.\d+.\d+)").unwrap();
+    }
+
+    let mut parts = line.rsplit("/").into_iter();
+    let name = parts.next();
+    let date = parts.next();
+
+    if let Some(date) = date {
+        if let Some(name) = name {
+            // Create beta artifact in the form of beta-YYYY-MM-DD
+            if name == "channel-rust-beta.toml" {
+                return Some(format!("beta-{date}"));
+            } else if let Some(capture) = VERSION_REGEX.captures(name) {
+                if let Some(version) = capture.get(1).map(|c| c.as_str()) {
+                    return Some(version.to_string());
+                }
+            }
+        }
+    }
+    None
 }
 
 /// Calculating the missing commits.

--- a/site/src/request_handlers.rs
+++ b/site/src/request_handlers.rs
@@ -2,7 +2,7 @@ mod bootstrap;
 mod dashboard;
 mod github;
 mod graph;
-mod next_commit;
+mod next_artifact;
 mod self_profile;
 mod status_page;
 
@@ -10,7 +10,7 @@ pub use bootstrap::handle_bootstrap;
 pub use dashboard::handle_dashboard;
 pub use github::handle_github;
 pub use graph::{handle_graph, handle_graphs};
-pub use next_commit::handle_next_commit;
+pub use next_artifact::handle_next_artifact;
 pub use self_profile::{
     handle_self_profile, handle_self_profile_processed_download, handle_self_profile_raw,
     handle_self_profile_raw_download,

--- a/site/src/request_handlers/next_artifact.rs
+++ b/site/src/request_handlers/next_artifact.rs
@@ -1,9 +1,28 @@
 use crate::load::{MissingReason, SiteCtxt};
-use collector::api::next_commit;
+use collector::api::next_artifact;
 
+use database::ArtifactId;
 use std::sync::Arc;
 
-pub async fn handle_next_commit(ctxt: Arc<SiteCtxt>) -> next_commit::Response {
+pub async fn handle_next_artifact(ctxt: Arc<SiteCtxt>) -> next_artifact::Response {
+    // Prefer benchmarking released artifacts first
+    match ctxt.missing_artifacts().await {
+        Ok(next_artifact) => {
+            if let Some(next_artifact) = next_artifact.into_iter().next() {
+                log::debug!("next_artifact: {next_artifact}");
+                return next_artifact::Response {
+                    artifact: Some(next_artifact::NextArtifact {
+                        artifact: ArtifactId::Tag(next_artifact),
+                        exclude: None,
+                        include: None,
+                        runs: None,
+                    }),
+                };
+            }
+        }
+        Err(error) => log::error!("Failed to fetch missing artifacts: {error:?}"),
+    }
+
     let next_commit = ctxt.missing_commits().await.into_iter().next();
 
     let next_commit = if let Some((commit, missing_reason)) = next_commit {
@@ -52,8 +71,8 @@ pub async fn handle_next_commit(ctxt: Arc<SiteCtxt>) -> next_commit::Response {
             commit.sha,
             missing_reason_dbg
         );
-        Some(next_commit::NextCommit {
-            commit,
+        Some(next_artifact::NextArtifact {
+            artifact: ArtifactId::Commit(commit),
             include,
             exclude,
             runs,
@@ -62,7 +81,7 @@ pub async fn handle_next_commit(ctxt: Arc<SiteCtxt>) -> next_commit::Response {
         None
     };
 
-    next_commit::Response {
-        commit: next_commit,
+    next_artifact::Response {
+        artifact: next_commit,
     }
 }

--- a/site/src/request_handlers/next_artifact.rs
+++ b/site/src/request_handlers/next_artifact.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 pub async fn handle_next_artifact(ctxt: Arc<SiteCtxt>) -> next_artifact::Response {
     // Prefer benchmarking released artifacts first
-    match ctxt.missing_artifacts().await {
+    match ctxt.missing_published_artifacts().await {
         Ok(next_artifact) => {
             if let Some(next_artifact) = next_artifact.into_iter().next() {
                 log::debug!("next_artifact: {next_artifact}");

--- a/site/src/request_handlers/next_artifact.rs
+++ b/site/src/request_handlers/next_artifact.rs
@@ -1,7 +1,6 @@
 use crate::load::{MissingReason, SiteCtxt};
 use collector::api::next_artifact;
 
-use database::ArtifactId;
 use std::sync::Arc;
 
 pub async fn handle_next_artifact(ctxt: Arc<SiteCtxt>) -> next_artifact::Response {
@@ -11,12 +10,7 @@ pub async fn handle_next_artifact(ctxt: Arc<SiteCtxt>) -> next_artifact::Respons
             if let Some(next_artifact) = next_artifact.into_iter().next() {
                 log::debug!("next_artifact: {next_artifact}");
                 return next_artifact::Response {
-                    artifact: Some(next_artifact::NextArtifact {
-                        artifact: ArtifactId::Tag(next_artifact),
-                        exclude: None,
-                        include: None,
-                        runs: None,
-                    }),
+                    artifact: Some(next_artifact::NextArtifact::Release(next_artifact)),
                 };
             }
         }
@@ -71,8 +65,8 @@ pub async fn handle_next_artifact(ctxt: Arc<SiteCtxt>) -> next_artifact::Respons
             commit.sha,
             missing_reason_dbg
         );
-        Some(next_artifact::NextArtifact {
-            artifact: ArtifactId::Commit(commit),
+        Some(next_artifact::NextArtifact::Commit {
+            commit,
             include,
             exclude,
             runs,

--- a/site/src/server.rs
+++ b/site/src/server.rs
@@ -361,9 +361,9 @@ async fn serve_req(server: Server, req: Request) -> Result<Response, ServerError
                 .handle_get_async(&req, |c| request_handlers::handle_status_page(c))
                 .await;
         }
-        "/perf/next_commit" => {
+        "/perf/next_artifact" => {
             return server
-                .handle_get_async(&req, |c| request_handlers::handle_next_commit(c))
+                .handle_get_async(&req, |c| request_handlers::handle_next_artifact(c))
                 .await;
         }
         "/perf/triage" if *req.method() == http::Method::GET => {


### PR DESCRIPTION
https://static.rust-lang.org/manifests.txt is used to download all stable and beta releases. Those that are not yet in DB are then returned from the `next_artifact` endpoint and benchmarked in `BenchNext`.

Fixes: https://github.com/rust-lang/rustc-perf/issues/1419