### PR TITLE
Adjust runtime output

### DIFF
--- a/collector/src/runtime/mod.rs
+++ b/collector/src/runtime/mod.rs
@@ -24,7 +24,7 @@ pub fn bench_runtime(
     let total_benchmark_count = suite.total_benchmark_count();
     let filtered = suite.filtered_benchmark_count(&filter);
     println!(
-        "Executing {} benchmarks ({} filtered out)",
+        "Executing {} benchmarks ({} filtered out)\n",
         filtered,
         total_benchmark_count - filtered
     );
@@ -120,7 +120,7 @@ fn print_stats(result: &BenchmarkResult) {
             .sqrt();
 
             println!(
-                "{name:>20}: {:>16} (+/- {:>8})",
+                "{name:>18}: {:>16} (+/- {:>11})",
                 (mean as u64).separate_with_commas(),
                 (stddev as u64).separate_with_commas()
             );
@@ -136,4 +136,5 @@ fn print_stats(result: &BenchmarkResult) {
     });
     print_metric(result, "Branch misses", |m| m.branch_misses);
     print_metric(result, "Cache misses", |m| m.cache_misses);
+    println!();
 }

--- a/collector/src/runtime/mod.rs
+++ b/collector/src/runtime/mod.rs
@@ -131,7 +131,7 @@ fn print_stats(result: &BenchmarkResult) {
 
     print_metric(result, "Instructions", |m| m.instructions);
     print_metric(result, "Cycles", |m| m.cycles);
-    print_metric(result, "Wall time [us]", |m| {
+    print_metric(result, "Wall time [µs]", |m| {
         Some(m.wall_time.as_micros() as u64)
     });
     print_metric(result, "Branch misses", |m| m.branch_misses);


### PR DESCRIPTION
Changing this:
```
Executing 3 benchmarks (0 filtered out)
Finished bufreader/bufreader_snappy (1/3)
      [Instructions]:      275,869,312 (+/-      635)
            [Cycles]:      228,132,383 (+/- 3,119,413)
    [Wall time [us]]:           89,175 (+/-      846)
     [Branch misses]:           15,512 (+/-    1,923)
      [Cache misses]:           79,498 (+/-   16,094)
Finished hashmap-bench/hashmap_insert_10k (2/3)
      [Instructions]:          639,980 (+/-       12)
            [Cycles]:          200,220 (+/-   16,462)
    [Wall time [us]]:              185 (+/-       51)
     [Branch misses]:              501 (+/-      458)
      [Cache misses]:                3 (+/-        3)
Finished nbody-bench/nbody_10k (3/3)
      [Instructions]:   28,007,920,488 (+/-      786)
            [Cycles]:   13,748,457,426 (+/- 339,286,053)
    [Wall time [us]]:        3,210,610 (+/-   94,733)
     [Branch misses]:          199,037 (+/-      410)
      [Cache misses]:            7,480 (+/-    3,798)
```
to this:
```Executing 3 benchmarks (0 filtered out)

Finished bufreader/bufreader_snappy (1/3)
    [Instructions]:      286,401,708 (+/-         636)
          [Cycles]:   12,258,369,838 (+/-  96,330,396)
  [Wall time [µs]]:        2,901,817 (+/-      20,770)
   [Branch misses]:           15,801 (+/-         789)
    [Cache misses]:          578,963 (+/-      48,346)

Finished hashmap-bench/hashmap_insert_10k (2/3)
    [Instructions]:          629,981 (+/-          12)
          [Cycles]:          201,904 (+/-       8,482)
  [Wall time [µs]]:              189 (+/-          60)
   [Branch misses]:              266 (+/-           4)
    [Cache misses]:               65 (+/-          81)

Finished nbody-bench/nbody_10k (3/3)
    [Instructions]:   28,008,520,655 (+/-         788)
          [Cycles]:   13,904,366,318 (+/- 271,625,915)
  [Wall time [µs]]:        3,266,020 (+/-      97,155)
   [Branch misses]:          172,175 (+/-      34,396)
    [Cache misses]:           16,486 (+/-       9,395)

```
