### PR TITLE
Only run `push` CI workflows on push to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 on:
-  push: {}
+  push:
+    branches:
+      - master
   pull_request: {}
   schedule:
     - cron: "0 12 * * 1" # Every Monday at 12:00 UTC


### PR DESCRIPTION
I noticed that we run all (!) CI workflows twice on each PR commit, because we use an unfiltered `push` event. That's wasteful and increases latency of PR checks and also merging PRs. We should only run the `push` event on master.