### PR TITLE
Add Markdown export button to compare page

### DIFF
--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -275,7 +275,11 @@
                     </div>
                     <input type="checkbox" v-model="showRawData" style="margin-left: 20px;" />
                 </div>
-                <button @click="resetFilter">Reset filters</button>
+                <button @click="resetFilter" style="margin-right: 10px;">Reset filters</button>
+                <button @click="exportToMarkdown"
+                        title="Download the currently filtered data as a Markdown table">
+                    Export to Markdown
+                </button>
             </div>
         </fieldset>
         <p v-if="dataLoading && !data">Loading ...</p>

--- a/site/static/compare/script.js
+++ b/site/static/compare/script.js
@@ -287,6 +287,9 @@ const app = Vue.createApp({
         },
         resetFilter() {
             this.filter = createDefaultFilter();
+        },
+        exportToMarkdown() {
+            exportToMarkdown(this.testCases);
         }
     },
 });
@@ -707,6 +710,67 @@ function submitSettings() {
     let end = document.getElementById("end-bound").value;
     let params = createSearchParamsForMetric(stat, start, end);
     window.location.search = params.toString();
+}
+
+function exportToMarkdown(testCases) {
+    function changesTable(cases) {
+        let data = "| Benchmark | Profile | Scenario | % Change | Significance Factor |\n";
+        data += "|:---:|:---:|:---:|:---:|:---:|\n"
+
+        for (const testCase of cases) {
+            data += `| ${testCase.benchmark} | ${testCase.profile} | ${testCase.scenario} `;
+            data += `| ${testCase.percent.toFixed(2)}% | ${testCase.significanceFactor.toFixed(2)}x\n`;
+        }
+
+        return data;
+    }
+
+    const summary = computeSummary(testCases);
+    const regressions = summary.regressions;
+    const improvements = summary.improvements;
+    const all = summary.all;
+
+    function formatRange(range) {
+        if (range.length === 0) {
+            return "-";
+        }
+        return `${range[0].toFixed(2)}%, ${range[1].toFixed(2)}%`;
+    }
+
+    let content = "# Summary\n";
+    content += "| | Range | Mean | Count |\n";
+    content += "|:---:|:---:|:---:|:---:|\n";
+    content += `| Regressions | ${formatRange(regressions.range)} | ${regressions.average.toFixed(2)}% | ${regressions.count} |\n`;
+    content += `| Improvements | ${formatRange(improvements.range)} | ${improvements.average.toFixed(2)}% | ${improvements.count} |\n`;
+    content += `| All | ${formatRange(all.range)} | ${all.average.toFixed(2)}% | ${all.count} |\n\n`;
+
+    content += "# Primary benchmarks\n";
+    content += changesTable(testCases.filter(testCase => testCase.category === "primary"));
+
+    content += "\n# Secondary benchmarks\n";
+    content += changesTable(testCases.filter(testCase => testCase.category === "secondary"));
+
+    downloadFile(content, "perf-summary.md");
+}
+
+function downloadFile(content, name) {
+    const blob = new Blob([content], {
+        type: "text/markdown"
+    });
+
+    const url = window.URL.createObjectURL(blob);
+
+    // Create a fake link (taken from https://stackoverflow.com/a/9834261/1107768)
+    const a = document.createElement("a");
+    a.style.display = "none";
+    a.href = url;
+    a.download = name;
+
+    const inserted = document.body.appendChild(a);
+    a.click();
+
+    window.URL.revokeObjectURL(url);
+    inserted.remove();
 }
 
 app.mount('#app');


### PR DESCRIPTION
This PR adds a button to export the (currently filtered) data from the compare page to Markdown (it will be downloaded as a Markdown file). The Markdown file will contain the summary of all filtered results and the two changes tables (for primary and secondary benchmarks). It can be useful e.g. to paste this data to GitHub comments.

I have put the button to the Filters section, because:
1) It is opened by default
2) Here it won't eat away vertical space from the rest of the page
3) It exports the currently filtered data

But it can be moved pretty much anywhere.

![image](https://user-images.githubusercontent.com/4539057/186883762-812363aa-10eb-4571-a02f-647b84d7b9ea.png)

<details>
<summary>Example exported Markdown tables</summary>

# Summary
| | Range | Mean | Count |
|:---:|:---:|:---:|:---:|
| Regressions | 0.30%, 2.78% | 0.82% | 133 |
| Improvements | -26.83%, -0.30% | -2.48% | 269 |
| All | -26.83%, 2.78% | -1.39% | 402 |

# Primary benchmarks
| Benchmark | Profile | Scenario | % Change | Significance Factor |
|:---:|:---:|:---:|:---:|:---:|

# Secondary benchmarks
| Benchmark | Profile | Scenario | % Change | Significance Factor |
|:---:|:---:|:---:|:---:|:---:|
| match-stress-enum | check | full | -26.83% | 134.17x
| match-stress-enum | check | incr-full | -26.00% | 130.00x
| match-stress-enum | debug | full | -25.20% | 126.01x
| match-stress-enum | opt | full | -25.09% | 125.46x
| match-stress-enum | debug | incr-full | -24.33% | 121.63x
| match-stress-enum | opt | incr-full | -24.25% | 121.24x
| deeply-nested-async | debug | full | -12.84% | 64.22x
| deeply-nested-async | opt | full | -12.29% | 61.44x
| deeply-nested-async | debug | incr-full | -12.15% | 60.74x
| syn | opt | incr-unchanged | -10.06% | 50.29x
| diesel | doc | full | -9.48% | 47.42x
| deeply-nested-async | opt | incr-full | -7.88% | 39.41x
| externs | debug | full | -7.16% | 35.81x
| externs | opt | full | -7.12% | 35.61x
| externs | debug | incr-unchanged | -6.93% | 34.65x
| externs | opt | incr-unchanged | -6.93% | 34.65x
| externs | debug | incr-full | -6.39% | 31.96x
| externs | opt | incr-full | -6.36% | 31.81x
| webrender-wrench | doc | full | -5.47% | 27.33x
| tokio-webpush-simple | doc | full | -5.03% | 25.13x
| token-stream-stress | doc | full | -4.93% | 24.66x
| issue-46449 | doc | full | -4.87% | 24.35x
| regression-31157 | doc | full | -4.84% | 24.21x
| syn | opt | full | -4.81% | 24.03x

</details>


Closes: https://github.com/rust-lang/rustc-perf/issues/302