### PR TITLE
Correct checking of end bound for triage comparison

### DIFF
--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -448,7 +448,7 @@ pub mod triage {
     #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Request {
         pub start: Bound,
-        pub end: Option<Bound>,
+        pub end: Bound,
     }
 
     #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
Fixes #1343 

This now properly checks that there is an artifact (which indicates a finished perf run) when doing a triage comparison loop. This should make it impossible to doing a full triage comparison where the end bound has not yet finished running. 