### PR TITLE
For Cachegrind, aggregate all jemalloc functions into a single entry.

### DIFF
--- a/ci/check-profiling.sh
+++ b/ci/check-profiling.sh
@@ -55,6 +55,8 @@ test -f results/cgout-Test-helloworld-Check-Full
 grep -q "events: Ir" results/cgout-Test-helloworld-Check-Full
 test -f results/cgann-Test-helloworld-Check-Full
 grep -q "PROGRAM TOTALS" results/cgann-Test-helloworld-Check-Full
+# Ensure the jemalloc file/function aggregation is working.
+grep -q "<all-jemalloc-files>:<all-jemalloc-functions>" results/cgann-Test-helloworld-Check-Full
 
 # Callgrind.
 RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=debug \


### PR DESCRIPTION
Because a single entry like this:
```
120,365,108 (8.7%)  <all-jemalloc-files>:<all-jemalloc-functions>
```
is much more helpful than dozens of entries like this:
```
1,900,760 (0.9%)  /home/njn/dev/rust2/build/x86_64-unknown-linux-gnu/stage0-rustc/x86_64-unknown-linux-gnu/release/build/jemalloc-sys-1e20251078fe5355/out/build/include/jemalloc/internal/rtree.h:free
 9,296,168 (0.7%)  /home/njn/dev/rust2/build/x86_64-unknown-linux-gnu/stage0-rustc/x86_64-unknown-linux-gnu/release/build/jemalloc-sys-1e20251078fe5355/out/build/include/jemalloc/internal/jemalloc_internal_inlines_c.h:malloc
 7,926,636 (0.6%)  /home/njn/dev/rust2/build/x86_64-unknown-linux-gnu/stage0-rustc/x86_64-unknown-linux-gnu/release/build/jemalloc-sys-1e20251078fe5355/out/build/src/jemalloc.c:free
 7,905,743 (0.6%)  /home/njn/dev/rust2/build/x86_64-unknown-linux-gnu/stage0-rustc/x86_64-unknown-linux-gnu/release/build/jemalloc-sys-1e20251078fe5355/out/build/include/jemalloc/internal/cache_bin.h:free
 7,834,577 (0.6%)  /home/njn/dev/rust2/build/x86_64-unknown-linux-gnu/stage0-rustc/x86_64-unknown-linux-gnu/release/build/jemalloc-sys-1e20251078fe5355/out/build/include/jemalloc/internal/cache_bin.h:malloc
 5,425,997 (0.4%)  /home/njn/dev/rust2/build/x86_64-unknown-linux-gnu/stage0-rustc/x86_64-unknown-linux-gnu/release/build/jemalloc-sys-1e20251078fe5355/out/build/src/arena.c:_rjem_je_arena_ralloc
 4,268,616 (0.3%)  /home/njn/dev/rust2/build/x86_64-unknown-linux-gnu/stage0-rustc/x86_64-unknown-linux-gnu/release/build/jemalloc-sys-1e20251078fe5355/out/build/src/jemalloc.c:do_rallocx
 3,539,679 (0.3%)  /home/njn/dev/rust2/build/x86_64-unknown-linux-gnu/stage0-rustc/x86_64-unknown-linux-gnu/release/build/jemalloc-sys-1e20251078fe5355/out/build/src/arena.c:_rjem_je_arena_ralloc_no_move
 3,093,308 (0.2%)  /home/njn/dev/rust2/build/x86_64-unknown-linux-gnu/stage0-rustc/x86_64-unknown-linux-gnu/release/build/jemalloc-sys-1e20251078fe5355/out/build/include/jemalloc/internal/sz.h:malloc
 2,393,337 (0.2%)  /home/njn/dev/rust2/build/x86_64-unknown-linux-gnu/stage0-rustc/x86_64-unknown-linux-gnu/release/build/jemalloc-sys-1e20251078fe5355/out/build/src/arena.c:_rjem_je_arena_cache_bin_fill_small
 2,371,694 (0.2%)  /home/njn/dev/rust2/build/x86_64-unknown-linux-gnu/stage0-rustc/x86_64-unknown-linux-gnu/release/build/jemalloc-sys-1e20251078fe5355/out/build/include/jemalloc/internal/rtree.h:tcache_bin_flush_edatas_lookup.constprop.0
 2,309,382 (0.2%)  /home/njn/dev/rust2/build/x86_64-unknown-linux-gnu/stage0-rustc/x86_64-unknown-linux-gnu/release/build/jemalloc-sys-1e20251078fe5355/out/build/src/jemalloc.c:malloc
...
```
(And in reality, those jemalloc function entries are interleaved with many non-jemalloc entries, making them even harder to read.)