### PR TITLE
Display doc benchmarks in dashboard

### DIFF
--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -38,6 +38,7 @@ pub mod dashboard {
         pub check: Cases,
         pub debug: Cases,
         pub opt: Cases,
+        pub doc: Cases,
     }
 }
 

--- a/site/src/request_handlers/dashboard.rs
+++ b/site/src/request_handlers/dashboard.rs
@@ -149,6 +149,7 @@ pub async fn handle_dashboard(ctxt: Arc<SiteCtxt>) -> ServerResult<dashboard::Re
         check: by_profile.check,
         debug: by_profile.debug,
         opt: by_profile.opt,
+        doc: by_profile.doc,
     })
 }
 

--- a/site/static/dashboard.html
+++ b/site/static/dashboard.html
@@ -18,6 +18,7 @@
     <div id="check-average-times"></div>
     <div id="debug-average-times"></div>
     <div id="opt-average-times"></div>
+    <div id="doc-average-times"></div>
     <div id="as-of"></div>
     <div style="text-align: center;">
         <a href="https://github.com/rust-lang/rustc-perf">Contribute on GitHub</a>
@@ -26,7 +27,7 @@
     <script>
 
         function render(element, name, data, versions) {
-            let articles = { "check": "a", "debug": "a", "opt": "an" };
+            let articles = { "check": "a", "debug": "a", "opt": "an", "doc": "a" };
             new Highcharts.chart(document.getElementById(element), {
                 chart: {
                     zoomType: "xy",
@@ -74,6 +75,7 @@
             render("check-average-times", "check", data.check, data.versions);
             render("debug-average-times", "debug", data.debug, data.versions);
             render("opt-average-times", "opt", data.opt, data.versions);
+            render("doc-average-times", "doc", data.doc, data.versions);
         }
 
         function make_data() {


### PR DESCRIPTION
It was missing from the dashboard.