### PR TITLE
Add more information to PR summary comment

### DIFF
--- a/site/src/github/comparison_summary.rs
+++ b/site/src/github/comparison_summary.rs
@@ -246,6 +246,12 @@ async fn summarize_run(
             MetricReliability::Low,
             calculate_metric_comparison(ctxt, &commit, Metric::CyclesUser).await?,
         ),
+        (
+            "Binary size",
+            Metric::LinkedArtifactSize,
+            MetricReliability::Low,
+            calculate_metric_comparison(ctxt, &commit, Metric::LinkedArtifactSize).await?,
+        ),
     ];
 
     for (title, metric, reliability, comparison) in metrics {

--- a/site/src/github/comparison_summary.rs
+++ b/site/src/github/comparison_summary.rs
@@ -227,6 +227,8 @@ async fn summarize_run(
         }
     }
 
+    let bootstrap = summarize_bootstrap(&inst_comparison);
+
     let metrics = vec![
         (
             "Instruction count",
@@ -264,7 +266,23 @@ async fn summarize_run(
         write_metric_summary(primary, secondary, reliability, &mut message);
     }
 
+    write!(&mut message, "\n{bootstrap}").unwrap();
+
     Ok(message)
+}
+
+fn summarize_bootstrap(comparison: &ArtifactComparison) -> String {
+    let prev_s = comparison.a.bootstrap_total as f64 / 1e9;
+    let current_s = comparison.b.bootstrap_total as f64 / 1e9;
+
+    if prev_s == 0.0 || current_s == 0.0 {
+        return "**Bootstrap**: missing data".to_string();
+    }
+
+    let change = (current_s / prev_s) - 1.0;
+    let change = change * 100.0;
+
+    format!("**Bootstrap**: {prev_s}s -> {current_s}s ({change:.2}%)")
 }
 
 fn write_metric_summary(

--- a/site/src/github/comparison_summary.rs
+++ b/site/src/github/comparison_summary.rs
@@ -153,6 +153,12 @@ enum PerfRunSource {
     TryBuildRollup,
 }
 
+// How reliable is a given metric?
+enum MetricReliability {
+    High,
+    Low,
+}
+
 async fn summarize_run(
     ctxt: &SiteCtxt,
     commit: QueuedCommit,
@@ -225,31 +231,31 @@ async fn summarize_run(
         (
             "Instruction count",
             Metric::InstructionsUser,
-            true, // highly reliable
+            MetricReliability::High,
             inst_comparison,
         ),
         (
             "Max RSS (memory usage)",
             Metric::MaxRSS,
-            false, // not highly reliable
+            MetricReliability::Low,
             calculate_metric_comparison(ctxt, &commit, Metric::MaxRSS).await?,
         ),
         (
             "Cycles",
             Metric::CyclesUser,
-            false, // not highly reliable
+            MetricReliability::Low,
             calculate_metric_comparison(ctxt, &commit, Metric::CyclesUser).await?,
         ),
     ];
 
-    for (title, metric, highly_reliable, comparison) in metrics {
+    for (title, metric, reliability, comparison) in metrics {
         message.push_str(&format!(
             "\n### [{title}]({})\n",
             make_comparison_url(&commit, metric)
         ));
 
         let (primary, secondary) = comparison.summarize_by_category(&benchmark_map);
-        write_metric_summary(primary, secondary, highly_reliable, &mut message);
+        write_metric_summary(primary, secondary, reliability, &mut message);
     }
 
     Ok(message)
@@ -258,28 +264,31 @@ async fn summarize_run(
 fn write_metric_summary(
     primary: ArtifactComparisonSummary,
     secondary: ArtifactComparisonSummary,
-    highly_reliable: bool,
+    realibility: MetricReliability,
     message: &mut String,
 ) {
     if !primary.is_relevant() && !secondary.is_relevant() {
         message
             .push_str("This benchmark run did not return any relevant results for this metric.\n");
     } else {
-        if highly_reliable {
-            message.push_str(
-                "This is a highly reliable metric that was used to determine the \
+        match realibility {
+            MetricReliability::High => {
+                message.push_str(
+                    "This is a highly reliable metric that was used to determine the \
                 overall result at the top of this comment.\n\n",
-            );
-            write_summary_table(&primary, &secondary, false, message);
-        } else {
-            // `<details>` means it is hidden, requiring a click to reveal.
-            message.push_str("<details>\n<summary>Results</summary>\n\n");
-            message.push_str(
-                "This is a less reliable metric that may be of interest but was not \
+                );
+                write_summary_table(&primary, &secondary, false, message);
+            }
+            MetricReliability::Low => {
+                // `<details>` means it is hidden, requiring a click to reveal.
+                message.push_str("<details>\n<summary>Results</summary>\n\n");
+                message.push_str(
+                    "This is a less reliable metric that may be of interest but was not \
                 used to determine the overall result at the top of this comment.\n\n",
-            );
-            write_summary_table(&primary, &secondary, false, message);
-            message.push_str("</details>\n");
+                );
+                write_summary_table(&primary, &secondary, false, message);
+                message.push_str("</details>\n");
+            }
         }
     }
 }


### PR DESCRIPTION
It's that time of the year again, when someone (this time me) tries to modify the PR comment structure :) I think that bootstrap changes and binary size changes are sometimes overlooked, as they are not immediately visible, so it could be useful to add them to the comment.

![image](https://user-images.githubusercontent.com/4539057/235321548-27b9bee6-83ea-41f4-969d-6fcee45d3ab7.png)

The size of the comment grows of course. I suspect that the text at the beginning of the comment is rarely read by anyone. I wouldn't mind putting it behind a "What to do" button at the end of the comment.