### PR TITLE
Add the option to ignore certain profiles in `perf-config.json`

### DIFF
--- a/collector/src/benchmark/profile.rs
+++ b/collector/src/benchmark/profile.rs
@@ -1,4 +1,4 @@
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, clap::ArgEnum)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, clap::ArgEnum, serde::Deserialize)]
 #[clap(rename_all = "PascalCase")]
 pub enum Profile {
     Check,


### PR DESCRIPTION
This is useful for benchmarks that only care about a narrow metric (like the resulting binary size). With this setting, they can ignore e.g. check and doc builds to:
1) Save perf.rlo time from doing non-interesting benchmarks
2) Remove duplicate regressions/improvements for things that we don't care about specifically

This feature will be used for size benchmarks (https://github.com/rust-lang/rustc-perf/pull/1413).

We don't really need to add the same field for scenarios, because ignoring scenarios is simply done by not adding any patch files.