### PR TITLE
Add rustdoc-json perf check

### DIFF
--- a/collector/src/benchmark/mod.rs
+++ b/collector/src/benchmark/mod.rs
@@ -291,7 +291,7 @@ impl Benchmark {
                 }
 
                 // Rustdoc does not support incremental compilation
-                if profile != Profile::Doc {
+                if profile.is_doc() {
                     // An incremental  from scratch (slowest incremental case).
                     // This is required for any subsequent incremental builds.
                     if scenarios.iter().any(|s| s.is_incr()) {

--- a/collector/src/benchmark/profile.rs
+++ b/collector/src/benchmark/profile.rs
@@ -4,15 +4,20 @@ pub enum Profile {
     Check,
     Debug,
     Doc,
+    JsonDoc,
     Opt,
 }
 
 impl Profile {
     pub fn all() -> Vec<Self> {
-        vec![Profile::Check, Profile::Debug, Profile::Doc, Profile::Opt]
+        vec![Profile::Check, Profile::Debug, Profile::Doc, Profile::JsonDoc, Profile::Opt]
     }
 
     pub fn all_non_doc() -> Vec<Self> {
         vec![Profile::Check, Profile::Debug, Profile::Opt]
+    }
+
+    pub fn is_doc(self) -> bool {
+        matches!(self, Self::Doc | Self::JsonDoc)
     }
 }

--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -233,7 +233,7 @@ fn generate_cachegrind_diffs(
     for benchmark in benchmarks {
         for &profile in profiles {
             for scenario in scenarios.iter().flat_map(|scenario| {
-                if profile == Profile::Doc && scenario.is_incr() {
+                if profile.is_doc() && scenario.is_incr() {
                     return vec![];
                 }
                 match scenario {

--- a/collector/src/execute/bencher.rs
+++ b/collector/src/execute/bencher.rs
@@ -98,6 +98,7 @@ impl<'a> BenchProcessor<'a> {
             Profile::Check => database::Profile::Check,
             Profile::Debug => database::Profile::Debug,
             Profile::Doc => database::Profile::Doc,
+            Profile::JsonDoc => database::Profile::JsonDoc,
             Profile::Opt => database::Profile::Opt,
         };
 

--- a/collector/src/execute/mod.rs
+++ b/collector/src/execute/mod.rs
@@ -61,7 +61,7 @@ impl PerfTool {
             | ProfileTool(DepGraph)
             | ProfileTool(MonoItems)
             | ProfileTool(LlvmIr) => {
-                if profile == Profile::Doc {
+                if profile.is_doc() {
                     Some("rustdoc")
                 } else {
                     Some("rustc")
@@ -69,7 +69,7 @@ impl PerfTool {
             }
             ProfileTool(LlvmLines) => match profile {
                 Profile::Debug | Profile::Opt => Some("llvm-lines"),
-                Profile::Check | Profile::Doc => None,
+                Profile::Check | Profile::Doc | Profile::JsonDoc => None,
             },
         }
     }
@@ -210,9 +210,10 @@ impl<'a> CargoProcess<'a> {
                         Some(sub) => sub,
                     }
                 } else {
-                    match self.profile {
-                        Profile::Doc => "rustdoc",
-                        _ => "rustc",
+                    if self.profile.is_doc() {
+                        "rustdoc"
+                    } else {
+                        "rustc"
                     }
                 };
 
@@ -224,6 +225,9 @@ impl<'a> CargoProcess<'a> {
                 }
                 Profile::Debug => {}
                 Profile::Doc => {}
+                Profile::JsonDoc => {
+                    cmd.env("RUSTDOCFLAGS", "-Z unstable-options --output-format=json");
+                }
                 Profile::Opt => {
                     cmd.arg("--release");
                 }

--- a/collector/src/toolchain.rs
+++ b/collector/src/toolchain.rs
@@ -347,15 +347,15 @@ pub fn get_local_toolchain(
             Some(rustdoc.canonicalize().with_context(|| {
                 format!("failed to canonicalize rustdoc executable {:?}", rustdoc)
             })?)
-        } else if profiles.contains(&Profile::Doc) {
+        } else if profiles.iter().any(|p| p.is_doc()) {
             // We need a `rustdoc`. Look for one next to `rustc`.
             if let Ok(rustdoc) = rustc.with_file_name("rustdoc").canonicalize() {
                 debug!("found rustdoc: {:?}", &rustdoc);
                 Some(rustdoc)
             } else {
                 anyhow::bail!(
-                    "'Doc' build specified but '--rustdoc' not specified and no 'rustdoc' found \
-                    next to 'rustc'"
+                    "'Doc' or 'JsonDoc' build specified but '--rustdoc' not specified and no \
+                    'rustdoc' found next to 'rustc'"
                 );
             }
         } else {

--- a/database/src/bin/ingest-json.rs
+++ b/database/src/bin/ingest-json.rs
@@ -925,6 +925,7 @@ async fn ingest<T: Ingesting>(conn: &T, caches: &mut IdCache, path: &Path) {
                 Profile::Check => "check",
                 Profile::Debug => "debug",
                 Profile::Doc => "doc",
+                Profile::JsonDoc => "jsondoc",
                 Profile::Opt => "opt",
             };
             let state = match &run.state {

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -222,6 +222,8 @@ pub enum Profile {
     Debug,
     /// A doc build
     Doc,
+    /// A doc build with `--output-format=json` option.
+    JsonDoc,
     /// An optimized "release" build
     Opt,
 }
@@ -233,6 +235,7 @@ impl std::str::FromStr for Profile {
             "check" => Profile::Check,
             "debug" => Profile::Debug,
             "doc" => Profile::Doc,
+            "jsondoc" => Profile::JsonDoc,
             "opt" => Profile::Opt,
             _ => return Err(format!("{} is not a profile", s)),
         })
@@ -249,6 +252,7 @@ impl fmt::Display for Profile {
                 Profile::Opt => "opt",
                 Profile::Debug => "debug",
                 Profile::Doc => "doc",
+                Profile::JsonDoc => "jsondoc",
             }
         )
     }

--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -551,6 +551,7 @@ where
                                 "opt" => Profile::Opt,
                                 "debug" => Profile::Debug,
                                 "doc" => Profile::Doc,
+                                "jsondoc" => Profile::JsonDoc,
                                 o => unreachable!("{}: not a profile", o),
                             },
                             row.get::<_, String>(3).as_str().parse().unwrap(),

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -473,6 +473,7 @@ impl Connection for SqliteConnection {
                                 "opt" => Profile::Opt,
                                 "debug" => Profile::Debug,
                                 "doc" => Profile::Doc,
+                                "jsondoc" => Profile::JsonDoc,
                                 o => unreachable!("{}: not a profile", o),
                             },
                             row.get::<_, String>(3)?.as_str().parse().unwrap(),

--- a/site/src/request_handlers/dashboard.rs
+++ b/site/src/request_handlers/dashboard.rs
@@ -156,6 +156,7 @@ pub struct ByProfile<T> {
     pub check: T,
     pub debug: T,
     pub doc: T,
+    pub json_doc: T,
     pub opt: T,
 }
 
@@ -169,6 +170,7 @@ impl<T> ByProfile<T> {
             check: f(Profile::Check).await?,
             debug: f(Profile::Debug).await?,
             doc: f(Profile::Doc).await?,
+            json_doc: f(Profile::JsonDoc).await?,
             opt: f(Profile::Opt).await?,
         })
     }
@@ -181,6 +183,7 @@ impl<T> std::ops::Index<Profile> for ByProfile<T> {
             Profile::Check => &self.check,
             Profile::Debug => &self.debug,
             Profile::Doc => &self.doc,
+            Profile::JsonDoc => &self.json_doc,
             Profile::Opt => &self.opt,
         }
     }


### PR DESCRIPTION
The JSON output format is taking more and more importance in rustdoc and we reached a point where performance checks would start to make sense.

Now, with that said, this remains a very specific feature and I'm not sure if it's worth having it tested by `rustc-perf` directly. It will also add noise considering that rustdoc benchmarks tend to be noisy ones. Maybe the solution here would be to only run this check manually or on rustdoc PRs? But before even that, do you think it's a good idea at all?