### PR TITLE
Fix CI package installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,7 @@ jobs:
 
       - name: Configure environment
         run: |
+          sudo apt-get update
           sudo apt-get install -y linux-tools-common linux-tools-generic linux-tools-`uname -r`
           echo -1 | sudo tee /proc/sys/kernel/perf_event_paranoid
 


### PR DESCRIPTION
Some package was returning 404, let's see if updating `apt` cache helps with it.