### PR TITLE
Use a macro for defining benchmarks

### DIFF
--- a/collector/benchlib/src/benchmark.rs
+++ b/collector/benchlib/src/benchmark.rs
@@ -89,6 +89,24 @@ fn run_benchmark(args: BenchmarkArgs, benchmarks: BenchmarkMap) -> anyhow::Resul
     Ok(())
 }
 
+/// Adds a single benchmark to the benchmark suite.
+/// ```ignore
+/// use benchlib::define_benchmark;
+///
+/// define_benchmark!(suite, my_bench, {
+///     || do_something()
+/// });
+/// ```
+#[macro_export]
+macro_rules! define_benchmark {
+    ($suite:expr, $name:ident, $fun:expr) => {
+        let func = move || $fun;
+        $suite.register(stringify!($name), func);
+    };
+}
+
+pub use define_benchmark;
+
 /// Tests if the name of the benchmark passes through the include and exclude filter flags.
 fn passes_filter(name: &str, exclude: Option<&str>, include: Option<&str>) -> bool {
     match (exclude, include) {

--- a/collector/runtime-benchmarks/bufreader/src/main.rs
+++ b/collector/runtime-benchmarks/bufreader/src/main.rs
@@ -1,34 +1,36 @@
-use benchlib::benchmark::{black_box, BenchmarkSuite};
-use snap::{read::FrameDecoder, write::FrameEncoder};
 use std::io::{BufRead, BufReader, Write};
+
+use snap::{read::FrameDecoder, write::FrameEncoder};
+
+use benchlib::benchmark::{benchmark_suite, black_box};
+use benchlib::define_benchmark;
 
 const BYTES: usize = 64 * 1024 * 1024;
 
 fn main() {
-    let mut suite = BenchmarkSuite::new();
-
     // Inspired by https://github.com/rust-lang/rust/issues/102727
     // The pattern we want is a BufReader which wraps a Read impl where one Read::read call will
     // never fill the whole BufReader buffer.
-    suite.register("bufreader-snappy", || {
-        let data = vec![0u8; BYTES];
-        move || {
-            let mut compressed = Vec::new();
-            FrameEncoder::new(&mut compressed)
-                .write_all(&data[..])
-                .unwrap();
-            let mut reader = BufReader::with_capacity(BYTES, FrameDecoder::new(&compressed[..]));
+    benchmark_suite(|suite| {
+        define_benchmark!(suite, bufreader_snappy, {
+            let data = vec![0u8; BYTES];
+            move || {
+                let mut compressed = Vec::new();
+                FrameEncoder::new(&mut compressed)
+                    .write_all(&data[..])
+                    .unwrap();
+                let mut reader =
+                    BufReader::with_capacity(BYTES, FrameDecoder::new(&compressed[..]));
 
-            while let Ok(buf) = reader.fill_buf() {
-                if buf.is_empty() {
-                    break;
+                while let Ok(buf) = reader.fill_buf() {
+                    if buf.is_empty() {
+                        break;
+                    }
+                    black_box(buf);
+                    let len = buf.len();
+                    reader.consume(len);
                 }
-                black_box(buf);
-                let len = buf.len();
-                reader.consume(len);
             }
-        }
+        });
     });
-
-    suite.run().unwrap();
 }

--- a/collector/runtime-benchmarks/hashmap/src/main.rs
+++ b/collector/runtime-benchmarks/hashmap/src/main.rs
@@ -1,18 +1,20 @@
 use benchlib;
-use benchlib::benchmark::BenchmarkSuite;
+use benchlib::benchmark::benchmark_suite;
+use benchlib::define_benchmark;
 
 fn main() {
-    let mut suite = BenchmarkSuite::new();
-
-    /// Measures how long does it take to insert 10 thousand numbers into a `hashbrown` hashmap.
-    suite.register("hashmap-insert-10k", || {
-        let mut map =
-            hashbrown::HashMap::with_capacity_and_hasher(10000, fxhash::FxBuildHasher::default());
-        move || {
-            for index in 0..10000 {
-                map.insert(index, index);
+    benchmark_suite(|suite| {
+        // Measures how long does it take to insert 10 thousand numbers into a `hashbrown` hashmap.
+        define_benchmark!(suite, hashmap_insert_10k, {
+            let mut map = hashbrown::HashMap::with_capacity_and_hasher(
+                10000,
+                fxhash::FxBuildHasher::default(),
+            );
+            move || {
+                for index in 0..10000 {
+                    map.insert(index, index);
+                }
             }
-        }
+        });
     });
-    suite.run().unwrap();
 }

--- a/collector/runtime-benchmarks/nbody/src/main.rs
+++ b/collector/runtime-benchmarks/nbody/src/main.rs
@@ -2,12 +2,13 @@
 //! Code taken from https://github.com/prestontw/rust-nbody
 
 use benchlib::benchmark::benchmark_suite;
+use benchlib::define_benchmark;
 
 mod nbody;
 
 fn main() {
     benchmark_suite(|suite| {
-        suite.register("nbody-10k", || {
+        define_benchmark!(suite, nbody_10k, {
             let mut nbody_10k = nbody::init(10000);
             || {
                 for _ in 0..10 {


### PR DESCRIPTION
This is done mostly for forward compatibility. In the future, it might make sense to normalize the benchmark functions (e.g. apply `#[inline(never)]` to them, align them to some boundary to reduce code alignment issues etc.). This can be a bit difficult to do with closures, maybe we will need to generate actual functions.

For that reason, I suggest to change benchmark definition to a macro. That will allow us to easily change the inner representation in the future without needing to change the code of all runtime benchmarks. This PR introduces the macro, but still keeps benchmarks as closures.