### PR TITLE
Update bytehound sha after they force pushed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
           git clone https://github.com/koute/bytehound
           cd bytehound
           # Newer versions of Bytehound use unstable features
-          git checkout bcae7caa3b01bb60ec6d4159ac8b9af28a7c927a
+          git checkout d8363a1f959cc52f2ce0e0603120b9ad2e70d506
           cargo build --release -p bytehound-preload
           echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${PWD}/target/release" >> $GITHUB_ENV
 


### PR DESCRIPTION
CI was breaking because the bytehound repo force pushed the main branch and the sha we were pinned to no longer exists.