### PR TITLE
Optimize Dockerfile to speed up CI caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,14 @@ jobs:
       - name: Formatting check
         run: cargo fmt --all -- --check
 
-      - name: Test and build
-        run: docker build -t rustc-perf .
+      - uses: docker/setup-buildx-action@v2
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          tags: rustc-perf
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Deploy to production
         uses: rust-lang/simpleinfra/github-actions/upload-docker-image@master


### PR DESCRIPTION
Use `cargo chef` + sparse `crates.io` registry in Dockerfile to speed up Docker (re)builds. Also add GHA cache for Docker layers and use Buildkit for building on CI.

This reduces the time to run the required Linux CI build from 10-12 minutes to 3-4 minutes.