### PR TITLE
Hide old `rust-timer` comments when a summary is posted

### DIFF
--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -9,6 +9,13 @@ use serde::Deserialize;
 type BoxedError = Box<dyn std::error::Error + Send + Sync>;
 
 pub const RUST_REPO_GITHUB_API_URL: &str = "https://api.github.com/repos/rust-lang/rust";
+pub const RUST_REPO_GITHUB_GRAPH_URL: &str = "https://api.github.com/graphql";
+
+/// Comments that are temporary and do not add any value once there has been a new development
+/// (a rustc build or a perf. run was finished) are marked with this comment.
+///
+/// They are removed once a perf. run comparison summary is posted on a PR.
+pub const COMMENT_MARK_TEMPORARY: &str = "<!-- rust-timer: temporary -->";
 
 pub use comparison_summary::post_finished;
 
@@ -236,6 +243,7 @@ pub async fn enqueue_shas(
             ));
         }
     }
+    msg.push_str(&format!("\n{COMMENT_MARK_TEMPORARY}"));
     main_client.post_comment(pr_number, msg).await;
     Ok(())
 }

--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -8,6 +8,8 @@ use serde::Deserialize;
 
 type BoxedError = Box<dyn std::error::Error + Send + Sync>;
 
+pub const RUST_REPO_GITHUB_API_URL: &str = "https://api.github.com/repos/rust-lang/rust";
+
 pub use comparison_summary::post_finished;
 
 /// Enqueues try build artifacts and posts a message about them on the original rollup PR

--- a/site/src/github/comparison_summary.rs
+++ b/site/src/github/comparison_summary.rs
@@ -6,6 +6,7 @@ use crate::load::SiteCtxt;
 
 use database::{ArtifactId, QueuedCommit};
 
+use crate::github::RUST_REPO_GITHUB_API_URL;
 use std::collections::HashSet;
 use std::fmt::Write;
 
