### PR TITLE
Display "No relevant results" on compare page where there are filtered non-relevant results

### DIFF
--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -314,7 +314,8 @@
             </div>
             <test-cases-table
                 title="Primary"
-                :cases="testCases.filter(c => c.category === 'primary')"
+                :cases="primaryCases"
+                :has-non-relevant="testCasesWithNonRelevant.filter(c => c.category === 'primary').length > 0"
                 :show-raw-data="filter.showRawData"
                 :commit-a="data.a"
                 :commit-b="data.b"
@@ -328,7 +329,8 @@
             <hr />
             <test-cases-table
                 title="Secondary"
-                :cases="testCases.filter(c => c.category === 'secondary')"
+                :cases="secondaryCases"
+                :has-non-relevant="testCasesWithNonRelevant.filter(c => c.category === 'secondary').length > 0"
                 :show-raw-data="filter.showRawData"
                 :commit-a="data.a"
                 :commit-b="data.b"


### PR DESCRIPTION
This PR modifies the text on the  compare page to "No relevant results" when there are non-relevant results filtered out. In theory, we could also generalize to something like "No results (some results are filtered)", but that message would apply everytime, because there are always at least *some* results for each filter configuration. And since "Show non relevant" is the only filter checkbox that is turned off by default, I think that it makes sense to specialize for it.

Suggested [here](https://github.com/rust-lang/rust/pull/108159#issuecomment-1435389638).