### PR TITLE
Add comment about unifying types to Profile

### DIFF
--- a/collector/src/benchmark/profile.rs
+++ b/collector/src/benchmark/profile.rs
@@ -1,3 +1,10 @@
+/// Type of compilation used for benchmarking/profiling.
+// Note: This type is very similar to the definition of a profile in the database crate.
+// However, these types should not be unified, as they serve slightly different purposes.
+// This type is used for specifying profiles to be benchmarked using the CLI, which is not relevant
+// to the database crate.
+// In general, the database versions of types used in the collector should be considered a DB
+// implementation detail, as they may change when we alter database layout.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, clap::ArgEnum, serde::Deserialize)]
 #[clap(rename_all = "PascalCase")]
 pub enum Profile {


### PR DESCRIPTION
Suggested by @nnethercote [here](https://github.com/rust-lang/rustc-perf/pull/1511#issuecomment-1407791939).

I didn't add the same comment to `Scenario`, as it would be mostly duplicated (and scenario is not so similar in the DB, so people probably won't be inclined to try to merge it).

I added the note as a regular comment, as it's just an implementation note and shouldn't appear in rustdoc (not that many people look at docs of `rustc-perf` I suppose :) ).