@@ -66,10 +67,7 @@ pub async fn post_finished(ctxt: &SiteCtxt) {
 ///
 /// `is_master_commit` is used to differentiate messages for try runs and post-merge runs.
 async fn post_comparison_comment(ctxt: &SiteCtxt, commit: QueuedCommit, is_master_commit: bool) {
-    let client = super::client::Client::from_ctxt(
-        ctxt,
-        "https://api.github.com/repos/rust-lang/rust".to_owned(),
-    );
+    let client = super::client::Client::from_ctxt(ctxt, RUST_REPO_GITHUB_API_URL.to_owned());
     let pr = commit.pr;
     let body = match summarize_run(ctxt, commit, is_master_commit).await {
         Ok(message) => message,

--- a/site/src/github/comparison_summary.rs
+++ b/site/src/github/comparison_summary.rs
@@ -6,7 +6,7 @@ use crate::load::SiteCtxt;
 
 use database::{ArtifactId, QueuedCommit};
 
-use crate::github::RUST_REPO_GITHUB_API_URL;
+use crate::github::{COMMENT_MARK_TEMPORARY, RUST_REPO_GITHUB_API_URL, RUST_REPO_GITHUB_GRAPH_URL};
 use std::collections::HashSet;
 use std::fmt::Write;
 
@@ -58,7 +58,10 @@ pub async fn post_finished(ctxt: &SiteCtxt) {
             assert_eq!(completed, queued_commit);
 
             let is_master_commit = master_commits.contains(&queued_commit.sha);
-            post_comparison_comment(ctxt, queued_commit, is_master_commit).await;
+            if let Err(error) = post_comparison_comment(ctxt, queued_commit, is_master_commit).await
+            {
+                log::error!("Cannot post comparison comment: {error:?}");
+            }
         }
     }
 }
@@ -66,7 +69,11 @@ pub async fn post_finished(ctxt: &SiteCtxt) {
 /// Posts a comment to GitHub summarizing the comparison of the queued commit with its parent
 ///
 /// `is_master_commit` is used to differentiate messages for try runs and post-merge runs.
-async fn post_comparison_comment(ctxt: &SiteCtxt, commit: QueuedCommit, is_master_commit: bool) {
+async fn post_comparison_comment(
+    ctxt: &SiteCtxt,
+    commit: QueuedCommit,
+    is_master_commit: bool,
+) -> anyhow::Result<()> {
     let client = super::client::Client::from_ctxt(ctxt, RUST_REPO_GITHUB_API_URL.to_owned());
     let pr = commit.pr;
     let body = match summarize_run(ctxt, commit, is_master_commit).await {
@@ -75,6 +82,21 @@ async fn post_comparison_comment(ctxt: &SiteCtxt, commit: QueuedCommit, is_maste
     };
 
     client.post_comment(pr, body).await;
+
+    let graph_client =
+        super::client::Client::from_ctxt(ctxt, RUST_REPO_GITHUB_GRAPH_URL.to_owned());
+    for comment in graph_client.get_comments(pr).await? {
+        // If this bot is the author of the comment, the comment is not yet minimized and it is
+        // a temporary comment, minimize it.
+        if comment.viewer_did_author
+            && !comment.is_minimized
+            && comment.body.contains(COMMENT_MARK_TEMPORARY)
+        {
+            log::debug!("Hiding comment {}", comment.id);
+            graph_client.hide_comment(&comment.id, "OUTDATED").await?;
+        }
+    }
+    Ok(())
 }
 
 fn make_comparison_url(commit: &QueuedCommit, stat: Metric) -> String {

--- a/site/src/request_handlers/github.rs
+++ b/site/src/request_handlers/github.rs
@@ -1,7 +1,7 @@
 use crate::api::{github, ServerResult};
 use crate::github::{
     client, enqueue_shas, parse_homu_comment, rollup_pr_number, unroll_rollup,
-    RUST_REPO_GITHUB_API_URL,
+    COMMENT_MARK_TEMPORARY, RUST_REPO_GITHUB_API_URL,
 };
 use crate::load::SiteCtxt;
 
@@ -109,7 +109,10 @@ async fn handle_rust_timer(
         main_client
             .post_comment(
                 issue.number,
-                "Insufficient permissions to issue commands to rust-timer.",
+                format!(
+                    "Insufficient permissions to issue commands to rust-timer.
+{COMMENT_MARK_TEMPORARY}"
+                ),
             )
             .await;
         return Ok(github::Response);
@@ -126,9 +129,13 @@ async fn handle_rust_timer(
         main_client
             .post_comment(
                 issue.number,
-                "Awaiting bors try build completion.
+                format!(
+                    "Awaiting bors try build completion.
 
-@rustbot label: +S-waiting-on-perf",
+@rustbot label: +S-waiting-on-perf
+
+{COMMENT_MARK_TEMPORARY}"
+                ),
             )
             .await;
         return Ok(github::Response);

--- a/site/src/request_handlers/github.rs
+++ b/site/src/request_handlers/github.rs
@@ -1,5 +1,8 @@
 use crate::api::{github, ServerResult};
-use crate::github::{client, enqueue_shas, parse_homu_comment, rollup_pr_number, unroll_rollup};
+use crate::github::{
+    client, enqueue_shas, parse_homu_comment, rollup_pr_number, unroll_rollup,
+    RUST_REPO_GITHUB_API_URL,
+};
 use crate::load::SiteCtxt;
 
 use std::sync::Arc;
@@ -29,10 +32,7 @@ async fn handle_push(ctxt: Arc<SiteCtxt>, push: github::Push) -> ServerResult<gi
         &ctxt,
         "https://api.github.com/repos/rust-lang-ci/rust".to_owned(),
     );
-    let main_repo_client = client::Client::from_ctxt(
-        &ctxt,
-        "https://api.github.com/repos/rust-lang/rust".to_owned(),
-    );
+    let main_repo_client = client::Client::from_ctxt(&ctxt, RUST_REPO_GITHUB_API_URL.to_owned());
     if push.r#ref != "refs/heads/master" || push.sender.login != "bors" {
         return Ok(github::Response);
     }
@@ -70,10 +70,7 @@ async fn handle_issue(
     issue: github::Issue,
     comment: github::Comment,
 ) -> ServerResult<github::Response> {
-    let main_client = client::Client::from_ctxt(
-        &ctxt,
-        "https://api.github.com/repos/rust-lang/rust".to_owned(),
-    );
+    let main_client = client::Client::from_ctxt(&ctxt, RUST_REPO_GITHUB_API_URL.to_owned());
     let ci_client = client::Client::from_ctxt(
         &ctxt,
         "https://api.github.com/repos/rust-lang-ci/rust".to_owned(),


### PR DESCRIPTION
When a perf. summary is posted to a PR, all other non-summary comments made by the bot on the PR will be minimized. I copied the code from https://github.com/rust-lang/rust-log-analyzer/pull/56 to implement this.

I have no idea how to test this though :man_shrugging:

Fixes: https://github.com/rust-lang/rustc-perf/issues/1488