### PR TITLE
Change runtime benchmark definition to always refer to a self-contained function

### DIFF
--- a/collector/benchlib/src/lib.rs
+++ b/collector/benchlib/src/lib.rs
@@ -18,3 +18,6 @@ mod cli;
 pub mod comm;
 pub mod measure;
 pub mod process;
+
+pub use benchmark::black_box;
+pub use benchmark::run_benchmark_group;

--- a/collector/runtime-benchmarks/bufreader/src/main.rs
+++ b/collector/runtime-benchmarks/bufreader/src/main.rs
@@ -1,36 +1,37 @@
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, Cursor, Write};
 
 use snap::{read::FrameDecoder, write::FrameEncoder};
 
-use benchlib::benchmark::{black_box, run_benchmark_group};
-use benchlib::define_benchmark;
+use benchlib::{black_box, define_benchmark, run_benchmark_group};
 
-const BYTES: usize = 64 * 1024 * 1024;
+// Inspired by https://github.com/rust-lang/rust/issues/102727
+// The pattern we want is a BufReader which wraps a Read impl where one Read::read call will
+// never fill the whole BufReader buffer.
+fn read_buf(
+    mut reader: BufReader<FrameDecoder<Cursor<Vec<u8>>>>,
+) -> BufReader<FrameDecoder<Cursor<Vec<u8>>>> {
+    while let Ok(buf) = reader.fill_buf() {
+        if buf.is_empty() {
+            break;
+        }
+        black_box(buf);
+        let len = buf.len();
+        reader.consume(len);
+    }
+    reader
+}
 
 fn main() {
-    // Inspired by https://github.com/rust-lang/rust/issues/102727
-    // The pattern we want is a BufReader which wraps a Read impl where one Read::read call will
-    // never fill the whole BufReader buffer.
     run_benchmark_group(|group| {
-        define_benchmark!(group, bufreader_snappy, {
-            let data = vec![0u8; BYTES];
-            move || {
-                let mut compressed = Vec::new();
-                FrameEncoder::new(&mut compressed)
-                    .write_all(&data[..])
-                    .unwrap();
-                let mut reader =
-                    BufReader::with_capacity(BYTES, FrameDecoder::new(&compressed[..]));
+        define_benchmark!(group, "bufreader_snappy", read_buf, {
+            const BYTES: usize = 64 * 1024 * 1024;
 
-                while let Ok(buf) = reader.fill_buf() {
-                    if buf.is_empty() {
-                        break;
-                    }
-                    black_box(buf);
-                    let len = buf.len();
-                    reader.consume(len);
-                }
-            }
+            let data = vec![0u8; BYTES];
+            let mut compressed = Vec::new();
+            FrameEncoder::new(&mut compressed)
+                .write_all(&data[..])
+                .unwrap();
+            BufReader::with_capacity(BYTES, FrameDecoder::new(Cursor::new(compressed)))
         });
     });
 }

--- a/collector/runtime-benchmarks/hashmap/src/main.rs
+++ b/collector/runtime-benchmarks/hashmap/src/main.rs
@@ -1,20 +1,27 @@
-use benchlib;
-use benchlib::benchmark::run_benchmark_group;
-use benchlib::define_benchmark;
+use benchlib::{define_benchmark, run_benchmark_group};
+use fxhash::FxBuildHasher;
+use hashbrown::HashMap;
+
+fn map_insert(
+    (mut map, count): (HashMap<usize, usize, FxBuildHasher>, usize),
+) -> HashMap<usize, usize, FxBuildHasher> {
+    for index in 0..count {
+        map.insert(index, index);
+    }
+    map
+}
 
 fn main() {
     run_benchmark_group(|group| {
         // Measures how long does it take to insert 10 thousand numbers into a `hashbrown` hashmap.
-        define_benchmark!(group, hashmap_insert_10k, {
-            let mut map = hashbrown::HashMap::with_capacity_and_hasher(
+        define_benchmark!(group, "hashmap_insert_10k", map_insert, {
+            (
+                hashbrown::HashMap::with_capacity_and_hasher(
+                    10000,
+                    fxhash::FxBuildHasher::default(),
+                ),
                 10000,
-                fxhash::FxBuildHasher::default(),
-            );
-            move || {
-                for index in 0..10000 {
-                    map.insert(index, index);
-                }
-            }
+            )
         });
     });
 }

--- a/collector/runtime-benchmarks/nbody/src/main.rs
+++ b/collector/runtime-benchmarks/nbody/src/main.rs
@@ -1,21 +1,19 @@
 //! Calculates the N-body simulation.
 //! Code taken from https://github.com/prestontw/rust-nbody
 
-use benchlib::benchmark::run_benchmark_group;
-use benchlib::define_benchmark;
+use benchlib::{define_benchmark, run_benchmark_group};
 
 mod nbody;
 
+fn calculate_nbody(mut body: nbody::BodyStates) -> nbody::BodyStates {
+    for _ in 0..3 {
+        body = nbody::compute_forces(body);
+    }
+    body
+}
+
 fn main() {
     run_benchmark_group(|group| {
-        define_benchmark!(group, nbody_10k, {
-            let mut nbody_10k = nbody::init(10000);
-            || {
-                for _ in 0..10 {
-                    nbody_10k = nbody::compute_forces(nbody_10k);
-                }
-                nbody_10k
-            }
-        });
+        define_benchmark!(group, "nbody_10k", calculate_nbody, nbody::init(10000));
     });
 }


### PR DESCRIPTION
Ok, hear me out :grin: I realize that this change might be a bit controversial, but I think that it has some benefits.

Basically, this PR changes the `define_benchmark` macro in the runtime benchmark suite in a way that forces us to pass a named function instead of a closure (we now have to pass an identifier, example below). This makes the benchmark definition a bit more verbose for the simplest cases, but the fact that we will have a proper, named function in the resulting benchmark binary for each piece of code that we want to benchmark also has advantages:

- We can provide functionality that diffs the codegen (assembly, LLVM IR, MIR) for a specific benchmark between two compiler versions. I think that this functionality could be quite useful for investigating performance regressions. This is in theory doable with closures (maybe we could emit some special markers at the beginning/start of the closure that are propagated to assembly?), but it gets so much easier when it's just a normal function. We can use e.g. `cargo-show-asm` for this (I have already tried it). Of course, the diff will be less useful if the function is not self contained and uses a lot of other code.
- By being a function, we can be more confident in what we are actually benchmarking. Currently we have dynamically created a closure from another closure that prepared data, but it's unclear whether some inlining is happening between them and what part of the code is being benchmarked exactly (it's also not that easy to control the inlining of closures). By using a function, we can be quite explicit, and even force `#[inline(never)]` for the benchmarked functions, if it's needed (either automatically by providing some macro for defining the functions or some wrapper function or just by checking it in review).

I also think that it might be useful to try some of the benchmarks with e.g. different input sizes. We can't be as wild and dynamic as you could be in e.g. `criterion`, by trying thousands of combinations, because we will want to have stable names for the benchmarks for easier DB and UI processing (unless we come up with some other parametrization system for runtime benchmarks, but that seems difficult and unlikely). But I think that something like this might make sense:

```rust
fn map_insert(mut map: HashMap<usize, usize, FxBuildHasher>) -> HashMap<usize, usize, FxBuildHasher> {
    let capacity = map.capacity();
    for index in 0..capacity {
        map.insert(index, index);
    }
    map
}

fn main() {
    run_benchmark_group(|group| {
        // Measures how long does it take to insert 10 thousand numbers into a `hashbrown` hashmap.
        define_benchmark!(
            group,
            "hashmap_insert_10k",
            map_insert,
            hashbrown::HashMap::with_capacity_and_hasher(10000, fxhash::FxBuildHasher::default())
        );

        // Measures how long does it take to insert 100 thousand numbers into a `hashbrown` hashmap.
        define_benchmark!(
            group,
            "hashmap_insert_100k",
            map_insert,
            hashbrown::HashMap::with_capacity_and_hasher(100000, fxhash::FxBuildHasher::default())
        );
    });
}
```
The code is a bit long because of formatting and long type names, but I suppose that the gist is clear. For trying multiple inputs for the same function, it's only natural to put the benchmarked code into a separate function. Of course, this could be done with a closure too.

There are of course also some disadvantages, probably the main one is that the benchmarked code moves further away from the definition of the benchmark, and we have to come up with some name for it.

In theory, all this could probably be done with closures too, and closures are definitely more general. If we wanted the diffing feature, we could just put the code into a function and call it from the closure. But if we don't enforce this behaviour, it will hardly be done for most benchmarks and then it won't be so easy to diff any benchmark without the need to manually modify it. So for me, the biggest benefit of this approach is enforcing the creation of functions for benchmarked code so that we can diff any of the benchmarks easily.