### PR TITLE
Separate numbers in runtime benchmark results with commas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,6 +357,7 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror",
+ "thousands",
  "tokio",
  "walkdir",
  "windows-sys",
@@ -2188,6 +2189,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "time"

--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -34,6 +34,8 @@ walkdir = "2"
 flate2 = { version = "1.0.22", features = ["rust_backend"] }
 rayon = "1.5.2"
 cargo_metadata = "0.15.0"
+thousands = "0.2.0"
+
 benchlib = { path = "benchlib" }
 
 [target.'cfg(windows)'.dependencies]

--- a/collector/src/runtime/mod.rs
+++ b/collector/src/runtime/mod.rs
@@ -5,6 +5,7 @@ use benchlib::comm::messages::{BenchmarkMessage, BenchmarkResult, BenchmarkStats
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use thousands::Separable;
 
 pub use benchmark::BenchmarkFilter;
 
@@ -118,7 +119,11 @@ fn print_stats(result: &BenchmarkResult) {
             )
             .sqrt();
 
-            println!("{name:>20}: {:>16} (+/- {:>8})", mean as u64, stddev as u64);
+            println!(
+                "{name:>20}: {:>16} (+/- {:>8})",
+                (mean as u64).separate_with_commas(),
+                (stddev as u64).separate_with_commas()
+            );
         } else {
             println!("{name:>20}: Not available");
         }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4539057/197342752-96f3ca2d-3eb4-461a-adff-dcd3e62ca70a.png)