### PR TITLE
Prepare CI workflow for nightly releases

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.66.0
+          toolchain: stable
           override: true
 
       - uses: Swatinem/rust-cache@v1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,55 @@
+name: Nightly release
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 23 * * *"
+
+jobs:
+  publish_release:
+    name: Publish release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set version
+        run: |
+          echo "RUSTC_PERF_VERSION=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+
+      - name: Checkout the source code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.66.0
+          override: true
+
+      - uses: Swatinem/rust-cache@v1
+
+      - name: Compile
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --bin site
+
+      - name: Prepare archive
+        id: archive
+        run: |
+          export ARCHIVE_NAME=rustc-perf-${{ env.RUSTC_PERF_VERSION }}-linux-x64.tar.gz
+          cp target/release/site rustc-perf-site
+          tar -czvf $ARCHIVE_NAME rustc-perf-site
+          echo "ARCHIVE_NAME=${ARCHIVE_NAME}" >> $GITHUB_ENV
+
+      - name: Create release
+        uses: ncipollo/release-action@v1
+        with:
+          body: Nightly release of `rustc-perf` (commit `${{ github.sha }}`, date ${{ env.RUSTC_PERF_VERSION }})
+          token: ${{ secrets.GITHUB_TOKEN }}
+          allowUpdates: true
+          name: Nightly ${{ env.RUSTC_PERF_VERSION }}
+          prerelease: true
+          tag: nightly
+          commit: ${{ github.sha }}
+          artifacts: ${{ env.ARCHIVE_NAME }}
+          removeArtifacts: true


### PR DESCRIPTION
This new CI workflow builds a `rustc-perf` site binary each day (night) and publishes it into a draft GH release. The release is overwritten each day, so we won't be spammed with hundreds of releases.