### PR TITLE
Export Docker image in CI to make it available for deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
+          # Export the image to Docker to make it available in the next step
+          load: true
           tags: rustc-perf
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
The recent change switched to DockerKit for building the Docker image in CI, which does not export the built image to the local Docker service, therefore it wasn't found when the next CI job was trying to deploy the built image.