### PR TITLE
Migrate from `winapi` to `windows_sys`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "walkdir",
- "winapi",
+ "windows-sys",
  "xz2",
 ]
 
@@ -2448,6 +2448,49 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "winreg"

--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -36,7 +36,7 @@ rayon = "1.5.2"
 
 [target.'cfg(windows)'.dependencies]
 miow = "0.3"
-winapi = { version = "0.3", features = ["winerror"] }
+windows-sys = { version = "0.36.1", features = ["Win32_Foundation"] }
 
 [[bin]]
 name = "collector"

--- a/collector/src/read2.rs
+++ b/collector/src/read2.rs
@@ -107,7 +107,7 @@ mod imp {
     use miow::iocp::{CompletionPort, CompletionStatus};
     use miow::pipe::NamedPipe;
     use miow::Overlapped;
-    use winapi::shared::winerror::ERROR_BROKEN_PIPE;
+    use windows_sys::Win32::Foundation::ERROR_BROKEN_PIPE;
 
     struct Pipe<'a> {
         dst: &'a mut Vec<u8>,


### PR DESCRIPTION
1. [Winapi is no longer actively](https://github.com/retep998/winapi-rs/issues/867 ) maintained (last commit was 9 months ago as of now and 2nd last around 2 years ago) compared to last commit to [windows-rs ](https://github.com/microsoft/windows-rs)as of 3 days ago.
2. [windows-rs](https://github.com/microsoft/windows-rs) is the official Rust crate for Windows by Microsoft and is supposed to be providing a natural and idiomatic way for Rust developers to call Windows APIs. Some crates like [socket2](https://github.com/rust-lang/socket2) have already migrated to it.