### PR TITLE
Add a BufReader benchmark for reads smaller than the buffer

### DIFF
--- a/collector/runtime-benchmarks/Cargo.lock
+++ b/collector/runtime-benchmarks/Cargo.lock
@@ -65,6 +65,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bufreader"
+version = "0.1.0"
+dependencies = [
+ "benchlib",
+ "snap",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,6 +365,12 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "snap"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45456094d1983e2ee2a18fdfebce3189fa451699d0502cb8e3b49dba5ba41451"
 
 [[package]]
 name = "strsim"

--- a/collector/runtime-benchmarks/Cargo.toml
+++ b/collector/runtime-benchmarks/Cargo.toml
@@ -1,2 +1,6 @@
 [workspace]
-members = ["hashmap", "nbody"]
+members = [
+    "hashmap",
+    "nbody",
+    "bufreader",
+]

--- a/collector/runtime-benchmarks/bufreader/Cargo.toml
+++ b/collector/runtime-benchmarks/bufreader/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "bufreader"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+benchlib = { path = "../../benchlib" }
+snap = "1.0.5"

--- a/collector/runtime-benchmarks/bufreader/src/main.rs
+++ b/collector/runtime-benchmarks/bufreader/src/main.rs
@@ -1,0 +1,34 @@
+use benchlib::benchmark::{black_box, BenchmarkSuite};
+use snap::{read::FrameDecoder, write::FrameEncoder};
+use std::io::{BufRead, BufReader, Write};
+
+const BYTES: usize = 64 * 1024 * 1024;
+
+fn main() {
+    let mut suite = BenchmarkSuite::new();
+
+    // Inspired by https://github.com/rust-lang/rust/issues/102727
+    // The pattern we want is a BufReader which wraps a Read impl where one Read::read call will
+    // never fill the whole BufReader buffer.
+    suite.register("bufreader-snappy", || {
+        let data = vec![0u8; BYTES];
+        move || {
+            let mut compressed = Vec::new();
+            FrameEncoder::new(&mut compressed)
+                .write_all(&data[..])
+                .unwrap();
+            let mut reader = BufReader::with_capacity(BYTES, FrameDecoder::new(&compressed[..]));
+
+            while let Ok(buf) = reader.fill_buf() {
+                if buf.is_empty() {
+                    break;
+                }
+                black_box(buf);
+                let len = buf.len();
+                reader.consume(len);
+            }
+        }
+    });
+
+    suite.run().unwrap();
+}


### PR DESCRIPTION
I think this is a reasonably-real-world example of running into the regression in https://github.com/rust-lang/rust/issues/102727

The idea is that a user may drive a `BufReader` by manually accessing the buffer, then calling `consume` then `fill_buf`. The regression is hit when the wrapped `Read` impl doesn't fill the whole `BufReader` buffer in one read. Which a snappy decoder won't, because a decompressed data frame is limited to 65536 bytes.