### PR TITLE
Do not send empty queued comments on PRs

### DIFF
--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -243,8 +243,12 @@ pub async fn enqueue_shas(
             ));
         }
     }
-    msg.push_str(&format!("\n{COMMENT_MARK_TEMPORARY}"));
-    main_client.post_comment(pr_number, msg).await;
+
+    if !msg.is_empty() {
+        msg.push_str(&format!("\n{COMMENT_MARK_TEMPORARY}"));
+        main_client.post_comment(pr_number, msg).await;
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
I *think* that this [empty comment](https://github.com/rust-lang/rust/pull/103978#issuecomment-1304308298) was caused by the bot sending an empty message in `enqueue_shas` after a PR is merged. I suppose that before the message was simply empty and thus GitHub ignored it and didn't create the comment, but now we add the HTML comment mark to it, so it's not empty, but it's still created without any visible content.