### PR TITLE
Report errors during preparation of crates

### DIFF
--- a/collector/README.md
+++ b/collector/README.md
@@ -450,3 +450,17 @@ profilers whose results are not affected by system noise (e.g. `callgrind` or `e
 
 `RUST_LOG=debug` can be specified to enable verbose logging, which is useful
 for debugging `collector` itself.
+
+
+## How `rustc` wrapping works
+When a crate is benchmarked or profiled, the real `rustc` is replaced with the `rustc-fake` binary,
+which parses commands passed from the `collector` and invokes the actual profiling or benchmarking
+tool.
+
+Profiling/benchmarking a crate is performed in two steps:
+1) Preparation - here all dependencies are compiled and build scripts are executed.
+During this step, `cargo` is invoked with `... -- --skip-this-rustc`, which causes `rustc-fake` to skip
+compilation of the final/leaf crate. Cargo only passes arguments after `--` to the final crate,
+therefore this does not affect the compilation of dependencies.
+2) Profiling/benchmarking - `cargo` is invoked with `--wrap-rustc-with <TOOL>`, which executes the
+specified profiling tool by `rustc-fake`.

--- a/collector/src/benchmark/mod.rs
+++ b/collector/src/benchmark/mod.rs
@@ -253,15 +253,18 @@ impl Benchmark {
             for (profile, prep_dir) in &profile_dirs {
                 let server = server.clone();
                 s.spawn::<_, anyhow::Result<()>>(move |_| {
+                    // Panic the thread if an error occurs to make sure that the whole scope will
+                    // also panic if there was some error.
                     self.mk_cargo_process(compiler, prep_dir.path(), *profile)
                         .jobserver(server)
-                        .run_rustc(false)?;
+                        .run_rustc(false)
+                        .unwrap();
                     Ok(())
                 });
             }
             Ok(())
         })
-        .unwrap()?;
+        .expect("Preparation has failed")?;
 
         for (profile, prep_dir) in profile_dirs {
             eprintln!("Running {}: {:?} + {:?}", self.name, profile, scenarios);


### PR DESCRIPTION
Before:
```
Running webrender-2022: Check + [Full]
collector error: Failed to benchmark 'webrender-2022', recorded: expected success, got exit status: 101

stderr=    Checking bincode v1.3.3
    Checking wr_malloc_size_of v0.0.1 (/tmp/.tmp0JL5rX/wr_malloc_size_of)
    Checking peek-poke v0.2.0 (/tmp/.tmp0JL5rX/peek-poke)
    Checking etagere v0.2.6
    Checking plane-split v0.17.1
"/home/kobzol/.rustup/toolchains/e84e5ff04a647ce28540300244a26ba120642eea/bin/rustc" ["--crate-name", "wr_malloc_size_of", "--edition=2018", "wr_malloc_size_of/lib.rs", "--error-format=json", "--json=diagnostic-rendered-ansi,artifacts,future-incompat", "--crate-type", "lib", "--emit=dep-info,metadata", "-C", "panic=abort", "-C", "embed-bitcode=no", "-C", "debuginfo=2", "-C", "metadata=c8cdd12f12e44948", "-C", "extra-filename=-c8cdd12f12e44948", "--out-dir", "/tmp/.tmp0JL5rX/target/debug/deps", "-L", "dependency=/tmp/.tmp0JL5rX/target/debug/deps", "--extern", "app_units=/tmp/.tmp0JL5rX/target/debug/deps/libapp_units-e681452e9dd8cc1f.rmeta", "--extern", "euclid=/tmp/.tmp0JL5rX/target/debug/deps/libeuclid-3dade91424e2ce9f.rmeta", "-Adeprecated", "-Aunknown-lints", "-Zincremental-verify-ich"]
exiting -- non-wrapped rustc
"/home/kobzol/.rustup/toolchains/e84e5ff04a647ce28540300244a26ba120642eea/bin/rustc" ["--crate-name", "peek_poke", "--edition=2018", "peek-poke/src/lib.rs", "--error-format=json", "--json=diagnostic-rendered-ansi,artifacts,future-incompat", "--crate-type", "lib", "--emit=dep-info,metadata", "-C", "panic=abort", "-C", "embed-bitcode=no", "-C", "debuginfo=2", "--cfg", "feature=\"default\"", "--cfg", "feature=\"derive\"", "--cfg", "feature=\"euclid\"", "--cfg", "feature=\"extras\"", "--cfg", "feature=\"peek-poke-derive\"", "-C", "metadata=e342700e96f26c4f", "-C", "extra-filename=-e342700e96f26c4f", "--out-dir", "/tmp/.tmp0JL5rX/target/debug/deps", "-L", "dependency=/tmp/.tmp0JL5rX/target/debug/deps", "--extern", "euclid=/tmp/.tmp0JL5rX/target/debug/deps/libeuclid-3dade91424e2ce9f.rmeta", "--extern", "peek_poke_derive=/tmp/.tmp0JL5rX/target/debug/deps/libpeek_poke_derive-d1b317dc19627421.so", "-Adeprecated", "-Aunknown-lints", "-Zincremental-verify-ich"]
exiting -- non-wrapped rustc
error: could not compile `wr_malloc_size_of` (lib)
warning: build failed, waiting for other jobs to finish...
error: could not compile `peek-poke` (lib)
"/home/kobzol/.rustup/toolchains/e84e5ff04a647ce28540300244a26ba120642eea/bin/rustc" ["--crate-name", "plane_split", "--edition=2018", "/home/kobzol/.cargo/registry/src/index.crates.io-6f17d22bba15001f/plane-split-0.17.1/src/lib.rs", "--error-format=json", "--json=diagnostic-rendered-ansi,artifacts,future-incompat", "--crate-type", "lib", "--emit=dep-info,metadata", "-C", "panic=abort", "-C", "embed-bitcode=no", "-C", "debuginfo=2", "-C", "metadata=6662b5bc082bf0fa", "-C", "extra-filename=-6662b5bc082bf0fa", "--out-dir", "/tmp/.tmp0JL5rX/target/debug/deps", "-L", "dependency=/tmp/.tmp0JL5rX/target/debug/deps", "--extern", "binary_space_partition=/tmp/.tmp0JL5rX/target/debug/deps/libbinary_space_partition-ce8559b8c2fff056.rmeta", "--extern", "euclid=/tmp/.tmp0JL5rX/target/debug/deps/libeuclid-3dade91424e2ce9f.rmeta", "--extern", "log=/tmp/.tmp0JL5rX/target/debug/deps/liblog-a2ff91c3cf269f8a.rmeta", "--extern", "num_traits=/tmp/.tmp0JL5rX/target/debug/deps/libnum_traits-7bb5550f5808059f.rmeta", "--cap-lints", "allow", "-Adeprecated", "-Aunknown-lints", "-Zincremental-verify-ich"]
exiting -- non-wrapped rustc
error: could not compile `plane-split` (lib)
"/home/kobzol/.rustup/toolchains/e84e5ff04a647ce28540300244a26ba120642eea/bin/rustc" ["--crate-name", "etagere", "--edition=2018", "/home/kobzol/.cargo/registry/src/index.crates.io-6f17d22bba15001f/etagere-0.2.6/src/lib.rs", "--error-format=json", "--json=diagnostic-rendered-ansi,artifacts,future-incompat", "--crate-type", "lib", "--emit=dep-info,metadata", "-C", "panic=abort", "-C", "embed-bitcode=no", "-C", "debuginfo=2", "-C", "metadata=fc9db14c5a665296", "-C", "extra-filename=-fc9db14c5a665296", "--out-dir", "/tmp/.tmp0JL5rX/target/debug/deps", "-L", "dependency=/tmp/.tmp0JL5rX/target/debug/deps", "--extern", "euclid=/tmp/.tmp0JL5rX/target/debug/deps/libeuclid-3dade91424e2ce9f.rmeta", "--extern", "svg_fmt=/tmp/.tmp0JL5rX/target/debug/deps/libsvg_fmt-558f4a1ef3277e88.rmeta", "--cap-lints", "allow", "-Adeprecated", "-Aunknown-lints", "-Zincremental-verify-ich"]
exiting -- non-wrapped rustc
error: could not compile `etagere` (lib)
"/home/kobzol/.rustup/toolchains/e84e5ff04a647ce28540300244a26ba120642eea/bin/rustc" ["--crate-name", "bincode", "/home/kobzol/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bincode-1.3.3/src/lib.rs", "--error-format=json", "--json=diagnostic-rendered-ansi,artifacts,future-incompat", "--crate-type", "lib", "--emit=dep-info,metadata", "-C", "panic=abort", "-C", "embed-bitcode=no", "-C", "debuginfo=2", "-C", "metadata=4d026a73be98f562", "-C", "extra-filename=-4d026a73be98f562", "--out-dir", "/tmp/.tmp0JL5rX/target/debug/deps", "-L", "dependency=/tmp/.tmp0JL5rX/target/debug/deps", "--extern", "serde=/tmp/.tmp0JL5rX/target/debug/deps/libserde-f35afb1b090c7b1f.rmeta", "--cap-lints", "allow", "-Adeprecated", "-Aunknown-lints", "-Zincremental-verify-ich"]
exiting -- non-wrapped rustc
error: could not compile `bincode` (lib)


 stdout=
```

After:
```
Preparing webrender-2022
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: expected success, got exit status: 101

stderr=   Compiling serde v1.0.136
    Checking cfg-if v1.0.0
    Checking lazy_static v1.4.0
   Compiling log v0.4.16
   Compiling num-traits v0.2.14
    Checking libc v0.2.121
    Checking scopeguard v1.1.0
   Compiling webrender_build v0.0.1 (/tmp/.tmpnXBtyj/webrender_build)
    Checking byteorder v1.4.3
    Checking memoffset v0.6.5
    Checking bitflags v1.3.2
    Checking binary-space-partition v0.1.2
    Checking svg_fmt v0.4.1
    Checking either v1.6.1
   Compiling serde_derive v1.0.136
   Compiling glslopt v0.1.9
   Compiling peek-poke-derive v0.2.1 (/tmp/.tmpnXBtyj/peek-poke/peek-poke-derive)
   Compiling malloc_size_of_derive v0.1.2
   Compiling derive_more v0.99.17
    Checking crossbeam-utils v0.8.8
    Checking tracy-rs v0.1.2
    Checking smallvec v1.8.0
    Checking fxhash v0.2.1
   Compiling webrender v0.61.0 (/tmp/.tmpnXBtyj/webrender)
    Checking crossbeam-epoch v0.9.8
    Checking crossbeam-channel v0.5.4
   Compiling gl_generator v0.14.0
    Checking num_cpus v1.13.1
    Checking freetype-sys v0.13.1
    Checking time v0.1.43
    Checking crossbeam-deque v0.8.1
    Checking freetype v0.7.0
    Checking rayon-core v1.9.1
   Compiling gleam v0.13.1
    Checking rayon v1.5.1
    Checking euclid v0.22.6
    Checking app_units v0.7.1
    Checking serde_bytes v0.11.5
    Checking bincode v1.3.3
error: internal compiler error: /rustc/e84e5ff04a647ce28540300244a26ba120642eea/compiler/rustc_infer/src/infer/outlives/env.rs:145:26: add_outlives_bounds: unexpected regions

thread 'rustc' panicked at 'Box<dyn Any>', /rustc/e84e5ff04a647ce28540300244a26ba120642eea/compiler/rustc_errors/src/lib.rs:1644:9
stack backtrace:
   0:     0x7ff5abacf51a - std::backtrace_rs::backtrace::libunwind::trace::hab17a96bd248950c
                               at /rustc/e84e5ff04a647ce28540300244a26ba120642eea/library/std/src/../../backtrace/src/backtrace/libunwind.rs:93:5
   1:     0x7ff5abacf51a - std::backtrace_rs::backtrace::trace_unsynchronized::h2dd96cad48ba21dc
                               at /rustc/e84e5ff04a647ce28540300244a26ba120642eea/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2:     0x7ff5abacf51a - std::sys_common::backtrace::_print_fmt::h38b10a2f9d2b2585
                               at /rustc/e84e5ff04a647ce28540300244a26ba120642eea/library/std/src/sys_common/backtrace.rs:65:5
   3:     0x7ff5abacf51a - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::h194193fb0b01617d
                               at /rustc/e84e5ff04a647ce28540300244a26ba120642eea/library/std/src/sys_common/backtrace.rs:44:22
   4:     0x7ff5abb32c5e - core::fmt::write::hd9150a25fdbebf32
                               at /rustc/e84e5ff04a647ce28540300244a26ba120642eea/library/core/src/fmt/mod.rs:1232:17
   5:     0x7ff5abac2275 - std::io::Write::write_fmt::h3837df0e41e13e0e
                               at /rustc/e84e5ff04a647ce28540300244a26ba120642eea/library/std/src/io/mod.rs:1684:15
   6:     0x7ff5abacf2e5 - std::sys_common::backtrace::_print::h8a5cae525f1be897
                               at /rustc/e84e5ff04a647ce28540300244a26ba120642eea/library/std/src/sys_common/backtrace.rs:47:5
   7:     0x7ff5abacf2e5 - std::sys_common::backtrace::print::h49b97caefe2bba8a
                               at /rustc/e84e5ff04a647ce28540300244a26ba120642eea/library/std/src/sys_common/backtrace.rs:34:9
   8:     0x7ff5abad205f - std::panicking::default_hook::{{closure}}::h2a3da047f4b2da03
                               at /rustc/e84e5ff04a647ce28540300244a26ba120642eea/library/std/src/panicking.rs:271:22
   9:     0x7ff5abad1d9b - std::panicking::default_hook::hc971a327b2a9d145
                               at /rustc/e84e5ff04a647ce28540300244a26ba120642eea/library/std/src/panicking.rs:290:9
  10:     0x7ff5aedd2045 - rustc_driver_impl[6fa38601416e453]::DEFAULT_HOOK::{closure#0}::{closure#0}
  11:     0x7ff5abad289d - <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call::h8520e136aebea51a
                               at /rustc/e84e5ff04a647ce28540300244a26ba120642eea/library/alloc/src/boxed.rs:2002:9
  12:     0x7ff5abad289d - std::panicking::rust_panic_with_hook::h93b4e29d3ec3eadc
                               at /rustc/e84e5ff04a647ce28540300244a26ba120642eea/library/std/src/panicking.rs:696:13
  13:     0x7ff5af3307a1 - std[45927792e1219606]::panicking::begin_panic::<rustc_errors[d7b71bcef7ff042a]::ExplicitBug>::{closure#0}
  14:     0x7ff5af32bc46 - std[45927792e1219606]::sys_common::backtrace::__rust_end_short_backtrace::<std[45927792e1219606]::panicking::begin_panic<rustc_errors[d7b71bcef7ff042a]::ExplicitBug>::{closure#0}, !>
  15:     0x7ff5af2d2536 - std[45927792e1219606]::panicking::begin_panic::<rustc_errors[d7b71bcef7ff042a]::ExplicitBug>
  16:     0x7ff5af37cea6 - std[45927792e1219606]::panic::panic_any::<rustc_errors[d7b71bcef7ff042a]::ExplicitBug>
  17:     0x7ff5af379726 - <rustc_errors[d7b71bcef7ff042a]::HandlerInner>::bug::<&alloc[f3ac33a76f945683]::string::String>
  18:     0x7ff5af3793f0 - <rustc_errors[d7b71bcef7ff042a]::Handler>::bug::<&alloc[f3ac33a76f945683]::string::String>
  19:     0x7ff5af3657fb - rustc_middle[7f2c9dc76d3467a6]::util::bug::opt_span_bug_fmt::<rustc_span[a2f01ea7f179d208]::span_encoding::Span>::{closure#0}
  20:     0x7ff5af36425a - rustc_middle[7f2c9dc76d3467a6]::ty::context::tls::with_opt::<rustc_middle[7f2c9dc76d3467a6]::util::bug::opt_span_bug_fmt<rustc_span[a2f01ea7f179d208]::span_encoding::Span>::{closure#0}, !>::{closure#0}
  21:     0x7ff5af364226 - rustc_middle[7f2c9dc76d3467a6]::ty::context::tls::with_context_opt::<rustc_middle[7f2c9dc76d3467a6]::ty::context::tls::with_opt<rustc_middle[7f2c9dc76d3467a6]::util::bug::opt_span_bug_fmt<rustc_span[a2f01ea7f179d208]::span_encoding::Span>::{closure#0}, !>::{closure#0}, !>
  22:     0x7ff5af365746 - rustc_middle[7f2c9dc76d3467a6]::util::bug::opt_span_bug_fmt::<rustc_span[a2f01ea7f179d208]::span_encoding::Span>
  23:     0x7ff5ad4c69f3 - rustc_middle[7f2c9dc76d3467a6]::util::bug::bug_fmt
  24:     0x7ff5adcdb855 - <rustc_infer[219913fda715446f]::infer::outlives::env::OutlivesEnvironment>::with_bounds::<core[33bcc9bae161e6d]::iter::adapters::flatten::Flatten<core[33bcc9bae161e6d]::iter::adapters::map::Map<indexmap[52bde976a34d3203]::set::IntoIter<rustc_middle[7f2c9dc76d3467a6]::ty::Ty>, <rustc_infer[219913fda715446f]::infer::InferCtxt as rustc_trait_selection[a330fa3a60fd254]::traits::outlives_bounds::InferCtxtExt>::implied_bounds_tys::{closure#0}>>>
  25:     0x7ff5ace930e0 - rustc_hir_analysis[afd80bd0636fe849]::check::compare_impl_item::compare_method_predicate_entailment
  26:     0x7ff5ace8d061 - rustc_hir_analysis[afd80bd0636fe849]::check::compare_impl_item::compare_impl_method
  27:     0x7ff5ace7fa67 - rustc_hir_analysis[afd80bd0636fe849]::check::check::check_mod_item_types
  28:     0x7ff5ae40e23e - rustc_query_system[c5524b2d21c39947]::query::plumbing::try_execute_query::<rustc_query_impl[79380581a3052c55]::queries::check_mod_item_types, rustc_query_impl[79380581a3052c55]::plumbing::QueryCtxt>
  29:     0x7ff5ae40ddc3 - <rustc_query_impl[79380581a3052c55]::Queries as rustc_middle[7f2c9dc76d3467a6]::ty::query::QueryEngine>::check_mod_item_types
  30:     0x7ff5ad168cb4 - <rustc_session[63828082f6106403]::session::Session>::time::<(), rustc_hir_analysis[afd80bd0636fe849]::check_crate::{closure#6}>
  31:     0x7ff5ad165bf8 - rustc_hir_analysis[afd80bd0636fe849]::check_crate
  32:     0x7ff5ad15d942 - rustc_interface[920696c1fd270c1b]::passes::analysis
  33:     0x7ff5ae5eabec - rustc_query_system[c5524b2d21c39947]::query::plumbing::try_execute_query::<rustc_query_impl[79380581a3052c55]::queries::analysis, rustc_query_impl[79380581a3052c55]::plumbing::QueryCtxt>
  34:     0x7ff5ae5ea8e0 - <rustc_query_impl[79380581a3052c55]::Queries as rustc_middle[7f2c9dc76d3467a6]::ty::query::QueryEngine>::analysis
  35:     0x7ff5ae411a19 - <rustc_middle[7f2c9dc76d3467a6]::ty::context::GlobalCtxt>::enter::<rustc_driver_impl[6fa38601416e453]::run_compiler::{closure#1}::{closure#2}::{closure#4}, core[33bcc9bae161e6d]::result::Result<(), rustc_span[a2f01ea7f179d208]::ErrorGuaranteed>>
  36:     0x7ff5adfd9af8 - rustc_span[a2f01ea7f179d208]::with_source_map::<core[33bcc9bae161e6d]::result::Result<(), rustc_span[a2f01ea7f179d208]::ErrorGuaranteed>, rustc_interface[920696c1fd270c1b]::interface::run_compiler<core[33bcc9bae161e6d]::result::Result<(), rustc_span[a2f01ea7f179d208]::ErrorGuaranteed>, rustc_driver_impl[6fa38601416e453]::run_compiler::{closure#1}>::{closure#0}::{closure#0}>
  37:     0x7ff5adfd0c5c - std[45927792e1219606]::sys_common::backtrace::__rust_begin_short_backtrace::<rustc_interface[920696c1fd270c1b]::util::run_in_thread_pool_with_globals<rustc_interface[920696c1fd270c1b]::interface::run_compiler<core[33bcc9bae161e6d]::result::Result<(), rustc_span[a2f01ea7f179d208]::ErrorGuaranteed>, rustc_driver_impl[6fa38601416e453]::run_compiler::{closure#1}>::{closure#0}, core[33bcc9bae161e6d]::result::Result<(), rustc_span[a2f01ea7f179d208]::ErrorGuaranteed>>::{closure#0}::{closure#0}, core[33bcc9bae161e6d]::result::Result<(), rustc_span[a2f01ea7f179d208]::ErrorGuaranteed>>
  38:     0x7ff5adfd068a - <<std[45927792e1219606]::thread::Builder>::spawn_unchecked_<rustc_interface[920696c1fd270c1b]::util::run_in_thread_pool_with_globals<rustc_interface[920696c1fd270c1b]::interface::run_compiler<core[33bcc9bae161e6d]::result::Result<(), rustc_span[a2f01ea7f179d208]::ErrorGuaranteed>, rustc_driver_impl[6fa38601416e453]::run_compiler::{closure#1}>::{closure#0}, core[33bcc9bae161e6d]::result::Result<(), rustc_span[a2f01ea7f179d208]::ErrorGuaranteed>>::{closure#0}::{closure#0}, core[33bcc9bae161e6d]::result::Result<(), rustc_span[a2f01ea7f179d208]::ErrorGuaranteed>>::{closure#1} as core[33bcc9bae161e6d]::ops::function::FnOnce<()>>::call_once::{shim:vtable#0}
  39:     0x7ff5abadc793 - <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::h81703dda3203ac5a
                               at /rustc/e84e5ff04a647ce28540300244a26ba120642eea/library/alloc/src/boxed.rs:1988:9
  40:     0x7ff5abadc793 - <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::h30492a21713d5868
                               at /rustc/e84e5ff04a647ce28540300244a26ba120642eea/library/alloc/src/boxed.rs:1988:9
  41:     0x7ff5abadc793 - std::sys::unix::thread::Thread::new::thread_start::h834788d019271333
                               at /rustc/e84e5ff04a647ce28540300244a26ba120642eea/library/std/src/sys/unix/thread.rs:108:17
  42:     0x7ff5ab803b43 - start_thread
                               at ./nptl/./nptl/pthread_create.c:442:8
  43:     0x7ff5ab895a00 - clone3
                               at ./misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:81
  44:                0x0 - <unknown>

note: we would appreciate a bug report: https://github.com/rust-lang/rust/issues/new?labels=C-bug%2C+I-ICE%2C+T-compiler&template=ice.md

note: rustc 1.70.0-nightly (e84e5ff04 2023-03-15) running on x86_64-unknown-linux-gnu

note: compiler flags: --crate-type lib -C panic=abort -C embed-bitcode=no -C debuginfo=2 -Z incremental-verify-ich

note: some of the compiler flags provided by cargo are hidden

query stack during panic:
#0 [check_mod_item_types] checking item types in module `de`
#1 [analysis] running analysis passes on this crate
end of query stack
error: could not compile `bincode` (lib)
warning: build failed, waiting for other jobs to finish...


 stdout=
', collector/src/benchmark/mod.rs:261:26
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread 'main' panicked at 'Preparation has failed: Any { .. }', collector/src/benchmark/mod.rs:267:10
```

I also tried to document the `rustc` wrapping behavior, at least slightly, because I always scratch my head when I try to understand it.