### PR TITLE
Display two decimal places in the dashboard

### DIFF
--- a/site/src/request_handlers/dashboard.rs
+++ b/site/src/request_handlers/dashboard.rs
@@ -116,7 +116,7 @@ pub async fn handle_dashboard(ctxt: Arc<SiteCtxt>) -> ServerResult<dashboard::Re
                         .collect::<Vec<_>>(),
                 )
                 .map(|((_id, point), _interpolated)| {
-                    (point.expect("interpolated") * 10.0).round() / 10.0
+                    (point.expect("interpolated") * 100.0).round() / 100.0
                 })
                 .collect::<Vec<_>>();
 

--- a/site/src/request_handlers/dashboard.rs
+++ b/site/src/request_handlers/dashboard.rs
@@ -1,3 +1,4 @@
+use collector::benchmark::{compile_benchmark_dir, get_compile_benchmarks};
 use std::sync::Arc;
 
 use crate::api::{dashboard, ServerResult};
@@ -74,23 +75,18 @@ pub async fn handle_dashboard(ctxt: Arc<SiteCtxt>) -> ServerResult<dashboard::Re
             .collect::<Vec<_>>(),
     );
 
+    let stable_benchmarks: Vec<String> =
+        get_compile_benchmarks(&compile_benchmark_dir(), None, None)
+            .map_err(|error| format!("Could not load benchmarks: {error:?}"))?
+            .into_iter()
+            .filter(|benchmark| benchmark.category().is_stable())
+            .map(|benchmark| benchmark.name.to_string())
+            .collect();
+
     let query = selector::Query::new()
-        // FIXME: don't hardcode the stabilized benchmarks
-        // This list was found via:
-        // `rg supports.stable collector/compile-benchmarks/ -tjson -c --sort path`
         .set(
             selector::Tag::Benchmark,
-            selector::Selector::Subset(vec![
-                "encoding",
-                "futures",
-                "html5ever",
-                "inflate",
-                "piston-image",
-                "regex",
-                "style-servo",
-                "syn",
-                "tokio-webpush-simple",
-            ]),
+            selector::Selector::Subset(stable_benchmarks),
         )
         .set(selector::Tag::Metric, selector::Selector::One("wall-time"));
 


### PR DESCRIPTION
The differences of times in the dashboard between individual versions are becoming quite small. With one decimal place, it often shows the same number, so it's not easy to recognize if the wall-time changes or not. This PR changes the display to two decimal places instead.

While modifying the code, I also resolved one FIXME (I checked locally that the list of stable benchmarks remains the same).