### PR TITLE
Add a filter for try commits in graphs, compare page and triage

### DIFF
--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -37,10 +37,10 @@ impl Bound {
     pub fn left_match(&self, commit: &Commit) -> bool {
         match self {
             Bound::Commit(sha) => commit.sha == **sha,
-            Bound::Date(date) => commit.date.0.naive_utc().date() >= *date,
+            Bound::Date(date) => commit.is_master() && commit.date.0.naive_utc().date() >= *date,
             Bound::None => {
                 let last_month = chrono::Utc::now().date().naive_utc() - chrono::Duration::days(30);
-                last_month <= commit.date.0.naive_utc().date()
+                commit.is_master() && last_month <= commit.date.0.naive_utc().date()
             }
         }
     }
@@ -49,8 +49,8 @@ impl Bound {
     pub fn right_match(&self, commit: &Commit) -> bool {
         match self {
             Bound::Commit(sha) => commit.sha == **sha,
-            Bound::Date(date) => commit.date.0.date().naive_utc() <= *date,
-            Bound::None => true,
+            Bound::Date(date) => commit.is_master() && commit.date.0.date().naive_utc() <= *date,
+            Bound::None => commit.is_master(),
         }
     }
 }

--- a/site/src/request_handlers/graph.rs
+++ b/site/src/request_handlers/graph.rs
@@ -80,7 +80,11 @@ async fn create_graphs(
     request: graphs::Request,
     ctxt: &SiteCtxt,
 ) -> ServerResult<Arc<graphs::Response>> {
-    let artifact_ids = Arc::new(artifact_ids_for_range(ctxt, request.start, request.end));
+    let artifact_ids = Arc::new(master_artifact_ids_for_range(
+        ctxt,
+        request.start,
+        request.end,
+    ));
     let mut benchmarks = HashMap::new();
 
     let create_selector = |filter: &Option<String>| -> Selector<String> {
@@ -150,6 +154,15 @@ fn artifact_ids_for_range(ctxt: &SiteCtxt, start: Bound, end: Bound) -> Vec<Arti
         .enumerate()
         .filter(|(index, commit)| *index == 0 || *index == count - 1 || commit.is_master())
         .map(|c| c.1.into())
+        .collect()
+}
+
+/// Returns master commit artifact IDs for the given range.
+fn master_artifact_ids_for_range(ctxt: &SiteCtxt, start: Bound, end: Bound) -> Vec<ArtifactId> {
+    ctxt.data_range(start..=end)
+        .into_iter()
+        .filter(|commit| commit.is_master())
+        .map(|commit| commit.into())
         .collect()
 }
 


### PR DESCRIPTION
Before these changes, try commits could appear in graphs/index page (when no filter was selected), compare page start/end bounds (when no bound was selected) and also in triage I think.

Fixes: https://github.com/rust-lang/rustc-perf/issues/1406