### PR TITLE
Store compare page UI filters into URL

### DIFF
--- a/site/static/compare/script.js
+++ b/site/static/compare/script.js
@@ -1,9 +1,6 @@
 function findQueryParam(name) {
-    let urlParams = window.location.search?.substring(1).split("&").map(x => x.split("="));
-    let pair = urlParams?.find(x => x[0] === name)
-    if (pair) {
-        return unescape(pair[1]);
-    }
+    let params = new URLSearchParams(window.location.search.slice(1));
+    return params.get(name);
 }
 
 function createDefaultFilter() {
@@ -29,6 +26,43 @@ function createDefaultFilter() {
     };
 }
 
+/**
+ * Loads the initial state of UI filters from URL parameters.
+ */
+function initializeFilterFromUrl() {
+    const defaultFilter = createDefaultFilter();
+    let params = new URLSearchParams(window.location.search.slice(1));
+
+    function getBoolOrDefault(name, defaultValue) {
+        const urlValue = params.get(name);
+        if (urlValue !== null) {
+            return urlValue === "true";
+        }
+        return defaultValue;
+    }
+
+    return {
+        name: params.get("name"),
+        nonRelevant: getBoolOrDefault("nonRelevant", defaultFilter.nonRelevant),
+        profile: {
+            check: getBoolOrDefault("check", defaultFilter.profile.check),
+            debug: getBoolOrDefault("debug", defaultFilter.profile.debug),
+            opt: getBoolOrDefault("opt", defaultFilter.profile.opt),
+            doc: getBoolOrDefault("doc", defaultFilter.profile.doc)
+        },
+        scenario: {
+            full: getBoolOrDefault("full", defaultFilter.scenario.full),
+            incrFull: getBoolOrDefault("incrFull", defaultFilter.scenario.incrFull),
+            incrUnchanged: getBoolOrDefault("incrUnchanged", defaultFilter.scenario.incrUnchanged),
+            incrPatched: getBoolOrDefault("incrPatched", defaultFilter.scenario.incrPatched)
+        },
+        category: {
+            primary: getBoolOrDefault("primary", defaultFilter.category.primary),
+            secondary: getBoolOrDefault("secondary", defaultFilter.category.secondary)
+        }
+    };
+}
+
 const app = Vue.createApp({
     mounted() {
         const app = this;
@@ -46,7 +80,7 @@ const app = Vue.createApp({
     },
     data() {
         return {
-            filter: createDefaultFilter(),
+            filter: initializeFilterFromUrl(),
             showRawData: false,
             data: null,
             dataLoading: false

--- a/site/static/compare/script.js
+++ b/site/static/compare/script.js
@@ -1,5 +1,9 @@
+function getQueryParams() {
+    return new URLSearchParams(window.location.search);
+}
+
 function findQueryParam(name) {
-    const params = new URLSearchParams(window.location.search.slice(1));
+    const params = getQueryParams();
     return params.get(name);
 }
 
@@ -32,7 +36,7 @@ function createDefaultFilter() {
  */
 function initializeFilterFromUrl() {
     const defaultFilter = createDefaultFilter();
-    const params = new URLSearchParams(window.location.search.slice(1));
+    const params = getQueryParams();
 
     function getBoolOrDefault(name, defaultValue) {
         const urlValue = params.get(name);
@@ -70,7 +74,7 @@ function initializeFilterFromUrl() {
  */
 function storeFilterToUrl(filter) {
     const defaultFilter = createDefaultFilter();
-    const params = new URLSearchParams(window.location.search);
+    const params = getQueryParams();
 
     function storeOrReset(name, value, defaultValue) {
         if (value === defaultValue) {
@@ -361,10 +365,9 @@ const app = Vue.createApp({
             return result;
         },
         createUrlForMetric(metric) {
-            let start = findQueryParam("start");
-            let end = findQueryParam("end");
-
-            return createUrlFromParams(createSearchParamsForMetric(metric, start, end));
+            const params = getQueryParams();
+            params.set("stat", metric);
+            return createUrlFromParams(params);
         },
         resetFilter() {
             this.filter = createDefaultFilter();
@@ -767,20 +770,6 @@ function makeData(state, app) {
     });
 }
 
-function createSearchParamsForMetric(stat, start, end) {
-    let params = new URLSearchParams();
-    if (start !== undefined) {
-        params.append("start", start);
-    }
-    if (end !== undefined) {
-        params.append("end", end);
-    }
-    if (stat !== undefined) {
-        params.append("stat", stat);
-    }
-    return params.toString();
-}
-
 function createUrlFromParams(params) {
     const url = new URL(window.location);
     url.search = params;
@@ -791,7 +780,12 @@ function submitSettings() {
     let stat = getSelected("stats");
     let start = document.getElementById("start-bound").value;
     let end = document.getElementById("end-bound").value;
-    let params = createSearchParamsForMetric(stat, start, end);
+
+    const params = getQueryParams();
+    params.set("stat", stat);
+    params.set("start", start);
+    params.set("end", end);
+
     window.location.search = params.toString();
 }
 


### PR DESCRIPTION
This enables users to quickly share links to the compare page with specific filters applied. Suggested by @nnethercote.

When clicking on quick links, only the filters that were active when the page was loaded will be forwarded. If you want to respect the current filter selection when using a quick link, reload the page first (F5). Otherwise the quick link would have to be generated dynamically, which seemed like unnecessary hassle.