### PR TITLE
Cache Rust artifacts of Windows CI workflows to make them faster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,10 @@ jobs:
           toolchain: beta
           override: true
 
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: windows
+
       - name: cargo check
         run: cargo check
         env:


### PR DESCRIPTION
The windows CI check is quite slow (10-12 minutes), but it doesn't use the Docker build. Therefore it should be quite straightforward to make it faster with the `Swatinem/rust-cache` action.