### PR TITLE
Split GraphQL client from the REST API GitHub client and use proper authentication for it

### DIFF
--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -9,7 +9,6 @@ use serde::Deserialize;
 type BoxedError = Box<dyn std::error::Error + Send + Sync>;
 
 pub const RUST_REPO_GITHUB_API_URL: &str = "https://api.github.com/repos/rust-lang/rust";
-pub const RUST_REPO_GITHUB_GRAPH_URL: &str = "https://api.github.com/graphql";
 
 /// Comments that are temporary and do not add any value once there has been a new development
 /// (a rustc build or a perf. run was finished) are marked with this comment.

--- a/site/src/github/comparison_summary.rs
+++ b/site/src/github/comparison_summary.rs
@@ -6,7 +6,7 @@ use crate::load::SiteCtxt;
 
 use database::{ArtifactId, QueuedCommit};
 
-use crate::github::{COMMENT_MARK_TEMPORARY, RUST_REPO_GITHUB_API_URL, RUST_REPO_GITHUB_GRAPH_URL};
+use crate::github::{COMMENT_MARK_TEMPORARY, RUST_REPO_GITHUB_API_URL};
 use std::collections::HashSet;
 use std::fmt::Write;
 
@@ -83,8 +83,7 @@ async fn post_comparison_comment(
 
     client.post_comment(pr, body).await;
 
-    let graph_client =
-        super::client::Client::from_ctxt(ctxt, RUST_REPO_GITHUB_GRAPH_URL.to_owned());
+    let graph_client = super::client::GraphQLClient::from_ctxt(ctxt);
     for comment in graph_client.get_comments(pr).await? {
         // If this bot is the author of the comment, the comment is not yet minimized and it is
         // a temporary comment, minimize it.


### PR DESCRIPTION
This should hopefully fix comment hiding. Tested on my repo with a token with the `repo` scope.

User agent header was required, along with authentication header. I also split the clients into two parts, since their functionality doesn't have overlap and it would only lead to wrong usages if both implementations were in the same struct.