### PR TITLE
Pin Bytehound to a specific commit in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,8 @@ jobs:
         run: |
           git clone https://github.com/koute/bytehound
           cd bytehound
+          # Newer versions of Bytehound use unstable features
+          git checkout bcae7caa3b01bb60ec6d4159ac8b9af28a7c927a
           cargo build --release -p bytehound-preload
           echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${PWD}/target/release" >> $GITHUB_ENV
 


### PR DESCRIPTION
CI started failing because `bytehound` recently added feature flags (https://github.com/rust-lang/rustc-perf/pull/1457's CI failed because of it).

`clone` cannot directly download only a single revision (only a single branch) AFAIK, so I just checkout a SHA that we know was working.