### PR TITLE
Port status page script to TypeScript

### DIFF
--- a/site/frontend/package.json
+++ b/site/frontend/package.json
@@ -25,6 +25,10 @@
     "dashboard": {
       "source": "src/pages/dashboard.ts",
       "distDir": "dist/scripts"
+    },
+    "status": {
+      "source": "src/pages/status.ts",
+      "distDir": "dist/scripts"
     }
   },
   "browserslist": "> 0.5%, last 3 years, not dead"

--- a/site/frontend/src/configuration.ts
+++ b/site/frontend/src/configuration.ts
@@ -1,3 +1,4 @@
 export const BASE_URL = window.location.origin + "/perf";
 
 export const DASHBOARD_DATA_URL = `${BASE_URL}/dashboard`;
+export const STATUS_DATA_URL = `${BASE_URL}/status_page`;

--- a/site/frontend/src/pages/dashboard.ts
+++ b/site/frontend/src/pages/dashboard.ts
@@ -74,7 +74,7 @@ function populate_data(response: DashboardResponse) {
 
 async function make_data() {
     const response = await fetch(DASHBOARD_DATA_URL, {});
-    let data = await response.json();
+    const data = await response.json();
     populate_data(data);
 }
 

--- a/site/frontend/templates/pages/status.html
+++ b/site/frontend/templates/pages/status.html
@@ -10,7 +10,6 @@
         padding: 0 0.5em;
     }
 </style>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/highcharts/6.0.7/highcharts.js"></script>
 {% endblock %}
 {% block content %}
 <div>
@@ -23,6 +22,5 @@
 </div>
 {% endblock %}
 {% block script %}
-<script src="scripts/shared.js"></script>
 <script src="scripts/status.js"></script>
 {% endblock %}


### PR DESCRIPTION
For these simple pages, I'm just moving them over to NPM to reduce some code duplication and remove old code. I'm not trying to refactor them heavily nor describe the server data response in super detail (it would be quite annoying for all the enum variants). The biggest benefit of TS should be in the pages that use Vue (the compare page and soon the runtime UI page(s)).

For the status page, the downloaded JS bundle size goes down from ~15k to ~3k (not that it's super important here).