### PR TITLE
Cleanups after artifact collection

### DIFF
--- a/collector/collect.sh
+++ b/collector/collect.sh
@@ -22,14 +22,6 @@ while : ; do
         # Install measureme tooling
         cargo install --git https://github.com/rust-lang/measureme --branch stable flamegraph crox summarize
 
-        touch todo-artifacts
-        for x in $(cat todo-artifacts) ; do
-                echo "Benching $x from todo-artifacts"
-                target/release/collector bench_published $x --db $DATABASE;
-        done
-        rm todo-artifacts
-        touch todo-artifacts
-
         target/release/collector bench_next $SITE_URL --self-profile --bench-rustc --db $DATABASE;
         echo finished run at `date`;
 

--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -756,6 +756,8 @@ fn main_result() -> anyhow::Result<i32> {
             match next {
                 NextArtifact::Release(tag) => {
                     bench_published_artifact(tag, pool, &mut rt, &target_triple, &benchmark_dir)?;
+
+                    client.post(&format!("{}/perf/onpush", site_url)).send()?;
                 }
                 NextArtifact::Commit {
                     commit,


### PR DESCRIPTION
First commit prevents the site from stalling, since it doesn't otherwise process
the queue again to notice that the artifact is fully done.

Also removes the artifact code from the collector script itself in the second commit.