### PR TITLE
Make `collector download crate` default to the primary category.

### DIFF
--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -664,7 +664,7 @@ struct DownloadCommand {
     force: bool,
 
     /// What category does the benchmark belong to
-    #[clap(long, short('c'), arg_enum, global = true, default_value = "secondary")]
+    #[clap(long, short('c'), arg_enum, global = true, default_value = "primary")]
     category: Category,
 
     #[clap(subcommand)]


### PR DESCRIPTION
It's what I usually want, because crates downloaded from elsewhere (typically crates.io) are likely to be real-world code, and thus more appropriate in the primary category.