### PR TITLE
re-add "cycles" metric used on windows

### DIFF
--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -190,6 +190,8 @@ pub enum Metric {
     CpuClock,
     #[serde(rename = "cpu-clock:u")]
     CpuClockUser,
+    #[serde(rename = "cycles")]
+    Cycles,
     #[serde(rename = "cycles:u")]
     CyclesUser,
     #[serde(rename = "faults")]
@@ -246,6 +248,7 @@ impl Metric {
             Metric::ContextSwitches => "context-switches",
             Metric::CpuClock => "cpu-clock",
             Metric::CpuClockUser => "cpu-clock:u",
+            Metric::Cycles => "cycles",
             Metric::CyclesUser => "cycles:u",
             Metric::Faults => "faults",
             Metric::FaultsUser => "faults:u",


### PR DESCRIPTION
When trying to look at cycles on windows, the following error about a missing metric is triggered now. 

![image](https://user-images.githubusercontent.com/247183/199826874-d71ca89c-9ed2-44e5-8ea7-df8026b506f0.png)

This PR updates the site to handle this kind of metric again.