### PR TITLE
Stream Cargo output interactively when compiling runtime benchmarks

### DIFF
--- a/collector/src/runtime/benchmark.rs
+++ b/collector/src/runtime/benchmark.rs
@@ -1,10 +1,12 @@
+use crate::toolchain::LocalToolchain;
 use benchlib::benchmark::passes_filter;
 use cargo_metadata::Message;
 use core::option::Option;
 use core::option::Option::Some;
 use core::result::Result::Ok;
+use std::io::BufReader;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Child, Command, Stdio};
 
 /// A binary that defines several benchmarks using the `run_benchmark_group` function from
 /// `benchlib`.
@@ -65,10 +67,17 @@ impl BenchmarkFilter {
 /// We assume that each binary defines a benchmark suite using `benchlib`.
 /// We then execute each benchmark suite with the `list-benchmarks` command to find out its
 /// benchmark names.
-pub fn discover_benchmarks(cargo_stdout: &[u8]) -> anyhow::Result<BenchmarkSuite> {
+pub fn discover_benchmarks(
+    toolchain: &LocalToolchain,
+    dir: &Path,
+) -> anyhow::Result<BenchmarkSuite> {
+    log::info!("Compiling runtime benchmarks");
+    let mut child = start_runtime_benchmarks_compilation(toolchain, dir)?;
+
     let mut groups = vec![];
 
-    for message in Message::parse_stream(cargo_stdout) {
+    let stream = BufReader::new(child.stdout.take().unwrap());
+    for message in Message::parse_stream(stream) {
         let message = message?;
         match message {
             Message::CompilerArtifact(artifact) => {
@@ -81,6 +90,7 @@ pub fn discover_benchmarks(cargo_stdout: &[u8]) -> anyhow::Result<BenchmarkSuite
                                 path.display()
                             )
                         })?;
+                        log::info!("Compiled {}", path.display());
                         groups.push(BenchmarkGroup {
                             binary: path,
                             benchmark_names: benchmarks,
@@ -88,14 +98,47 @@ pub fn discover_benchmarks(cargo_stdout: &[u8]) -> anyhow::Result<BenchmarkSuite
                     }
                 }
             }
-            _ => {}
+            Message::TextLine(line) => println!("{}", line),
+            Message::CompilerMessage(msg) => {
+                print!("{}", msg.message.rendered.unwrap_or(msg.message.message))
+            }
+            _ => {
+                log::debug!("Cargo metadata output: {:?}", message);
+            }
         }
+    }
+
+    let output = child.wait()?;
+    if output.success() {
+        log::info!("Successfully compiled runtime benchmarks");
+    } else {
+        return Err(anyhow::anyhow!("Failed to compile runtime benchmarks"));
     }
 
     groups.sort_unstable_by(|a, b| a.binary.cmp(&b.binary));
     log::debug!("Found binaries: {:?}", groups);
 
     Ok(BenchmarkSuite { groups })
+}
+
+/// Compiles all runtime benchmark binaries (groups) and returns the stdout output stream of Cargo.
+fn start_runtime_benchmarks_compilation(
+    toolchain: &LocalToolchain,
+    dir: &Path,
+) -> anyhow::Result<Child> {
+    let child = Command::new(&toolchain.cargo)
+        .env("RUSTC", &toolchain.rustc)
+        .arg("build")
+        .arg("--release")
+        .arg("--message-format")
+        .arg("json-diagnostic-rendered-ansi")
+        .current_dir(dir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|error| anyhow::anyhow!("Failed to start cargo: {:?}", error))?;
+    Ok(child)
 }
 
 /// Uses a command from `benchlib` to find the benchmark names from the given


### PR DESCRIPTION
This also formats any compilation errors in runtime benchmarks properly and prints them to stdout.