### PR TITLE
Clean up code conversions of Profile enum

### DIFF
--- a/database/src/bin/ingest-json.rs
+++ b/database/src/bin/ingest-json.rs
@@ -921,12 +921,7 @@ async fn ingest<T: Ingesting>(conn: &T, caches: &mut IdCache, path: &Path) {
             } else {
                 Profile::Debug
             };
-            let profile_str = match profile {
-                Profile::Check => "check",
-                Profile::Debug => "debug",
-                Profile::Doc => "doc",
-                Profile::Opt => "opt",
-            };
+            let profile_str = profile.as_str();
             let state = match &run.state {
                 BenchmarkState::Clean => Scenario::Empty,
                 BenchmarkState::IncrementalStart => Scenario::IncrementalEmpty,

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -226,6 +226,17 @@ pub enum Profile {
     Opt,
 }
 
+impl Profile {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Profile::Check => "check",
+            Profile::Opt => "opt",
+            Profile::Debug => "debug",
+            Profile::Doc => "doc",
+        }
+    }
+}
+
 impl std::str::FromStr for Profile {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -241,16 +252,7 @@ impl std::str::FromStr for Profile {
 
 impl fmt::Display for Profile {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                Profile::Check => "check",
-                Profile::Opt => "opt",
-                Profile::Debug => "debug",
-                Profile::Doc => "doc",
-            }
-        )
+        write!(f, "{}", self.as_str())
     }
 }
 

--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -546,13 +546,7 @@ where
                         row.get::<_, i32>(0) as u32,
                         (
                             Benchmark::from(row.get::<_, String>(1).as_str()),
-                            match row.get::<_, String>(2).as_str() {
-                                "check" => Profile::Check,
-                                "opt" => Profile::Opt,
-                                "debug" => Profile::Debug,
-                                "doc" => Profile::Doc,
-                                o => unreachable!("{}: not a profile", o),
-                            },
+                            Profile::from_str(row.get::<_, String>(2).as_str()).unwrap(),
                             row.get::<_, String>(3).as_str().parse().unwrap(),
                             row.get::<_, String>(4).as_str().into(),
                         ),

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -468,13 +468,7 @@ impl Connection for SqliteConnection {
                         row.get::<_, i32>(0)? as u32,
                         (
                             Benchmark::from(row.get::<_, String>(1)?.as_str()),
-                            match row.get::<_, String>(2)?.as_str() {
-                                "check" => Profile::Check,
-                                "opt" => Profile::Opt,
-                                "debug" => Profile::Debug,
-                                "doc" => Profile::Doc,
-                                o => unreachable!("{}: not a profile", o),
-                            },
+                            Profile::from_str(row.get::<_, String>(2)?.as_str()).unwrap(),
                             row.get::<_, String>(3)?.as_str().parse().unwrap(),
                             row.get::<_, String>(4)?.as_str().into(),
                         ),


### PR DESCRIPTION
This cleans up a bit some conversion of the `Profile` type and allow to have it in one place.

Another thing I wondered: this type is also present in both `collector/src/benchmark/profile.rs` and `database/src/lib.rs`. Is there a reason why it is duplicated like this? `collector/src/benchmark/` has `database` as a dependency, so is there a particular reason why `Profile` was also created in `collector/src/benchmark`? If not I'm planning to merge both types in a follow-up PR.