### PR TITLE
Revert "Report errors during crate preparation in collector"

### DIFF
--- a/collector/src/benchmark/mod.rs
+++ b/collector/src/benchmark/mod.rs
@@ -253,18 +253,15 @@ impl Benchmark {
             for (profile, prep_dir) in &profile_dirs {
                 let server = server.clone();
                 s.spawn::<_, anyhow::Result<()>>(move |_| {
-                    // Panic the thread if an error occurs to make sure that the whole scope will
-                    // also panic if there was some error.
                     self.mk_cargo_process(compiler, prep_dir.path(), *profile)
                         .jobserver(server)
-                        .run_rustc(false)
-                        .unwrap();
+                        .run_rustc(false)?;
                     Ok(())
                 });
             }
             Ok(())
         })
-        .expect("Preparation has failed")?;
+        .unwrap()?;
 
         for (profile, prep_dir) in profile_dirs {
             eprintln!("Running {}: {:?} + {:?}", self.name, profile, scenarios);


### PR DESCRIPTION
This caused a bug in production, since panicking in the collection loop takes down the collector before it can save the faulty status to the DB. For now just revert the commit, we'll want to rethink the approach of panicking here.

This reverts commit d7dc01ccddc1272c87d013d1553fc9732ecbe93b.