### PR TITLE
Increase `--num-callers` from 4 to 8 for DHAT.

### DIFF
--- a/collector/src/bin/rustc-fake.rs
+++ b/collector/src/bin/rustc-fake.rs
@@ -287,7 +287,7 @@ fn main() {
                 let has_valgrind = cmd.output().is_ok();
                 assert!(has_valgrind);
                 cmd.arg("--tool=dhat")
-                    .arg("--num-callers=4")
+                    .arg("--num-callers=8")
                     .arg("--dhat-out-file=dhout")
                     .arg(&tool)
                     .args(&args);
@@ -301,7 +301,7 @@ fn main() {
                 assert!(has_valgrind);
                 cmd.arg("--tool=dhat")
                     .arg("--mode=copy")
-                    .arg("--num-callers=4")
+                    .arg("--num-callers=8")
                     .arg("--dhat-out-file=dhcopy")
                     .arg(&tool)
                     .args(&args);


### PR DESCRIPTION
I sometimes find myself making this change locally, when 4 doesn't give deep enough stacks.