### PR TITLE
Store runtime benchmark results into SQLite

### DIFF
--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -118,7 +118,7 @@ fn bench(
             }
             let mut tx = rt.block_on(conn.transaction());
             let (supports_stable, category) = category.db_representation();
-            rt.block_on(tx.conn().record_benchmark(
+            rt.block_on(tx.conn().record_compile_benchmark(
                 &benchmark_name.0,
                 Some(supports_stable),
                 category,

--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -720,8 +720,10 @@ fn main_result() -> anyhow::Result<i32> {
                 "",
             )?;
             let pool = Pool::open(&db.db);
+
             let fut = bench_runtime(
                 pool,
+                ArtifactId::Tag(toolchain.id.clone()),
                 toolchain,
                 BenchmarkFilter::new(local.exclude, local.include),
                 runtime_benchmark_dir,

--- a/collector/src/execute/bencher.rs
+++ b/collector/src/execute/bencher.rs
@@ -7,7 +7,7 @@ use crate::execute::{
     SelfProfileFiles, Stats, Upload,
 };
 use crate::toolchain::Compiler;
-use anyhow::Context;
+use crate::utils::git::get_rustc_perf_commit;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use std::path::PathBuf;
@@ -81,17 +81,7 @@ impl<'a> BenchProcessor<'a> {
         profile: Profile,
         stats: (Stats, Option<SelfProfile>, Option<SelfProfileFiles>),
     ) {
-        let version = String::from_utf8(
-            Command::new("git")
-                .arg("rev-parse")
-                .arg("HEAD")
-                .output()
-                .context("git rev-parse HEAD")
-                .unwrap()
-                .stdout,
-        )
-        .context("utf8")
-        .unwrap();
+        let version = get_rustc_perf_commit();
 
         let collection = self.rt.block_on(self.conn.collection_id(&version));
         let profile = match profile {

--- a/collector/src/execute/rustc.rs
+++ b/collector/src/execute/rustc.rs
@@ -8,6 +8,7 @@
 //! having to think about how to deduplicate results.
 
 use crate::toolchain::Compiler;
+use crate::utils::git::get_rustc_perf_commit;
 use anyhow::Context;
 use database::ArtifactId;
 use std::env;
@@ -140,17 +141,7 @@ fn record(
         }
     }
 
-    let version = String::from_utf8(
-        Command::new("git")
-            .arg("rev-parse")
-            .arg("HEAD")
-            .output()
-            .context("git rev-parse HEAD")
-            .unwrap()
-            .stdout,
-    )
-    .context("utf8")
-    .unwrap();
+    let version = get_rustc_perf_commit();
     let collection = rt.block_on(conn.collection_id(&version));
 
     for (krate, timing) in timing_data {

--- a/collector/src/runtime/benchmark.rs
+++ b/collector/src/runtime/benchmark.rs
@@ -45,7 +45,7 @@ impl BenchmarkSuite {
             .count() as u64
     }
 
-    fn benchmark_names(&self) -> impl Iterator<Item = &str> {
+    pub fn benchmark_names(&self) -> impl Iterator<Item = &str> {
         self.groups
             .iter()
             .flat_map(|suite| suite.benchmark_names.iter().map(|n| n.as_ref()))

--- a/collector/src/runtime/mod.rs
+++ b/collector/src/runtime/mod.rs
@@ -1,14 +1,16 @@
 mod benchmark;
 
 use crate::toolchain::LocalToolchain;
-use benchlib::comm::messages::{BenchmarkMessage, BenchmarkResult, BenchmarkStats};
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use thousands::Separable;
 
+use benchlib::comm::messages::{BenchmarkMessage, BenchmarkResult, BenchmarkStats};
 pub use benchmark::BenchmarkFilter;
-use database::Pool;
+use database::{ArtifactId, ArtifactIdNumber, Connection, Pool};
+
+use crate::utils::git::get_rustc_perf_commit;
 
 /// Perform a series of runtime benchmarks using the provided `rustc` compiler.
 /// The runtime benchmarks are looked up in `benchmark_dir`, which is expected to be a path
@@ -16,6 +18,7 @@ use database::Pool;
 /// groups that leverage `benchlib`.
 pub async fn bench_runtime(
     db: Pool,
+    artifact_id: ArtifactId,
     toolchain: LocalToolchain,
     filter: BenchmarkFilter,
     benchmark_dir: PathBuf,
@@ -23,10 +26,12 @@ pub async fn bench_runtime(
 ) -> anyhow::Result<()> {
     let suite = benchmark::discover_benchmarks(&toolchain, &benchmark_dir)?;
 
-    let connection = db.connection().await;
+    let conn = db.connection().await;
     for benchmark in suite.benchmark_names() {
-        connection.record_runtime_benchmark(benchmark).await;
+        conn.record_runtime_benchmark(benchmark).await;
     }
+
+    let artifact_id = conn.artifact_id(&artifact_id).await;
 
     let total_benchmark_count = suite.total_benchmark_count();
     let filtered = suite.filtered_benchmark_count(&filter);
@@ -35,6 +40,8 @@ pub async fn bench_runtime(
         filtered,
         total_benchmark_count - filtered
     );
+
+    let rustc_perf_version = get_rustc_perf_commit();
 
     let mut benchmark_index = 0;
     for binary in suite.groups {
@@ -55,13 +62,38 @@ pub async fn bench_runtime(
                         benchmark_index,
                         filtered
                     );
+
                     print_stats(&result);
+                    record_stats(&conn, artifact_id, &rustc_perf_version, result).await;
                 }
             }
         }
     }
 
     Ok(())
+}
+
+/// Records the results (stats) of a benchmark into the database.
+async fn record_stats(
+    conn: &Box<dyn Connection>,
+    artifact_id: ArtifactIdNumber,
+    rustc_perf_version: &str,
+    result: BenchmarkResult,
+) {
+    for stat in result.stats {
+        let collection_id = conn.collection_id(rustc_perf_version).await;
+
+        if let Some(value) = stat.instructions {
+            conn.record_runtime_statistic(
+                collection_id,
+                artifact_id,
+                &result.name,
+                "instructions:u",
+                value as f64,
+            )
+            .await;
+        }
+    }
 }
 
 /// Starts executing a single runtime benchmark group defined in a binary crate located in
@@ -94,8 +126,7 @@ fn execute_runtime_benchmark_binary(
 
     let reader = BufReader::new(stdout);
     let iterator = reader.lines().map(|line| {
-        line.and_then(|line| Ok(serde_json::from_str::<BenchmarkMessage>(&line)?))
-            .map_err(|err| err.into())
+        Ok(line.and_then(|line| Ok(serde_json::from_str::<BenchmarkMessage>(&line)?))?)
     });
     Ok(iterator)
 }

--- a/collector/src/utils/git.rs
+++ b/collector/src/utils/git.rs
@@ -1,0 +1,16 @@
+use anyhow::Context;
+use std::process::Command;
+
+pub fn get_rustc_perf_commit() -> String {
+    String::from_utf8(
+        Command::new("git")
+            .arg("rev-parse")
+            .arg("HEAD")
+            .output()
+            .context("git rev-parse HEAD")
+            .unwrap()
+            .stdout,
+    )
+    .context("utf8")
+    .unwrap()
+}

--- a/collector/src/utils/mod.rs
+++ b/collector/src/utils/mod.rs
@@ -1,2 +1,3 @@
 pub mod fs;
+pub mod git;
 pub mod read2;

--- a/database/src/bin/import-sqlite.rs
+++ b/database/src/bin/import-sqlite.rs
@@ -26,7 +26,7 @@ async fn main() {
 
     let mut benchmarks = HashSet::new();
     let benchmark_data: HashMap<String, BenchmarkData> = sqlite_conn
-        .get_benchmarks()
+        .get_compile_benchmarks()
         .await
         .into_iter()
         .map(|benchmark| (benchmark.name.clone(), benchmark))

--- a/database/src/bin/import-sqlite.rs
+++ b/database/src/bin/import-sqlite.rs
@@ -1,4 +1,4 @@
-use database::{BenchmarkData, Lookup, Pool};
+use database::{CompileBenchmark, Lookup, Pool};
 use hashbrown::HashMap;
 use std::collections::HashSet;
 
@@ -25,7 +25,7 @@ async fn main() {
     let cid = postgres_conn.collection_id(&cid_name).await;
 
     let mut benchmarks = HashSet::new();
-    let benchmark_data: HashMap<String, BenchmarkData> = sqlite_conn
+    let benchmark_data: HashMap<String, CompileBenchmark> = sqlite_conn
         .get_compile_benchmarks()
         .await
         .into_iter()
@@ -48,7 +48,7 @@ async fn main() {
         for &(benchmark, profile, scenario, metric) in sqlite_idx.all_statistic_descriptions() {
             if benchmarks.insert(benchmark) {
                 postgres_conn
-                    .record_benchmark(
+                    .record_compile_benchmark(
                         benchmark.as_str(),
                         None,
                         benchmark_data[benchmark.as_str()].category.clone(),

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -748,7 +748,7 @@ impl fmt::Display for CollectionId {
 }
 
 #[derive(Debug, Clone, Serialize)]
-pub struct BenchmarkData {
+pub struct CompileBenchmark {
     pub name: String,
     pub category: String,
 }

--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -47,6 +47,14 @@ pub trait Connection: Send + Sync {
         metric: &str,
         value: f64,
     );
+    async fn record_runtime_statistic(
+        &self,
+        collection: CollectionId,
+        artifact: ArtifactIdNumber,
+        benchmark: &str,
+        metric: &str,
+        value: f64,
+    );
     /// Records a self-profile artifact in S3.
     ///
     /// The upload is a separate step (which may fail or be canceled, but that's

--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -15,7 +15,7 @@ pub trait Connection: Send + Sync {
     async fn transaction(&mut self) -> Box<dyn Transaction + '_>;
 
     async fn load_index(&mut self) -> Index;
-    async fn get_benchmarks(&self) -> Vec<BenchmarkData>;
+    async fn get_compile_benchmarks(&self) -> Vec<BenchmarkData>;
 
     async fn artifact_by_name(&self, artifact: &str) -> Option<ArtifactId>;
 

--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -1,4 +1,4 @@
-use crate::{ArtifactId, ArtifactIdNumber, BenchmarkData};
+use crate::{ArtifactId, ArtifactIdNumber, CompileBenchmark};
 use crate::{CollectionId, Index, Profile, QueuedCommit, Scenario, Step};
 use chrono::{DateTime, Utc};
 use hashbrown::HashMap;
@@ -15,7 +15,7 @@ pub trait Connection: Send + Sync {
     async fn transaction(&mut self) -> Box<dyn Transaction + '_>;
 
     async fn load_index(&mut self) -> Index;
-    async fn get_compile_benchmarks(&self) -> Vec<BenchmarkData>;
+    async fn get_compile_benchmarks(&self) -> Vec<CompileBenchmark>;
 
     async fn artifact_by_name(&self, artifact: &str) -> Option<ArtifactId>;
 
@@ -27,7 +27,12 @@ pub trait Connection: Send + Sync {
     async fn artifact_id(&self, artifact: &ArtifactId) -> ArtifactIdNumber;
     /// None means that the caller doesn't know; it should be left alone if
     /// known or set to false if unknown.
-    async fn record_benchmark(&self, krate: &str, supports_stable: Option<bool>, category: String);
+    async fn record_compile_benchmark(
+        &self,
+        krate: &str,
+        supports_stable: Option<bool>,
+        category: String,
+    );
     async fn record_statistic(
         &self,
         collection: CollectionId,

--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -15,7 +15,18 @@ pub trait Connection: Send + Sync {
     async fn transaction(&mut self) -> Box<dyn Transaction + '_>;
 
     async fn load_index(&mut self) -> Index;
+
+    /// None means that the caller doesn't know; it should be left alone if
+    /// known or set to false if unknown.
+    async fn record_compile_benchmark(
+        &self,
+        krate: &str,
+        supports_stable: Option<bool>,
+        category: String,
+    );
     async fn get_compile_benchmarks(&self) -> Vec<CompileBenchmark>;
+
+    async fn record_runtime_benchmark(&self, name: &str);
 
     async fn artifact_by_name(&self, artifact: &str) -> Option<ArtifactId>;
 
@@ -25,14 +36,7 @@ pub trait Connection: Send + Sync {
 
     async fn collection_id(&self, version: &str) -> CollectionId;
     async fn artifact_id(&self, artifact: &ArtifactId) -> ArtifactIdNumber;
-    /// None means that the caller doesn't know; it should be left alone if
-    /// known or set to false if unknown.
-    async fn record_compile_benchmark(
-        &self,
-        krate: &str,
-        supports_stable: Option<bool>,
-        category: String,
-    );
+
     async fn record_statistic(
         &self,
         collection: CollectionId,

--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -739,6 +739,16 @@ where
             .await
             .unwrap();
     }
+    async fn record_runtime_statistic(
+        &self,
+        _collection: CollectionId,
+        _artifact: ArtifactIdNumber,
+        _benchmark: &str,
+        _metric: &str,
+        _value: f64,
+    ) {
+        unimplemented!()
+    }
 
     async fn record_rustc_crate(
         &self,

--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -555,7 +555,7 @@ where
                 .collect(),
         }
     }
-    async fn get_benchmarks(&self) -> Vec<BenchmarkData> {
+    async fn get_compile_benchmarks(&self) -> Vec<BenchmarkData> {
         let rows = self
             .conn()
             .query(&self.statements().get_benchmarks, &[])

--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -1,7 +1,7 @@
 use crate::pool::{Connection, ConnectionManager, ManagedConnection, Transaction};
 use crate::{
-    ArtifactId, ArtifactIdNumber, Benchmark, BenchmarkData, CollectionId, Commit, CommitType, Date,
-    Index, Profile, QueuedCommit, Scenario,
+    ArtifactId, ArtifactIdNumber, Benchmark, CollectionId, Commit, CommitType, CompileBenchmark,
+    Date, Index, Profile, QueuedCommit, Scenario,
 };
 use anyhow::Context as _;
 use chrono::{DateTime, TimeZone, Utc};
@@ -555,14 +555,14 @@ where
                 .collect(),
         }
     }
-    async fn get_compile_benchmarks(&self) -> Vec<BenchmarkData> {
+    async fn get_compile_benchmarks(&self) -> Vec<CompileBenchmark> {
         let rows = self
             .conn()
             .query(&self.statements().get_benchmarks, &[])
             .await
             .unwrap();
         rows.into_iter()
-            .map(|r| BenchmarkData {
+            .map(|r| CompileBenchmark {
                 name: r.get(0),
                 category: r.get(1),
             })
@@ -883,7 +883,7 @@ where
             .unwrap();
     }
 
-    async fn record_benchmark(
+    async fn record_compile_benchmark(
         &self,
         benchmark: &str,
         supports_stable: Option<bool>,

--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -922,6 +922,9 @@ where
                 .unwrap();
         }
     }
+    async fn record_runtime_benchmark(&self, _name: &str) {
+        unimplemented!()
+    }
 
     async fn collector_start(&self, aid: ArtifactIdNumber, steps: &[String]) {
         // Clean up -- we'll re-insert any missing things in the loop below.

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -322,6 +322,26 @@ static MIGRATIONS: &[Migration] = &[
     ),
     Migration::new("alter table benchmark add column category text not null default ''"),
     Migration::new("alter table pull_request_build add column commit_date timestamp"),
+    Migration::new(
+        r#"
+        create table runtime_benchmark(
+            name text primary key not null
+        );
+        create table runtime_pstat_series(
+            id integer primary key not null,
+            benchmark text not null references runtime_benchmark(name) on delete cascade on update cascade,
+            metric text not null,
+            UNIQUE(benchmark, metric)
+        );
+        create table runtime_pstat(
+            series integer references runtime_pstat_series(id) on delete cascade on update cascade,
+            aid integer references artifact(id) on delete cascade on update cascade,
+            cid integer references collection(id) on delete cascade on update cascade,
+            value double not null,
+            PRIMARY KEY(series, aid, cid)
+        );
+        "#,
+    ),
 ];
 
 #[async_trait::async_trait]

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -500,7 +500,7 @@ impl Connection for SqliteConnection {
         }
     }
 
-    async fn get_benchmarks(&self) -> Vec<BenchmarkData> {
+    async fn get_compile_benchmarks(&self) -> Vec<BenchmarkData> {
         let conn = self.raw_ref();
         let mut query = conn
             .prepare_cached("select name, category from benchmark")

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -543,6 +543,15 @@ impl Connection for SqliteConnection {
         }
         benchmarks
     }
+    async fn record_runtime_benchmark(&self, name: &str) {
+        self.raw_ref()
+            .execute(
+                "insert into runtime_benchmark (name) VALUES (?)
+                ON CONFLICT (name) do nothing",
+                params![name],
+            )
+            .unwrap();
+    }
 
     async fn get_pstats(
         &self,

--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -132,7 +132,7 @@ pub mod bootstrap {
 pub mod comparison {
     use crate::comparison::Metric;
     use collector::Bound;
-    use database::{BenchmarkData, Date};
+    use database::{CompileBenchmark, Date};
     use serde::{Deserialize, Serialize};
     use std::collections::HashMap;
 
@@ -149,8 +149,8 @@ pub mod comparison {
         pub category: String,
     }
 
-    impl From<BenchmarkData> for BenchmarkInfo {
-        fn from(data: BenchmarkData) -> Self {
+    impl From<CompileBenchmark> for BenchmarkInfo {
+        fn from(data: CompileBenchmark) -> Self {
             Self {
                 name: data.name,
                 category: data.category.to_string(),

--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -125,7 +125,7 @@ pub async fn handle_compare(
     let prev = comparison.prev(master_commits);
     let next = comparison.next(master_commits);
     let is_contiguous = comparison.is_contiguous(&*conn, master_commits).await;
-    let benchmark_map = conn.get_benchmarks().await;
+    let benchmark_map = conn.get_compile_benchmarks().await;
 
     let comparisons = comparison
         .comparisons

--- a/site/src/load.rs
+++ b/site/src/load.rs
@@ -258,7 +258,7 @@ impl SiteCtxt {
     }
 
     pub async fn get_benchmark_category_map(&self) -> HashMap<Benchmark, Category> {
-        let benchmarks = self.pool.connection().await.get_benchmarks().await;
+        let benchmarks = self.pool.connection().await.get_compile_benchmarks().await;
         benchmarks
             .into_iter()
             .map(|bench| {


### PR DESCRIPTION
Currently, each iteration of a runtime benchmark is stored with a fresh collection ID. This is something that we may want to change, although there is currently a unique index across (`pstat_series`, `artifact_id` and `collection_id`), so we cannot easily associate multiple metric sets with a single collection ID.