### PR TITLE
Ping `wg-compiler-performance` if a master commit breaks some benchmark

### DIFF
--- a/site/src/github/comparison_summary.rs
+++ b/site/src/github/comparison_summary.rs
@@ -169,6 +169,9 @@ async fn summarize_run(
 
     if !errors.is_empty() {
         writeln!(&mut message, "\n{errors}").unwrap();
+        if is_master_commit {
+            writeln!(&mut message, "\ncc @rust-lang/wg-compiler-performance").unwrap();
+        }
     }
 
     let mut table_written = false;


### PR DESCRIPTION
To find out ASAP that some PR broke something. If it was also a regression, the `CC` will there be twice, but I don't suppose that it's too important, it shouldn't send two notifications I hope :)