### PR TITLE
Don't add S-waiting-on-review label when perf finishes

### DIFF
--- a/site/src/github/comparison_summary.rs
+++ b/site/src/github/comparison_summary.rs
@@ -300,6 +300,6 @@ for rollup, we strongly recommend not doing so since this PR may lead to changes
 compiler perf.{next_steps}
 
 @bors rollup=never
-@rustbot label: +S-waiting-on-review -S-waiting-on-perf {sign}perf-regression",
+@rustbot label: -S-waiting-on-perf {sign}perf-regression",
     )
 }


### PR DESCRIPTION
See https://github.com/rust-lang/rustc-perf/issues/1502 for rationale. Fixes https://github.com/rust-lang/rustc-perf/issues/1502