### PR TITLE
Handle Noise Better

### DIFF
--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -194,6 +194,7 @@ pub mod comparison {
         pub profile: String,
         pub scenario: String,
         pub is_relevant: bool,
+        pub significance_threshold: f64,
         pub significance_factor: f64,
         pub statistics: (f64, f64),
     }

--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -135,6 +135,7 @@ pub async fn handle_compare(
             profile: comparison.profile.to_string(),
             scenario: comparison.scenario.to_string(),
             is_relevant: comparison.is_relevant(),
+            significance_threshold: comparison.significance_threshold(),
             significance_factor: comparison.significance_factor(),
             statistics: comparison.results,
         })
@@ -1012,8 +1013,7 @@ pub struct HistoricalDataMap {
 }
 
 impl HistoricalDataMap {
-    const NUM_PREVIOUS_COMMITS: usize = 100;
-    const MIN_PREVIOUS_COMMITS: usize = 50;
+    const NUM_PREVIOUS_COMMITS: usize = 30;
 
     async fn calculate(
         ctxt: &SiteCtxt,
@@ -1030,7 +1030,7 @@ impl HistoricalDataMap {
         ));
 
         // Return early if we don't have enough data for historical analysis
-        if previous_commits.len() < Self::MIN_PREVIOUS_COMMITS {
+        if previous_commits.len() < Self::NUM_PREVIOUS_COMMITS {
             return Ok(Self {
                 data: historical_data,
             });
@@ -1054,7 +1054,7 @@ impl HistoricalDataMap {
         }
 
         // Only retain test cases for which we have enough data to calculate variance.
-        historical_data.retain(|_, v| v.data.len() >= Self::MIN_PREVIOUS_COMMITS);
+        historical_data.retain(|_, v| v.data.len() >= Self::NUM_PREVIOUS_COMMITS);
 
         Ok(Self {
             data: historical_data,

--- a/site/static/compare/script.js
+++ b/site/static/compare/script.js
@@ -357,19 +357,19 @@ app.component('test-cases-table', {
             <th>Scenario</th>
             <th>% Change</th>
             <th>
-                Significance Factor<span class="tooltip">?
+                Significance Threshold<span class="tooltip">?
                     <span class="tooltiptext">
-                        How much a particular result is over the significance threshold. A factor of 2.50x
-                        means the result is 2.5 times over the significance threshold.
+                        The minimum % change that is considered significant. The higher the significance threshold, the noisier a test case is.
+                        You can see <a href="https://github.com/rust-lang/rustc-perf/blob/master/docs/comparison-analysis.md#what-makes-a-test-result-significant">
+                        here</a> how the significance threshold is calculated.
                     </span>
                 </span>
             </th>
             <th>
-                Significance Threshold<span class="tooltip">?
+                Significance Factor<span class="tooltip">?
                     <span class="tooltiptext">
-                        The minimum % change that is considered significant. The higher the significance, the noisier a test case is.
-                        You can see <a href="https://github.com/rust-lang/rustc-perf/blob/master/docs/comparison-analysis.md#what-makes-a-test-result-significant">
-                        here</a> how the significance threshold is calculated.
+                        How much a particular result is over the significance threshold. A factor of 2.50x
+                        means the result is 2.5 times over the significance threshold.
                     </span>
                 </span>
             </th>
@@ -401,10 +401,10 @@ app.component('test-cases-table', {
                     </a>
                 </td>
                 <td>
-                    {{ testCase.significanceFactor ? testCase.significanceFactor.toFixed(2) + "x" : "-" }}
+                    {{ testCase.significanceThreshold ? testCase.significanceThreshold.toFixed(2) + "%" : "-" }}
                 </td>
                 <td>
-                    {{ testCase.significanceThreshold ? testCase.significanceThreshold.toFixed(2) + "%" : "-" }}
+                    {{ testCase.significanceFactor ? testCase.significanceFactor.toFixed(2) + "x" : "-" }}
                 </td>
                 <td v-if="showRawData" class="numeric">
                   <a v-bind:href="detailedQueryLink(commitA, testCase)">

--- a/site/static/compare/script.js
+++ b/site/static/compare/script.js
@@ -134,6 +134,7 @@ const app = Vue.createApp({
                             category: (benchmarkMap[c.benchmark] || {}).category || "secondary",
                             isRelevant: c.is_relevant,
                             significanceFactor: c.significance_factor,
+                            significanceThreshold: (c.significance_threshold * 100.0), // ensure the threshold is in %
                             datumA,
                             datumB,
                             percent,
@@ -152,7 +153,7 @@ const app = Vue.createApp({
         bootstrapTotals() {
             const a = this.data.a.bootstrap_total / 1e9;
             const b = this.data.b.bootstrap_total / 1e9;
-            return {a, b};
+            return { a, b };
         },
         bootstraps() {
             return Object.entries(this.data.a.bootstrap).map(e => {
@@ -359,10 +360,16 @@ app.component('test-cases-table', {
                 Significance Factor<span class="tooltip">?
                     <span class="tooltiptext">
                         How much a particular result is over the significance threshold. A factor of 2.50x
-                        means
-                        the result is 2.5 times over the significance threshold. You can see <a
-                            href="https://github.com/rust-lang/rustc-perf/blob/master/docs/comparison-analysis.md#what-makes-a-test-result-significant">
-                            here</a> how the significance threshold is calculated.
+                        means the result is 2.5 times over the significance threshold.
+                    </span>
+                </span>
+            </th>
+            <th>
+                Significance Threshold<span class="tooltip">?
+                    <span class="tooltiptext">
+                        The minimum % change that is considered significant. The higher the significance, the noisier a test case is.
+                        You can see <a href="https://github.com/rust-lang/rustc-perf/blob/master/docs/comparison-analysis.md#what-makes-a-test-result-significant">
+                        here</a> how the significance threshold is calculated.
                     </span>
                 </span>
             </th>
@@ -395,6 +402,9 @@ app.component('test-cases-table', {
                 </td>
                 <td>
                     {{ testCase.significanceFactor ? testCase.significanceFactor.toFixed(2) + "x" : "-" }}
+                </td>
+                <td>
+                    {{ testCase.significanceThreshold ? testCase.significanceThreshold.toFixed(2) + "%" : "-" }}
                 </td>
                 <td v-if="showRawData" class="numeric">
                   <a v-bind:href="detailedQueryLink(commitA, testCase)">
@@ -447,7 +457,7 @@ const SummaryRange = {
   [<SummaryPercentValue :value="range[0]" :padWidth="6" />, <SummaryPercentValue :value="range[1]" :padWidth="6" />]
 </div>
 <div v-else style="text-align: center;">-</div>
-`, components: {SummaryPercentValue}
+`, components: { SummaryPercentValue }
 };
 const SummaryCount = {
     props: {
@@ -510,7 +520,7 @@ app.component('summary-table', {
     </tbody>
 </table>
 `,
-    components: {SummaryRange, SummaryPercentValue, SummaryCount}
+    components: { SummaryRange, SummaryPercentValue, SummaryCount }
 });
 
 app.component("aggregations", {


### PR DESCRIPTION
This adjusts historical analysis to handle noise more quickly. The following changes are included:
* Limit the number of historical runs that are used to compute significance threshold to 30 instead of 100. This means that if a test case starts to become noisy, the significance threshold will more quickly reflect this.
* Expose significance threshold in the compare page. Being able to see the significance threshold will allow readers to more quickly judge whether a test case is historically noisy or not. See below for what this looks like.
* Sort test cases on the compare page by significance factor. The tests cases with the largest change *in comparison to the historical average* will be on top vs. just the test cases with the largest change (which favors noisy test cases).

![image](https://user-images.githubusercontent.com/1327285/199813477-8a326727-ebe7-4785-93fb-dcac80750112.png)
