### PR TITLE
Do not return NaN or Infinity significance factors

### DIFF
--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -194,7 +194,7 @@ pub mod comparison {
         pub profile: String,
         pub scenario: String,
         pub is_relevant: bool,
-        pub significance_factor: Option<f64>,
+        pub significance_factor: f64,
         pub statistics: (f64, f64),
     }
 }


### PR DESCRIPTION
The new artifact size results are so stable that their significance thresholds are very low. This creates some numerical problems that can be seen [here](https://perf.rust-lang.org/compare.html?start=25ea5a36c6e3a4fa1f739538d9e89eb1cd747564&end=e2e3da0be1bf838c7b3199740a227236918a5a48&stat=size%3Alinked_artifact).

Here for the first 7 results, the significance factor is Infinity, while for the last two it's NaN.

This PR changes the factor calculation so that it turns NaN and Infinity into a zero (the `is_finite` call handles both NaNs and Infinity, or so it claims). It also removes the `Option`, since the function always returned `Some` and there is no other usage of it anywhere.

One problem remains though, the `is_relevant` calculation would still consider these 9 results to be relevant, even though the significance factor would be zero, since it only compares the relative change to the significance threshold, which is low. Should I add a special case that forcefully considers the benchmark to not be relevant if the significance factor is zero?