### PR TITLE
Add PR number and commit to log for failed rollup merge

### DIFF
--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -92,7 +92,9 @@ async fn enqueue_unrolled_try_builds<'a>(
                 &format!("Unrolled build for #{}", original_pr_number),
             )
             .await
-            .map_err(|e| format!("Error merging commit into perf-tmp: {e:?}"))?;
+            .map_err(|e| {
+                format!("Error merging #{original_pr_number}'s commit '{rolled_up_head}' into perf-tmp: {e:?}")
+            })?;
 
         // Force the `try-perf` branch to point to what the perf-tmp branch points to
         client


### PR DESCRIPTION
This will help investigating #1424 which failed due to a merge conflict. The logs don't show which PR or commit failed though. 