### PR TITLE
Log preparation errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,7 +395,6 @@ dependencies = [
  "cargo_metadata",
  "chrono",
  "clap",
- "crossbeam-utils",
  "database",
  "env_logger 0.8.3",
  "filetime",

--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -27,7 +27,6 @@ intern = { path = "../intern" }
 futures = "0.3.5"
 num_cpus = "1.13"
 jobserver = "0.1.21"
-crossbeam-utils = "0.8"
 snap = "1"
 filetime = "0.2.14"
 walkdir = "2"


### PR DESCRIPTION
This PR adds logging for errors during preparation. If preparation of a benchmark fails in any way or panics (shouldn't happen, hopefully), the error will now be correctly propagated and logged.

This PR also removes dependency on `crossbeam-utils`.