### PR TITLE
Add code formatter for frontend

### DIFF
--- a/site/.prettierrc.json
+++ b/site/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "bracketSpacing": false,
+  "tabWidth": 2
+}

--- a/site/frontend/package-lock.json
+++ b/site/frontend/package-lock.json
@@ -22,6 +22,7 @@
         "@parcel/transformer-vue": "^2.8.3",
         "@types/highcharts": "^7.0.0",
         "@types/msgpack-lite": "^0.1.8",
+        "prettier": "2.8.8",
         "typescript": "^5.0.2"
       }
     },
@@ -3146,6 +3147,21 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/react-error-overlay": {

--- a/site/frontend/package.json
+++ b/site/frontend/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "watch": "parcel watch",
     "build": "parcel build",
-    "check": "tsc -p tsconfig.json --noEmit"
+    "fmt": "prettier --write src",
+    "check": "tsc -p tsconfig.json --noEmit && prettier --check src"
   },
   "author": "",
   "license": "MIT",
@@ -14,6 +15,7 @@
     "@parcel/transformer-vue": "^2.8.3",
     "@types/highcharts": "^7.0.0",
     "@types/msgpack-lite": "^0.1.8",
+    "prettier": "2.8.8",
     "typescript": "^5.0.2"
   },
   "dependencies": {

--- a/site/frontend/src/components/as-of.vue
+++ b/site/frontend/src/components/as-of.vue
@@ -2,7 +2,7 @@
 import {BenchmarkInfo} from "../api";
 
 const props = defineProps<{
-  info: BenchmarkInfo
+  info: BenchmarkInfo;
 }>();
 </script>
 <template>

--- a/site/frontend/src/components/with-suspense.vue
+++ b/site/frontend/src/components/with-suspense.vue
@@ -2,7 +2,7 @@
 import {Suspense} from "vue";
 
 const props = defineProps<{
-  component: Object
+  component: Object;
 }>();
 const component = props.component as any;
 </script>

--- a/site/frontend/src/pages/bootstrap/data-selector.vue
+++ b/site/frontend/src/pages/bootstrap/data-selector.vue
@@ -2,36 +2,40 @@
 import {onMounted, ref} from "vue";
 
 export interface SelectionParams {
-    start: string;
-    end: string;
+  start: string;
+  end: string;
 }
 
 const props = defineProps<SelectionParams>();
 
 const emit = defineEmits<{
-    (e: "change", params: SelectionParams): void
+  (e: "change", params: SelectionParams): void;
 }>();
 
 const startRef = ref<HTMLInputElement | null>(null);
 const endRef = ref<HTMLInputElement | null>(null);
 
 onMounted(() => {
-    startRef.value.value = props.start;
-    endRef.value.value = props.end;
-})
+  startRef.value.value = props.start;
+  endRef.value.value = props.end;
+});
 
 function submitSettings() {
-    const start = startRef.value.value;
-    const end = endRef.value.value;
+  const start = startRef.value.value;
+  const end = endRef.value.value;
 
-    const params = { start, end };
-    emit("change", params);
+  const params = {start, end};
+  emit("change", params);
 }
 </script>
 
 <template>
   <div id="settings">
-    start: <input placeholder="yyyy-mm-dd or commit" ref="startRef" />
-    end: <input placeholder="yyyy-mm-dd or commit" ref="endRef" />&nbsp;<a href="#" @click.prevent="submitSettings">Submit</a>
+    start: <input placeholder="yyyy-mm-dd or commit" ref="startRef" /> end:
+    <input placeholder="yyyy-mm-dd or commit" ref="endRef" />&nbsp;<a
+      href="#"
+      @click.prevent="submitSettings"
+      >Submit</a
+    >
   </div>
 </template>

--- a/site/frontend/src/pages/bootstrap/page.vue
+++ b/site/frontend/src/pages/bootstrap/page.vue
@@ -5,12 +5,21 @@ import {withLoading} from "../../utils/loading";
 import {renderPlots} from "./plots";
 import {BootstrapData, BootstrapSelector} from "./state";
 import {BOOTSTRAP_DATA_URL} from "../../urls";
-import {createUrlWithAppendedParams, getUrlParams, navigateToUrlParams} from "../../utils/navigation";
+import {
+  createUrlWithAppendedParams,
+  getUrlParams,
+  navigateToUrlParams,
+} from "../../utils/navigation";
 
 import {postJson} from "../../utils/requests";
 
-async function loadBootstrapData(selector: BootstrapSelector, loading: Ref<boolean>) {
-  const bootstrapData: BootstrapData = await withLoading(loading, () => postJson<BootstrapData>(BOOTSTRAP_DATA_URL, selector));
+async function loadBootstrapData(
+  selector: BootstrapSelector,
+  loading: Ref<boolean>
+) {
+  const bootstrapData: BootstrapData = await withLoading(loading, () =>
+    postJson<BootstrapData>(BOOTSTRAP_DATA_URL, selector)
+  );
 
   // Wait for the UI to be updated, which also resets the plot HTML elements.
   // Then draw the plots.
@@ -24,15 +33,17 @@ function loadSelectorFromUrl(urlParams: Dict<string>): BootstrapSelector {
   return {
     start,
     end,
-    min_seconds: 25
+    min_seconds: 25,
   };
 }
 
 function updateSelection(params: SelectionParams) {
-  navigateToUrlParams(createUrlWithAppendedParams({
-    start: params.start,
-    end: params.end
-  }).searchParams);
+  navigateToUrlParams(
+    createUrlWithAppendedParams({
+      start: params.start,
+      end: params.end,
+    }).searchParams
+  );
 }
 
 const loading = ref(true);
@@ -42,16 +53,19 @@ loadBootstrapData(selector, loading);
 </script>
 
 <template>
-  <DataSelector :start="selector.start" :end="selector.end"
-                @change="updateSelection"></DataSelector>
+  <DataSelector
+    :start="selector.start"
+    :end="selector.end"
+    @change="updateSelection"
+  ></DataSelector>
   <div v-if="loading" id="loading">
     <h2>Loading &amp; rendering data..</h2>
     <h3>This may take a while!</h3>
   </div>
   <div v-else>
     <div>
-      See <a href="/compare.html">compare page</a> for descriptions of what
-      the names mean.
+      See <a href="/compare.html">compare page</a> for descriptions of what the
+      names mean.
     </div>
     <div id="byCrateChart"></div>
     <div id="totalChart"></div>

--- a/site/frontend/src/pages/bootstrap/plots.ts
+++ b/site/frontend/src/pages/bootstrap/plots.ts
@@ -2,191 +2,218 @@ import uPlot, {TypedArray} from "uplot";
 import {BootstrapData, BootstrapSelector} from "./state";
 
 function tooltipPlugin({onclick, commits, shiftX = 10, shiftY = 10}) {
-    let tooltipLeftOffset = 0;
-    let tooltipTopOffset = 0;
+  let tooltipLeftOffset = 0;
+  let tooltipTopOffset = 0;
 
-    const tooltip = document.createElement("div");
-    tooltip.className = "u-tooltip";
+  const tooltip = document.createElement("div");
+  tooltip.className = "u-tooltip";
 
-    let seriesIdx = null;
-    let dataIdx = null;
+  let seriesIdx = null;
+  let dataIdx = null;
 
-    const formatDate = uPlot.fmtDate("{M}/{D}/{YY} {h}:{mm}:{ss} {AA}");
+  const formatDate = uPlot.fmtDate("{M}/{D}/{YY} {h}:{mm}:{ss} {AA}");
 
-    let over;
+  let over;
 
-    let tooltipVisible = false;
+  let tooltipVisible = false;
 
-    function showTooltip() {
-        if (!tooltipVisible) {
-            tooltip.style.display = "block";
-            over.style.cursor = "pointer";
-            tooltipVisible = true;
-        }
+  function showTooltip() {
+    if (!tooltipVisible) {
+      tooltip.style.display = "block";
+      over.style.cursor = "pointer";
+      tooltipVisible = true;
     }
+  }
 
-    function hideTooltip() {
-        if (tooltipVisible) {
-            tooltip.style.display = "none";
-            over.style.cursor = null;
-            tooltipVisible = false;
-        }
+  function hideTooltip() {
+    if (tooltipVisible) {
+      tooltip.style.display = "none";
+      over.style.cursor = null;
+      tooltipVisible = false;
     }
+  }
 
-    function setTooltip(u) {
-        showTooltip();
+  function setTooltip(u) {
+    showTooltip();
 
-        let top = u.valToPos(u.data[seriesIdx][dataIdx], 'y');
-        let lft = u.valToPos(u.data[0][dataIdx], 'x');
+    let top = u.valToPos(u.data[seriesIdx][dataIdx], "y");
+    let lft = u.valToPos(u.data[0][dataIdx], "x");
 
-        tooltip.style.top = (tooltipTopOffset + top + shiftX) + "px";
-        tooltip.style.left = (tooltipLeftOffset + lft + shiftY) + "px";
+    tooltip.style.top = tooltipTopOffset + top + shiftX + "px";
+    tooltip.style.left = tooltipLeftOffset + lft + shiftY + "px";
 
-        tooltip.textContent = (
-            formatDate(new Date(u.data[0][dataIdx] * 1e3)) + " - " +
-            commits[dataIdx][1].slice(0, 10) + "\n" +
-            u.series[seriesIdx].label + ": " +
-            u.data[seriesIdx][dataIdx] / 1e9 + " seconds"
-        );
-    }
+    tooltip.textContent =
+      formatDate(new Date(u.data[0][dataIdx] * 1e3)) +
+      " - " +
+      commits[dataIdx][1].slice(0, 10) +
+      "\n" +
+      u.series[seriesIdx].label +
+      ": " +
+      u.data[seriesIdx][dataIdx] / 1e9 +
+      " seconds";
+  }
 
-    return {
-        hooks: {
-            ready: [
-                u => {
-                    over = u.root.querySelector(".u-over");
+  return {
+    hooks: {
+      ready: [
+        (u) => {
+          over = u.root.querySelector(".u-over");
 
-                    tooltipLeftOffset = parseFloat(over.style.left);
-                    tooltipTopOffset = parseFloat(over.style.top);
-                    u.root.querySelector(".u-wrap").appendChild(tooltip);
+          tooltipLeftOffset = parseFloat(over.style.left);
+          tooltipTopOffset = parseFloat(over.style.top);
+          u.root.querySelector(".u-wrap").appendChild(tooltip);
 
-                    let clientX;
-                    let clientY;
+          let clientX;
+          let clientY;
 
-                    over.addEventListener("mousedown", e => {
-                        clientX = e.clientX;
-                        clientY = e.clientY;
-                    });
+          over.addEventListener("mousedown", (e) => {
+            clientX = e.clientX;
+            clientY = e.clientY;
+          });
 
-                    over.addEventListener("mouseup", e => {
-                        // clicked in-place
-                        if (e.clientX == clientX && e.clientY == clientY) {
-                            if (seriesIdx != null && dataIdx != null) {
-                                onclick(u, seriesIdx, dataIdx);
-                            }
-                        }
-                    });
-                }
-            ],
-            setCursor: [
-                u => {
-                    let c = u.cursor;
+          over.addEventListener("mouseup", (e) => {
+            // clicked in-place
+            if (e.clientX == clientX && e.clientY == clientY) {
+              if (seriesIdx != null && dataIdx != null) {
+                onclick(u, seriesIdx, dataIdx);
+              }
+            }
+          });
+        },
+      ],
+      setCursor: [
+        (u) => {
+          let c = u.cursor;
 
-                    if (dataIdx != c.idx) {
-                        dataIdx = c.idx;
+          if (dataIdx != c.idx) {
+            dataIdx = c.idx;
 
-                        if (seriesIdx != null)
-                            setTooltip(u);
-                    }
-                }
-            ],
-            setSeries: [
-                (u, sidx) => {
-                    if (seriesIdx != sidx) {
-                        seriesIdx = sidx;
+            if (seriesIdx != null) setTooltip(u);
+          }
+        },
+      ],
+      setSeries: [
+        (u, sidx) => {
+          if (seriesIdx != sidx) {
+            seriesIdx = sidx;
 
-                        if (sidx == null)
-                            hideTooltip();
-                        else if (dataIdx != null)
-                            setTooltip(u);
-                    }
-                }
-            ],
-        }
-    };
+            if (sidx == null) hideTooltip();
+            else if (dataIdx != null) setTooltip(u);
+          }
+        },
+      ],
+    },
+  };
 }
 
-function genPlotOpts({title, height, yAxisLabel, series, commits, alpha = 0.3, prox = 5}) {
-    return {
-        title,
-        width: window.innerWidth * 0.9,
-        height,
-        series,
-        legend: {
-            live: false,
+function genPlotOpts({
+  title,
+  height,
+  yAxisLabel,
+  series,
+  commits,
+  alpha = 0.3,
+  prox = 5,
+}) {
+  return {
+    title,
+    width: window.innerWidth * 0.9,
+    height,
+    series,
+    legend: {
+      live: false,
+    },
+    focus: {
+      alpha,
+    },
+    cursor: {
+      focus: {
+        prox,
+      },
+      drag: {
+        x: true,
+        y: true,
+      },
+    },
+    axes: [
+      {},
+      {
+        label: yAxisLabel,
+        space: 24,
+        values: (self, splits) => {
+          return splits.map((v) => v / 1e9 + " sec");
         },
-        focus: {
-            alpha,
+      },
+    ],
+    plugins: [
+      tooltipPlugin({
+        onclick(u, seriesIdx, dataIdx) {
+          let thisCommit = commits[dataIdx][1];
+          let prevCommit = (commits[dataIdx - 1] || [null, null])[1];
+          window.open(`/compare.html?start=${prevCommit}&end=${thisCommit}`);
         },
-        cursor: {
-            focus: {
-                prox,
-            },
-            drag: {
-                x: true,
-                y: true,
-            },
-        },
-        axes: [
-            {},
-            {
-                label: yAxisLabel,
-                space: 24,
-                values: (self, splits) => {
-                    return splits.map(v => v / 1e9 + " sec");
-                },
-            },
-        ],
-        plugins: [
-            tooltipPlugin({
-                onclick(u, seriesIdx, dataIdx) {
-                    let thisCommit = commits[dataIdx][1];
-                    let prevCommit = (commits[dataIdx - 1] || [null, null])[1];
-                    window.open(`/compare.html?start=${prevCommit}&end=${thisCommit}`);
-                },
-                commits,
-            }),
-        ],
-    };
+        commits,
+      }),
+    ],
+  };
 }
 
 export function renderPlots(data: BootstrapData, selector: BootstrapSelector) {
-    let byChartSeriesOpts = [{}];
-    let xVals = data.commits.map(c => c[0]);
-    let byChartPlotData = [xVals];
-    // https://sashamaps.net/docs/resources/20-colors/
-    let colors = [
-        '#e6194b', '#3cb44b', '#ffe119', '#4363d8', '#f58231',
-        '#911eb4', '#46f0f0', '#f032e6', '#a09b13', '#0ab0be',
-        'red', 'green', 'blue', 'purple'
-    ];
-    let crates = Object.keys(data.by_crate_build_times).sort();
-    for (let crate of crates) {
-        byChartPlotData.push(data.by_crate_build_times[crate]);
-        byChartSeriesOpts.push({
-            label: crate,
-            stroke: colors.length ? colors.pop() : 'black',
-        });
-    }
-
-    let byChartPlotOpts = genPlotOpts({
-        title: `Bootstrap time for crates >= ${selector.min_seconds} seconds`,
-        height: window.innerHeight * 0.56,
-        yAxisLabel: "",
-        series: byChartSeriesOpts,
-        commits: data.commits,
+  let byChartSeriesOpts = [{}];
+  let xVals = data.commits.map((c) => c[0]);
+  let byChartPlotData = [xVals];
+  // https://sashamaps.net/docs/resources/20-colors/
+  let colors = [
+    "#e6194b",
+    "#3cb44b",
+    "#ffe119",
+    "#4363d8",
+    "#f58231",
+    "#911eb4",
+    "#46f0f0",
+    "#f032e6",
+    "#a09b13",
+    "#0ab0be",
+    "red",
+    "green",
+    "blue",
+    "purple",
+  ];
+  let crates = Object.keys(data.by_crate_build_times).sort();
+  for (let crate of crates) {
+    byChartPlotData.push(data.by_crate_build_times[crate]);
+    byChartSeriesOpts.push({
+      label: crate,
+      stroke: colors.length ? colors.pop() : "black",
     });
+  }
 
-    new uPlot(byChartPlotOpts, byChartPlotData as any as TypedArray[], document.querySelector<HTMLElement>("#byCrateChart"));
+  let byChartPlotOpts = genPlotOpts({
+    title: `Bootstrap time for crates >= ${selector.min_seconds} seconds`,
+    height: window.innerHeight * 0.56,
+    yAxisLabel: "",
+    series: byChartSeriesOpts,
+    commits: data.commits,
+  });
 
-    let totalPlotData = [xVals, data.total_build_times];
-    let totalPlotOpts = genPlotOpts({
-        title: "Total bootstrap time",
-        height: window.innerHeight * 0.26,
-        yAxisLabel: "",
-        series: [{}, {label: "rustc", stroke: '#7cb5ec'}],
-        commits: data.commits,
-    });
+  new uPlot(
+    byChartPlotOpts,
+    byChartPlotData as any as TypedArray[],
+    document.querySelector<HTMLElement>("#byCrateChart")
+  );
 
-    new uPlot(totalPlotOpts, totalPlotData as any as TypedArray[], document.querySelector<HTMLElement>("#totalChart"));
+  let totalPlotData = [xVals, data.total_build_times];
+  let totalPlotOpts = genPlotOpts({
+    title: "Total bootstrap time",
+    height: window.innerHeight * 0.26,
+    yAxisLabel: "",
+    series: [{}, {label: "rustc", stroke: "#7cb5ec"}],
+    commits: data.commits,
+  });
+
+  new uPlot(
+    totalPlotOpts,
+    totalPlotData as any as TypedArray[],
+    document.querySelector<HTMLElement>("#totalChart")
+  );
 }

--- a/site/frontend/src/pages/bootstrap/state.ts
+++ b/site/frontend/src/pages/bootstrap/state.ts
@@ -1,13 +1,13 @@
 // Parameters used to filter bootstrap data
 export interface BootstrapSelector {
-    start: string;
-    end: string;
-    min_seconds: number;
+  start: string;
+  end: string;
+  min_seconds: number;
 }
 
 // Bootstrap data received from the server
 export interface BootstrapData {
-    commits: [[number, string]],
-    by_crate_build_times: Dict<[number]>,
-    total_build_times: [number]
+  commits: [[number, string]];
+  by_crate_build_times: Dict<[number]>;
+  total_build_times: [number];
 }

--- a/site/frontend/src/pages/compare.ts
+++ b/site/frontend/src/pages/compare.ts
@@ -3,6 +3,6 @@ import {createApp} from "vue";
 import WithSuspense from "../components/with-suspense.vue";
 
 const app = createApp(WithSuspense, {
-  component: Compare
+  component: Compare,
 });
 app.mount("#app");

--- a/site/frontend/src/pages/compare/benchmarks/benchmarks.vue
+++ b/site/frontend/src/pages/compare/benchmarks/benchmarks.vue
@@ -14,21 +14,38 @@ export interface BenchmarkProps {
 
 const props = defineProps<BenchmarkProps>();
 
-function Section({title, link, linkUp}: {title: string, link: string, linkUp: boolean}) {
+function Section({
+  title,
+  link,
+  linkUp,
+}: {
+  title: string;
+  link: string;
+  linkUp: boolean;
+}) {
   return (
     <div class="category-title">
       {title} benchmarks
-      <span title={`To ${link} benchmarks`}>&nbsp;
+      <span title={`To ${link} benchmarks`}>
+        &nbsp;
         <a href={`#${link}-benchmarks`}>{linkUp ? "⮭" : "⮯"}</a>
       </span>
     </div>
   );
 }
 
-const primaryCases = computed(() => props.testCases.filter(c => c.category === "primary"));
-const secondaryCases = computed(() => props.testCases.filter(c => c.category === "secondary"));
-const primaryHasNonRelevant = computed(() => props.allTestCases.filter(c => c.category === "primary").length > 0);
-const secondaryHasNonRelevant = computed(() => props.allTestCases.filter(c => c.category === "secondary").length > 0);
+const primaryCases = computed(() =>
+  props.testCases.filter((c) => c.category === "primary")
+);
+const secondaryCases = computed(() =>
+  props.testCases.filter((c) => c.category === "secondary")
+);
+const primaryHasNonRelevant = computed(
+  () => props.allTestCases.filter((c) => c.category === "primary").length > 0
+);
+const secondaryHasNonRelevant = computed(
+  () => props.allTestCases.filter((c) => c.category === "secondary").length > 0
+);
 </script>
 
 <template>
@@ -41,26 +58,28 @@ const secondaryHasNonRelevant = computed(() => props.allTestCases.filter(c => c.
       </details>
       <hr />
     </div>
-    <TestCasesTable id="primary-benchmarks"
-                    :cases="primaryCases"
-                    :has-non-relevant="primaryHasNonRelevant"
-                    :show-raw-data="filter.showRawData"
-                    :commit-a="data.a"
-                    :commit-b="data.b"
-                    :stat="stat"
+    <TestCasesTable
+      id="primary-benchmarks"
+      :cases="primaryCases"
+      :has-non-relevant="primaryHasNonRelevant"
+      :show-raw-data="filter.showRawData"
+      :commit-a="data.a"
+      :commit-b="data.b"
+      :stat="stat"
     >
       <template #header>
         <Section title="Primary" link="secondary" :linkUp="false"></Section>
       </template>
     </TestCasesTable>
     <hr />
-    <TestCasesTable id="secondary-benchmarks"
-                    :cases="secondaryCases"
-                    :has-non-relevant="secondaryHasNonRelevant"
-                    :show-raw-data="filter.showRawData"
-                    :commit-a="data.a"
-                    :commit-b="data.b"
-                    :stat="stat"
+    <TestCasesTable
+      id="secondary-benchmarks"
+      :cases="secondaryCases"
+      :has-non-relevant="secondaryHasNonRelevant"
+      :show-raw-data="filter.showRawData"
+      :commit-a="data.a"
+      :commit-b="data.b"
+      :stat="stat"
     >
       <template #header>
         <Section title="Secondary" link="primary" :linkUp="true"></Section>

--- a/site/frontend/src/pages/compare/benchmarks/test-cases-table.vue
+++ b/site/frontend/src/pages/compare/benchmarks/test-cases-table.vue
@@ -18,7 +18,11 @@ function benchmarkLink(benchmark: string): string {
   return `https://github.com/rust-lang/rustc-perf/tree/master/collector/compile-benchmarks/${benchmark}`;
 }
 
-function graphLink(commit: ArtifactDescription, stat: string, testCase: TestCase): string {
+function graphLink(
+  commit: ArtifactDescription,
+  stat: string,
+  testCase: TestCase
+): string {
   let date = new Date(commit.date);
   // Move to `30 days ago` to display history of the test case
   date.setUTCDate(date.getUTCDate() - 30);
@@ -31,11 +35,18 @@ function graphLink(commit: ArtifactDescription, stat: string, testCase: TestCase
   return `/index.html?start=${start}&end=${end}&benchmark=${testCase.benchmark}&profile=${testCase.profile}&scenario=${testCase.scenario}&stat=${stat}`;
 }
 
-function detailedQueryPercentLink(commit: ArtifactDescription, baseCommit: ArtifactDescription, testCase: TestCase): string {
+function detailedQueryPercentLink(
+  commit: ArtifactDescription,
+  baseCommit: ArtifactDescription,
+  testCase: TestCase
+): string {
   return `/detailed-query.html?commit=${commit.commit}&base_commit=${baseCommit.commit}&benchmark=${testCase.benchmark}-${testCase.profile}&scenario=${testCase.scenario}`;
 }
 
-function detailedQueryRawDataLink(commit: ArtifactDescription, testCase: TestCase) {
+function detailedQueryRawDataLink(
+  commit: ArtifactDescription,
+  testCase: TestCase
+) {
   return `/detailed-query.html?commit=${commit.commit}&benchmark=${testCase.benchmark}-${testCase.profile}&scenario=${testCase.scenario}`;
 }
 
@@ -47,79 +58,105 @@ function prettifyRawNumber(number: number): string {
 <template>
   <div class="bench-table" :id="id">
     <slot name="header"></slot>
-    <div v-if="cases.length === 0" style="text-align: center;">
+    <div v-if="cases.length === 0" style="text-align: center">
       {{ hasNonRelevant ? "No relevant results" : "No results" }}
     </div>
     <table v-else class="benches compare">
       <thead>
-      <tr>
-        <th>Benchmark</th>
-        <th>Profile</th>
-        <th>Scenario</th>
-        <th>% Change</th>
-        <th>
-          Significance Threshold
-          <Tooltip>
-            The minimum % change that is considered significant. The higher the significance
-            threshold, the noisier a test case is.
-            You can see <a
-            href="https://github.com/rust-lang/rustc-perf/blob/master/docs/comparison-analysis.md#what-makes-a-test-result-significant">
-            here</a> how the significance threshold is calculated.
-          </Tooltip>
-        </th>
-        <th>
-          Significance Factor
-          <Tooltip>
-            How much a particular result is over the significance threshold. A factor of 2.50x
-            means the result is 2.5 times over the significance threshold.
-          </Tooltip>
-        </th>
-        <th v-if="showRawData">Before</th>
-        <th v-if="showRawData">After</th>
-      </tr>
+        <tr>
+          <th>Benchmark</th>
+          <th>Profile</th>
+          <th>Scenario</th>
+          <th>% Change</th>
+          <th>
+            Significance Threshold
+            <Tooltip>
+              The minimum % change that is considered significant. The higher
+              the significance threshold, the noisier a test case is. You can
+              see
+              <a
+                href="https://github.com/rust-lang/rustc-perf/blob/master/docs/comparison-analysis.md#what-makes-a-test-result-significant"
+              >
+                here</a
+              >
+              how the significance threshold is calculated.
+            </Tooltip>
+          </th>
+          <th>
+            Significance Factor
+            <Tooltip>
+              How much a particular result is over the significance threshold. A
+              factor of 2.50x means the result is 2.5 times over the
+              significance threshold.
+            </Tooltip>
+          </th>
+          <th v-if="showRawData">Before</th>
+          <th v-if="showRawData">After</th>
+        </tr>
       </thead>
       <tbody>
-      <template v-for="testCase in cases">
-        <tr>
-          <td>
-            <a v-bind:href="benchmarkLink(testCase.benchmark)"
-               class="silent-link"
-               target="_blank">
-              {{ testCase.benchmark }}
-            </a>
-          </td>
-          <td>
-            <a v-bind:href="graphLink(commitB, stat, testCase)" target="_blank" class="silent-link">
-              {{ testCase.profile }}
-            </a>
-          </td>
-          <td>{{ testCase.scenario }}</td>
-          <td>
-            <a v-bind:href="detailedQueryPercentLink(commitB, commitA, testCase)">
-              <span v-bind:class="percentClass(testCase.percent)">
+        <template v-for="testCase in cases">
+          <tr>
+            <td>
+              <a
+                v-bind:href="benchmarkLink(testCase.benchmark)"
+                class="silent-link"
+                target="_blank"
+              >
+                {{ testCase.benchmark }}
+              </a>
+            </td>
+            <td>
+              <a
+                v-bind:href="graphLink(commitB, stat, testCase)"
+                target="_blank"
+                class="silent-link"
+              >
+                {{ testCase.profile }}
+              </a>
+            </td>
+            <td>{{ testCase.scenario }}</td>
+            <td>
+              <a
+                v-bind:href="
+                  detailedQueryPercentLink(commitB, commitA, testCase)
+                "
+              >
+                <span v-bind:class="percentClass(testCase.percent)">
                   {{ testCase.percent.toFixed(2) }}%
-              </span>
-            </a>
-          </td>
-          <td>
-            {{ testCase.significanceThreshold ? testCase.significanceThreshold.toFixed(2) + "%" : "-"
-            }}
-          </td>
-          <td>
-            {{ testCase.significanceFactor ? testCase.significanceFactor.toFixed(2) + "x" : "-" }}
-          </td>
-          <td v-if="showRawData" class="numeric">
-            <a v-bind:href="detailedQueryRawDataLink(commitA, testCase)">
-              <abbr :title="testCase.datumA">{{ prettifyRawNumber(testCase.datumA) }}</abbr>
-            </a>
-          </td>
-          <td v-if="showRawData" class="numeric">
-            <a v-bind:href="detailedQueryRawDataLink(commitB, testCase)">
-              <abbr :title="testCase.datumB">{{ prettifyRawNumber(testCase.datumB) }}</abbr>
-            </a>
-          </td>
-        </tr>
-      </template>
+                </span>
+              </a>
+            </td>
+            <td>
+              {{
+                testCase.significanceThreshold
+                  ? testCase.significanceThreshold.toFixed(2) + "%"
+                  : "-"
+              }}
+            </td>
+            <td>
+              {{
+                testCase.significanceFactor
+                  ? testCase.significanceFactor.toFixed(2) + "x"
+                  : "-"
+              }}
+            </td>
+            <td v-if="showRawData" class="numeric">
+              <a v-bind:href="detailedQueryRawDataLink(commitA, testCase)">
+                <abbr :title="testCase.datumA">{{
+                  prettifyRawNumber(testCase.datumA)
+                }}</abbr>
+              </a>
+            </td>
+            <td v-if="showRawData" class="numeric">
+              <a v-bind:href="detailedQueryRawDataLink(commitB, testCase)">
+                <abbr :title="testCase.datumB">{{
+                  prettifyRawNumber(testCase.datumB)
+                }}</abbr>
+              </a>
+            </td>
+          </tr>
+        </template>
       </tbody>
     </table>
   </div>
@@ -127,48 +164,49 @@ function prettifyRawNumber(number: number): string {
 
 <style scoped lang="scss">
 .benches {
-    font-size: medium;
-    table-layout: fixed;
+  font-size: medium;
+  table-layout: fixed;
 
-    td, th {
-        padding: 0.3em;
-    }
+  td,
+  th {
+    padding: 0.3em;
+  }
 }
 
 .benches tbody::before {
-    content: '';
-    display: block;
-    height: 10px;
+  content: "";
+  display: block;
+  height: 10px;
 }
 
 .benches tbody:first-child th {
-    text-align: center;
+  text-align: center;
 }
 
 .benches tbody:not(:first-child) th {
-    border-right: dotted 1px;
+  border-right: dotted 1px;
 }
 
 .benches th {
-    text-align: center;
-    width: 25%;
-    min-width: 50px;
+  text-align: center;
+  width: 25%;
+  min-width: 50px;
 }
 
 .benches td {
-    text-align: center;
-    width: 25%;
+  text-align: center;
+  width: 25%;
 }
 
 .benches td.numeric {
-    text-align: right;
+  text-align: right;
 }
 
 .bench-table {
-    margin-top: 10px;
+  margin-top: 10px;
 }
 
 .silent-link {
-    color: inherit;
+  color: inherit;
 }
 </style>

--- a/site/frontend/src/pages/compare/bootstrap-table.vue
+++ b/site/frontend/src/pages/compare/bootstrap-table.vue
@@ -7,38 +7,43 @@ const props = defineProps<{data: CompareResponse}>();
 const totalsA = props.data.a.bootstrap_total / 1e9;
 const totalsB = props.data.b.bootstrap_total / 1e9;
 
-const bootstraps = Object.entries(props.data.a.bootstrap).map(e => {
-  const name = e[0];
+const bootstraps = Object.entries(props.data.a.bootstrap)
+  .map((e) => {
+    const name = e[0];
 
-  const format = datum => datum ? datum.toLocaleString("en-US", {
-    minimumFractionDigits: 3,
-    maximumFractionDigits: 3
-  }) : "";
-  const a = e[1] / 1e9;
-  const b = props.data.b.bootstrap[name] / 1e9;
-  return {
-    name,
-    a: format(a),
-    b: format(b),
-    percent: 100 * (b - a) / a
-  };
-}).sort((a, b) => {
-  let bp = Math.abs(b.percent);
-  if (Number.isNaN(bp)) {
-    bp = 0;
-  }
-  let ap = Math.abs(a.percent);
-  if (Number.isNaN(ap)) {
-    ap = 0;
-  }
-  if (bp < ap) {
-    return -1;
-  } else if (bp > ap) {
-    return 1;
-  } else {
-    return a.name.localeCompare(b.name);
-  }
-});
+    const format = (datum) =>
+      datum
+        ? datum.toLocaleString("en-US", {
+            minimumFractionDigits: 3,
+            maximumFractionDigits: 3,
+          })
+        : "";
+    const a = e[1] / 1e9;
+    const b = props.data.b.bootstrap[name] / 1e9;
+    return {
+      name,
+      a: format(a),
+      b: format(b),
+      percent: (100 * (b - a)) / a,
+    };
+  })
+  .sort((a, b) => {
+    let bp = Math.abs(b.percent);
+    if (Number.isNaN(bp)) {
+      bp = 0;
+    }
+    let ap = Math.abs(a.percent);
+    if (Number.isNaN(ap)) {
+      ap = 0;
+    }
+    if (bp < ap) {
+      return -1;
+    } else if (bp > ap) {
+      return 1;
+    } else {
+      return a.name.localeCompare(b.name);
+    }
+  });
 
 function diffClass(diff: number): string {
   let klass = "";
@@ -53,10 +58,15 @@ function diffClass(diff: number): string {
 
 <template>
   <div class="category-title">Bootstrap timings</div>
-  <table class="bootstrap" style="margin: auto;"
-         v-if="Object.keys(props.data.a.bootstrap).length > 0">
+  <table
+    class="bootstrap"
+    style="margin: auto"
+    v-if="Object.keys(props.data.a.bootstrap).length > 0"
+  >
     <tr>
-      <td colspan="4">Values in seconds. Variance is 1-3% on smaller crates!</td>
+      <td colspan="4">
+        Values in seconds. Variance is 1-3% on smaller crates!
+      </td>
     </tr>
     <tr>
       <th>total</th>
@@ -65,19 +75,21 @@ function diffClass(diff: number): string {
       <th v-if="totalsA && totalsB">
         Total: {{ (totalsB - totalsA).toFixed(1) }}
         <div v-bind:class="diffClass(totalsB - totalsA)">
-          ({{ ((totalsB - totalsA) / totalsA * 100).toFixed(3) }}%)
+          ({{ (((totalsB - totalsA) / totalsA) * 100).toFixed(3) }}%)
         </div>
       </th>
     </tr>
     <template v-for="bootstrap in bootstraps">
       <tr>
-        <th style="text-align: right; width: 19em;">{{ bootstrap.name }}</th>
+        <th style="text-align: right; width: 19em">{{ bootstrap.name }}</th>
         <td v-if="bootstrap.a">{{ bootstrap.a }}</td>
         <td v-if="bootstrap.b">{{ bootstrap.b }}</td>
         <td>
-          <span v-if="bootstrap.percent"
-                v-bind:class="percentClass(bootstrap.percent)">{{ bootstrap.percent.toFixed(1)
-            }}%</span>
+          <span
+            v-if="bootstrap.percent"
+            v-bind:class="percentClass(bootstrap.percent)"
+            >{{ bootstrap.percent.toFixed(1) }}%</span
+          >
         </td>
       </tr>
     </template>
@@ -88,7 +100,8 @@ function diffClass(diff: number): string {
 .bootstrap {
   table-layout: fixed;
 
-  td, th {
+  td,
+  th {
     text-align: center;
     padding: 0.3em;
   }

--- a/site/frontend/src/pages/compare/data.ts
+++ b/site/frontend/src/pages/compare/data.ts
@@ -1,4 +1,11 @@
-import {BenchmarkMap, Category, CompareResponse, Comparison, DataFilter, Profile} from "./types";
+import {
+  BenchmarkMap,
+  Category,
+  CompareResponse,
+  Comparison,
+  DataFilter,
+  Profile,
+} from "./types";
 
 export interface Summary {
   count: number;
@@ -79,26 +86,25 @@ export function computeTestCasesWithNonRelevant(
     );
   }
 
-  let testCases =
-    data.comparisons
-      .map((c: Comparison): TestCase => {
-        const datumA = c.statistics[0];
-        const datumB = c.statistics[1];
-        const percent = 100 * ((datumB - datumA) / datumA);
-        return {
-          benchmark: c.benchmark,
-          profile: c.profile,
-          scenario: c.scenario,
-          category: (benchmarkMap[c.benchmark] || {}).category || "secondary",
-          isRelevant: c.is_relevant,
-          significanceFactor: c.significance_factor,
-          significanceThreshold: (c.significance_threshold * 100.0), // ensure the threshold is in %
-          datumA,
-          datumB,
-          percent
-        };
-      })
-      .filter(tc => shouldShowTestCase(tc));
+  let testCases = data.comparisons
+    .map((c: Comparison): TestCase => {
+      const datumA = c.statistics[0];
+      const datumB = c.statistics[1];
+      const percent = 100 * ((datumB - datumA) / datumA);
+      return {
+        benchmark: c.benchmark,
+        profile: c.profile,
+        scenario: c.scenario,
+        category: (benchmarkMap[c.benchmark] || {}).category || "secondary",
+        isRelevant: c.is_relevant,
+        significanceFactor: c.significance_factor,
+        significanceThreshold: c.significance_threshold * 100.0, // ensure the threshold is in %
+        datumA,
+        datumB,
+        percent,
+      };
+    })
+    .filter((tc) => shouldShowTestCase(tc));
 
   // Sort by name first, so that there is a canonical ordering
   // of test cases. This ensures the overall order is stable, even if
@@ -109,11 +115,14 @@ export function computeTestCasesWithNonRelevant(
   return testCases;
 }
 
-export function filterNonRelevant(filter: DataFilter, cases: TestCase[]): TestCase[] {
+export function filterNonRelevant(
+  filter: DataFilter,
+  cases: TestCase[]
+): TestCase[] {
   if (filter.nonRelevant) {
     return cases;
   }
-  return cases.filter(c => c.isRelevant);
+  return cases.filter((c) => c.isRelevant);
 }
 
 /**
@@ -123,15 +132,15 @@ export function filterNonRelevant(filter: DataFilter, cases: TestCase[]): TestCa
 export function computeSummary(testCases: TestCase[]): SummaryGroup {
   const regressions = {
     values: [],
-    benchmarks: new Set()
+    benchmarks: new Set(),
   };
   const improvements = {
     values: [],
-    benchmarks: new Set()
+    benchmarks: new Set(),
   };
   const all = {
     values: [],
-    benchmarks: new Set()
+    benchmarks: new Set(),
   };
 
   const handleTestCase = (items, testCase) => {
@@ -155,10 +164,7 @@ export function computeSummary(testCases: TestCase[]): SummaryGroup {
     const count = values.length;
     let range: Array<number> = [];
     if (count > 0) {
-      range = [
-        Math.min.apply(null, values),
-        Math.max.apply(null, values)
-      ];
+      range = [Math.min.apply(null, values), Math.max.apply(null, values)];
     }
 
     const sum = values.reduce((acc, item) => acc + item, 0);
@@ -168,25 +174,27 @@ export function computeSummary(testCases: TestCase[]): SummaryGroup {
       count,
       benchmarks: benchmarks.size,
       average,
-      range
+      range,
     };
   };
 
   return {
     improvements: computeSummary(improvements),
     regressions: computeSummary(regressions),
-    all: computeSummary(all)
+    all: computeSummary(all),
   };
 }
 
-export function computeBenchmarkMap(data: CompareResponse | null): BenchmarkMap {
-    if (data === null) return {};
+export function computeBenchmarkMap(
+  data: CompareResponse | null
+): BenchmarkMap {
+  if (data === null) return {};
 
-    const benchmarks = {};
-    for (const benchmark of data.benchmark_data) {
-      benchmarks[benchmark.name] = {
-        category: benchmark.category
-      };
-    }
-    return benchmarks;
+  const benchmarks = {};
+  for (const benchmark of data.benchmark_data) {
+    benchmarks[benchmark.name] = {
+      category: benchmark.category,
+    };
+  }
+  return benchmarks;
 }

--- a/site/frontend/src/pages/compare/export.ts
+++ b/site/frontend/src/pages/compare/export.ts
@@ -2,12 +2,15 @@ import {computeSummary, TestCase} from "./data";
 
 export function exportToMarkdown(testCases: TestCase[]) {
   function changesTable(cases) {
-    let data = "| Benchmark | Profile | Scenario | % Change | Significance Factor |\n";
-    data += "|:---:|:---:|:---:|:---:|:---:|\n"
+    let data =
+      "| Benchmark | Profile | Scenario | % Change | Significance Factor |\n";
+    data += "|:---:|:---:|:---:|:---:|:---:|\n";
 
     for (const testCase of cases) {
       data += `| ${testCase.benchmark} | ${testCase.profile} | ${testCase.scenario} `;
-      data += `| ${testCase.percent.toFixed(2)}% | ${testCase.significanceFactor.toFixed(2)}x\n`;
+      data += `| ${testCase.percent.toFixed(
+        2
+      )}% | ${testCase.significanceFactor.toFixed(2)}x\n`;
     }
 
     return data;
@@ -28,22 +31,32 @@ export function exportToMarkdown(testCases: TestCase[]) {
   let content = "# Summary\n";
   content += "| | Range | Mean | Count |\n";
   content += "|:---:|:---:|:---:|:---:|\n";
-  content += `| Regressions | ${formatRange(regressions.range)} | ${regressions.average.toFixed(2)}% | ${regressions.count} |\n`;
-  content += `| Improvements | ${formatRange(improvements.range)} | ${improvements.average.toFixed(2)}% | ${improvements.count} |\n`;
-  content += `| All | ${formatRange(all.range)} | ${all.average.toFixed(2)}% | ${all.count} |\n\n`;
+  content += `| Regressions | ${formatRange(
+    regressions.range
+  )} | ${regressions.average.toFixed(2)}% | ${regressions.count} |\n`;
+  content += `| Improvements | ${formatRange(
+    improvements.range
+  )} | ${improvements.average.toFixed(2)}% | ${improvements.count} |\n`;
+  content += `| All | ${formatRange(all.range)} | ${all.average.toFixed(
+    2
+  )}% | ${all.count} |\n\n`;
 
   content += "# Primary benchmarks\n";
-  content += changesTable(testCases.filter(testCase => testCase.category === "primary"));
+  content += changesTable(
+    testCases.filter((testCase) => testCase.category === "primary")
+  );
 
   content += "\n# Secondary benchmarks\n";
-  content += changesTable(testCases.filter(testCase => testCase.category === "secondary"));
+  content += changesTable(
+    testCases.filter((testCase) => testCase.category === "secondary")
+  );
 
   downloadFile(content, "perf-summary.md");
 }
 
 function downloadFile(content, name) {
   const blob = new Blob([content], {
-    type: "text/markdown"
+    type: "text/markdown",
   });
 
   const url = window.URL.createObjectURL(blob);

--- a/site/frontend/src/pages/compare/header/data-selector.vue
+++ b/site/frontend/src/pages/compare/header/data-selector.vue
@@ -16,7 +16,7 @@ interface Props extends SelectionParams {
 const props = defineProps<Props>();
 
 const emit = defineEmits<{
-  (e: "change", params: SelectionParams): void
+  (e: "change", params: SelectionParams): void;
 }>();
 
 const startRef = ref<HTMLInputElement | null>(null);
@@ -46,61 +46,78 @@ function submitSettings() {
       <template #content>
         <div class="commits section">
           <div class="section-heading">Commits</div>
-          <div style="display: flex; width: 100%; justify-content: space-around;">
+          <div
+            style="display: flex; width: 100%; justify-content: space-around"
+          >
             <div class="commit-input">
               <label for="start-bound">Before</label>
-              <input width="100em" placeholder="YYYY-MM-DD or Commit SHA" ref="startRef" />
+              <input
+                width="100em"
+                placeholder="YYYY-MM-DD or Commit SHA"
+                ref="startRef"
+              />
             </div>
             <div class="commit-input">
               <label for="end-bound">After</label>
-              <input width="100em" placeholder="YYYY-MM-DD or Commit SHA" ref="endRef" />
+              <input
+                width="100em"
+                placeholder="YYYY-MM-DD or Commit SHA"
+                ref="endRef"
+              />
             </div>
           </div>
         </div>
         <div class="metric section">
           <div class="section-heading">Metric</div>
-          <div style="display: flex; flex-direction: column; justify-content: center;">
+          <div
+            style="
+              display: flex;
+              flex-direction: column;
+              justify-content: center;
+            "
+          >
             <select class="stats" ref="statRef">
-              <option v-for="value in props.info.stats" :value="value">{{ value }}
+              <option v-for="value in props.info.stats" :value="value">
+                {{ value }}
               </option>
             </select>
           </div>
         </div>
-        <input type="submit" value="Submit" @click.prevent="submitSettings">
+        <input type="submit" value="Submit" @click.prevent="submitSettings" />
       </template>
     </Toggle>
   </fieldset>
 </template>
 
 <style scoped lang="scss">
-.settings input[type=submit] {
-    width: 100%;
-    font-weight: bold;
-    background: #ADD8E6;
+.settings input[type="submit"] {
+  width: 100%;
+  font-weight: bold;
+  background: #add8e6;
 }
 .commits {
-    border: none;
-    display: flex;
-    padding: 0;
+  border: none;
+  display: flex;
+  padding: 0;
 }
 .commit-input {
-    width: 270px;
-    display: flex;
-    flex-direction: column;
+  width: 270px;
+  display: flex;
+  flex-direction: column;
 }
 .commit-input label {
-    font-size: 12px;
-    font-weight: bold;
-    margin-bottom: 6px;
+  font-size: 12px;
+  font-weight: bold;
+  margin-bottom: 6px;
 }
 .metric {
-    position: relative;
-    height: 40px;
+  position: relative;
+  height: 40px;
 }
 .stats {
-    border-radius: 5px;
-    width: 200px;
-    font-size: 14px;
-    margin-left: 52px;
+  border-radius: 5px;
+  width: 200px;
+  font-size: 14px;
+  margin-left: 52px;
 }
 </style>

--- a/site/frontend/src/pages/compare/header/filters.vue
+++ b/site/frontend/src/pages/compare/header/filters.vue
@@ -7,9 +7,9 @@ import {deepCopy} from "../../../utils/copy";
 
 const props = defineProps<{
   // When reset, set filter to this value
-  defaultFilter: DataFilter,
+  defaultFilter: DataFilter;
   // Initialize the filter with this value
-  initialFilter: DataFilter
+  initialFilter: DataFilter;
 }>();
 const emit = defineEmits<{
   (e: "change", filter: DataFilter): void;
@@ -22,9 +22,13 @@ function reset() {
 }
 
 let filter = ref(deepCopy(props.initialFilter));
-watch(filter, (newValue, _) => {
-  emit("change", toRaw(newValue));
-}, {deep: true});
+watch(
+  filter,
+  (newValue, _) => {
+    emit("change", toRaw(newValue));
+  },
+  {deep: true}
+);
 </script>
 
 <template>
@@ -39,101 +43,146 @@ watch(filter, (newValue, _) => {
           </div>
           <div class="section section-list-wrapper">
             <div class="section-heading">
-              <div style="width: 160px;">
+              <div style="width: 160px">
                 <span>Profiles</span>
-                <Tooltip>The different compilation profiles (check, debug, opt, doc).</Tooltip>
+                <Tooltip
+                  >The different compilation profiles (check, debug, opt,
+                  doc).</Tooltip
+                >
               </div>
             </div>
             <ul class="states-list">
               <li>
                 <label>
-                  <input type="checkbox" id="profile-check" v-model="filter.profile.check" />
+                  <input
+                    type="checkbox"
+                    id="profile-check"
+                    v-model="filter.profile.check"
+                  />
                   <span class="cache-label">check</span>
                 </label>
                 <Tooltip>Check build that does not generate any code.</Tooltip>
               </li>
               <li>
                 <label>
-                  <input type="checkbox" id="profile-debug" v-model="filter.profile.debug" />
+                  <input
+                    type="checkbox"
+                    id="profile-debug"
+                    v-model="filter.profile.debug"
+                  />
                   <span class="cache-label">debug</span>
                 </label>
                 <Tooltip>Debug build that produces unoptimized code.</Tooltip>
               </li>
               <li>
                 <label>
-                  <input type="checkbox" id="profile-opt"
-                         v-model="filter.profile.opt" />
+                  <input
+                    type="checkbox"
+                    id="profile-opt"
+                    v-model="filter.profile.opt"
+                  />
                   <span class="cache-label">opt</span>
                 </label>
-                <Tooltip>Release build that produces as optimized code as possible.</Tooltip>
+                <Tooltip
+                  >Release build that produces as optimized code as
+                  possible.</Tooltip
+                >
               </li>
               <li>
                 <label>
-                  <input type="checkbox" id="profile-doc"
-                         v-model="filter.profile.doc" />
+                  <input
+                    type="checkbox"
+                    id="profile-doc"
+                    v-model="filter.profile.doc"
+                  />
                   <span class="cache-label">doc</span>
                 </label>
-                <Tooltip>Documentation build that produces HTML documentation site produced by
-                  `rustdoc`.
+                <Tooltip
+                  >Documentation build that produces HTML documentation site
+                  produced by `rustdoc`.
                 </Tooltip>
               </li>
             </ul>
           </div>
           <div class="section section-list-wrapper">
             <div class="section-heading">
-              <div style="width: 160px;">
+              <div style="width: 160px">
                 <span>Scenarios</span>
-                <Tooltip>The different scenarios based on their incremental compilation cache
-                  state.
+                <Tooltip
+                  >The different scenarios based on their incremental
+                  compilation cache state.
                 </Tooltip>
               </div>
             </div>
             <ul class="states-list">
               <li>
                 <label>
-                  <input type="checkbox" id="build-full" v-model="filter.scenario.full" />
+                  <input
+                    type="checkbox"
+                    id="build-full"
+                    v-model="filter.scenario.full"
+                  />
                   <span class="cache-label">full</span>
                 </label>
-                <Tooltip>A non-incremental full build starting with empty cache.</Tooltip>
+                <Tooltip
+                  >A non-incremental full build starting with empty
+                  cache.</Tooltip
+                >
               </li>
               <li>
                 <label>
-                  <input type="checkbox" id="build-incremental-full"
-                         v-model="filter.scenario.incrFull" />
+                  <input
+                    type="checkbox"
+                    id="build-incremental-full"
+                    v-model="filter.scenario.incrFull"
+                  />
                   <span class="cache-label">incr-full</span>
                 </label>
-                <Tooltip>An incremental build starting with empty cache.</Tooltip>
+                <Tooltip
+                  >An incremental build starting with empty cache.</Tooltip
+                >
               </li>
               <li>
                 <label>
-                  <input type="checkbox" id="build-incremental-unchanged"
-                         v-model="filter.scenario.incrUnchanged" />
+                  <input
+                    type="checkbox"
+                    id="build-incremental-unchanged"
+                    v-model="filter.scenario.incrUnchanged"
+                  />
                   <span class="cache-label">incr-unchanged</span>
                 </label>
-                <Tooltip>An incremental build starting with complete cache, and unchanged source
-                  directory --
-                  the "perfect" scenario for incremental.
+                <Tooltip
+                  >An incremental build starting with complete cache, and
+                  unchanged source directory -- the "perfect" scenario for
+                  incremental.
                 </Tooltip>
               </li>
               <li>
                 <label>
-                  <input type="checkbox" id="build-incremental-patched"
-                         v-model="filter.scenario.incrPatched" />
+                  <input
+                    type="checkbox"
+                    id="build-incremental-patched"
+                    v-model="filter.scenario.incrPatched"
+                  />
                   <span class="cache-label">incr-patched</span>
                 </label>
-                <Tooltip>An incremental build starting with complete cache, and an altered source
-                  directory.
-                  The typical variant of this is "println" which represents the addition of a
-                  `println!` macro somewhere in the source code.
+                <Tooltip
+                  >An incremental build starting with complete cache, and an
+                  altered source directory. The typical variant of this is
+                  "println" which represents the addition of a `println!` macro
+                  somewhere in the source code.
                 </Tooltip>
               </li>
             </ul>
           </div>
           <div class="section section-list-wrapper">
             <div class="section-heading">
-              <div style="width: 160px;">
+              <div style="width: 160px">
                 <span>Categories</span>
-                <Tooltip>Select benchmarks based on their category (primary or secondary).</Tooltip>
+                <Tooltip
+                  >Select benchmarks based on their category (primary or
+                  secondary).</Tooltip
+                >
               </div>
             </div>
             <ul class="states-list">
@@ -154,26 +203,43 @@ watch(filter, (newValue, _) => {
             </ul>
           </div>
           <div class="section">
-            <div class="section-heading"><span>Show non-relevant results</span>
+            <div class="section-heading">
+              <span>Show non-relevant results</span>
               <Tooltip>
-                Whether to show test case results that are not relevant (i.e., not significant or
-                have a large enough magnitude). You can see
+                Whether to show test case results that are not relevant (i.e.,
+                not significant or have a large enough magnitude). You can see
                 <a
-                  href="https://github.com/rust-lang/rustc-perf/blob/master/docs/comparison-analysis.md#how-is-relevance-of-a-test-run-summary-determined">
-                  here</a> how relevance is calculated.
+                  href="https://github.com/rust-lang/rustc-perf/blob/master/docs/comparison-analysis.md#how-is-relevance-of-a-test-run-summary-determined"
+                >
+                  here</a
+                >
+                how relevance is calculated.
               </Tooltip>
             </div>
-            <input type="checkbox" v-model="filter.nonRelevant" style="margin-left: 20px;" />
+            <input
+              type="checkbox"
+              v-model="filter.nonRelevant"
+              style="margin-left: 20px"
+            />
           </div>
           <div class="section">
-            <div class="section-heading"><span>Display raw data</span>
+            <div class="section-heading">
+              <span>Display raw data</span>
               <Tooltip>Whether to display or not raw data columns.</Tooltip>
             </div>
-            <input type="checkbox" v-model="filter.showRawData" style="margin-left: 20px;" />
+            <input
+              type="checkbox"
+              v-model="filter.showRawData"
+              style="margin-left: 20px"
+            />
           </div>
-          <button @click="reset" style="margin-right: 10px;">Reset filters</button>
-          <button @click="emit('export')"
-                  title="Download the currently filtered data as a Markdown table">
+          <button @click="reset" style="margin-right: 10px">
+            Reset filters
+          </button>
+          <button
+            @click="emit('export')"
+            title="Download the currently filtered data as a Markdown table"
+          >
             Export to Markdown
           </button>
         </div>
@@ -184,44 +250,44 @@ watch(filter, (newValue, _) => {
 
 <style scoped lang="scss">
 .section-heading {
-    font-size: 16px;
+  font-size: 16px;
 }
 
 #filter {
-    margin-left: 52px;
+  margin-left: 52px;
 }
 
 .states-list {
-    display: flex;
-    flex-direction: column;
-    align-items: start;
-    list-style: none;
-    margin: 0;
-    padding: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }
 
 .section-list-wrapper {
-    flex-direction: column;
+  flex-direction: column;
 }
 
 @media (min-width: 760px) {
-    .states-list {
-        justify-content: start;
-        flex-direction: row;
-        align-items: center;
-        width: 80%;
-    }
+  .states-list {
+    justify-content: start;
+    flex-direction: row;
+    align-items: center;
+    width: 80%;
+  }
 
-    .section-list-wrapper {
-        flex-direction: row;
-    }
+  .section-list-wrapper {
+    flex-direction: row;
+  }
 }
 
 .states-list > li {
-    margin-right: 15px;
+  margin-right: 15px;
 }
 
 .cache-label {
-    font-weight: bold;
+  font-weight: bold;
 }
 </style>

--- a/site/frontend/src/pages/compare/header/header.vue
+++ b/site/frontend/src/pages/compare/header/header.vue
@@ -4,8 +4,8 @@ import {formatDate} from "../shared";
 import {computed} from "vue";
 
 const props = defineProps<{
-  data: CompareResponse | null,
-  selector: CompareSelector
+  data: CompareResponse | null;
+  selector: CompareSelector;
 }>();
 
 function prLink(pr: number | null): string {
@@ -20,7 +20,10 @@ function short(artifact: ArtifactDescription): string {
 function shortCommit(commit): string {
   return commit.substring(0, 8);
 }
-function formatBound(artifact: ArtifactDescription | null, bound: string): string {
+function formatBound(
+  artifact: ArtifactDescription | null,
+  bound: string
+): string {
   if (artifact === null) {
     return bound ? bound.substring(0, 10) : "???";
   }
@@ -36,44 +39,74 @@ function formatBound(artifact: ArtifactDescription | null, bound: string): strin
   return artifact.commit.substring(0, 7);
 }
 
-const prevLink = computed(() => `/compare.html?start=${props.data.prev}&end=${props.data.a.commit}&stat=${props.selector.stat}`);
-const nextLink = computed(() => `/compare.html?start=${props.data.b.commit}&end=${props.data.next}&stat=${props.selector.stat}`);
-const compareLink = computed(() => `https://github.com/rust-lang/rust/compare/${props.data.a.commit}...${props.data.b.commit}`);
+const prevLink = computed(
+  () =>
+    `/compare.html?start=${props.data.prev}&end=${props.data.a.commit}&stat=${props.selector.stat}`
+);
+const nextLink = computed(
+  () =>
+    `/compare.html?start=${props.data.b.commit}&end=${props.data.next}&stat=${props.selector.stat}`
+);
+const compareLink = computed(
+  () =>
+    `https://github.com/rust-lang/rust/compare/${props.data.a.commit}...${props.data.b.commit}`
+);
 
-const before = computed(() => formatBound(props.data?.a ?? null, props.selector.start));
-const after = computed(() => formatBound(props.data?.b ?? null, props.selector.end));
+const before = computed(() =>
+  formatBound(props.data?.a ?? null, props.selector.start)
+);
+const after = computed(() =>
+  formatBound(props.data?.b ?? null, props.selector.end)
+);
 </script>
 
 <template>
-  <h2>Comparing <span id="stat-header">{{ selector.stat }}</span> between <span
-    id="before">{{ before }}</span> and
+  <h2>
+    Comparing <span id="stat-header">{{ selector.stat }}</span> between
+    <span id="before">{{ before }}</span> and
     <span id="after">{{ after }}</span>
   </h2>
-  <div v-if="props.data !== null" style="margin: 12px 0;">
-    <div style="display: flex;justify-content: center;">
+  <div v-if="props.data !== null" style="margin: 12px 0">
+    <div style="display: flex; justify-content: center">
       <div class="description-box">
-        <div v-if="data.prev" class="description-arrow"><a v-bind:href="prevLink">&larr;</a></div>
-        <div style="padding: 10px;">
-          <span><a v-if="data.a.pr"
-                   v-bind:href="prLink(data.a.pr)">#{{ data.a.pr }}</a>&nbsp;</span>
+        <div v-if="data.prev" class="description-arrow">
+          <a v-bind:href="prevLink">&larr;</a>
+        </div>
+        <div style="padding: 10px">
+          <span
+            ><a v-if="data.a.pr" v-bind:href="prLink(data.a.pr)"
+              >#{{ data.a.pr }}</a
+            >&nbsp;</span
+          >
           <span v-if="data.a.date">{{ formatDate(data.a.date) }}</span>
-          (<a v-bind:href="commitLink(data.a.commit)">{{ short(data.a) }}</a>)
+          (<a v-bind:href="commitLink(data.a.commit)">{{ short(data.a) }}</a
+          >)
         </div>
       </div>
-      <div v-if="!data.is_contiguous" class="not-continuous"
-           title="WARNING! The commits are not continuous.">...
+      <div
+        v-if="!data.is_contiguous"
+        class="not-continuous"
+        title="WARNING! The commits are not continuous."
+      >
+        ...
       </div>
       <div class="description-box">
-        <div style="padding: 10px;">
-          <span><a v-if="data.b.pr"
-                   v-bind:href="prLink(data.b.pr)">#{{ data.b.pr }}</a>&nbsp;</span>
+        <div style="padding: 10px">
+          <span
+            ><a v-if="data.b.pr" v-bind:href="prLink(data.b.pr)"
+              >#{{ data.b.pr }}</a
+            >&nbsp;</span
+          >
           <span v-if="data.b.date">{{ formatDate(data.b.date) }}</span>
-          (<a v-bind:href="commitLink(data.b.commit)">{{ short(data.b) }}</a>)
+          (<a v-bind:href="commitLink(data.b.commit)">{{ short(data.b) }}</a
+          >)
         </div>
-        <div v-if="data.next" class="description-arrow"><a v-bind:href="nextLink">&rarr;</a></div>
+        <div v-if="data.next" class="description-arrow">
+          <a v-bind:href="nextLink">&rarr;</a>
+        </div>
       </div>
     </div>
-    <div style="display: flex; justify-content: center;">
+    <div style="display: flex; justify-content: center">
       <a v-bind:href="compareLink">🔎 compare commits</a>
     </div>
   </div>
@@ -81,23 +114,23 @@ const after = computed(() => formatBound(props.data?.b ?? null, props.selector.e
 
 <style scoped lang="scss">
 .description-box {
-    border: 1px solid;
-    display: flex;
+  border: 1px solid;
+  display: flex;
 }
 .description-arrow {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    background: #8dcc8d;
-    padding: 5px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  background: #8dcc8d;
+  padding: 5px;
 }
 .not-continuous {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    text-align: center;
-    background: #cc3300;
-    border: 1px solid;
-    cursor: help;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  background: #cc3300;
+  border: 1px solid;
+  cursor: help;
 }
 </style>

--- a/site/frontend/src/pages/compare/header/quick-links.vue
+++ b/site/frontend/src/pages/compare/header/quick-links.vue
@@ -1,12 +1,19 @@
 <script setup lang="ts">
-import {createUrlWithAppendedParams, getUrlParams} from "../../../utils/navigation";
+import {
+  createUrlWithAppendedParams,
+  getUrlParams,
+} from "../../../utils/navigation";
 
 const props = defineProps<{stat: string}>();
 
-function createMetric(label: string, stat: string, description: string): {
+function createMetric(
   label: string,
   stat: string,
   description: string
+): {
+  label: string;
+  stat: string;
+  description: string;
 } {
   return {label, stat, description};
 }
@@ -18,18 +25,30 @@ function createUrlForMetric(stat: string): string {
 }
 
 const metrics = [
-  createMetric("Instructions", "instructions:u", "Number of executed instructions"),
+  createMetric(
+    "Instructions",
+    "instructions:u",
+    "Number of executed instructions"
+  ),
   createMetric("Cycles", "cycles:u", "Number of executed cycles"),
   createMetric("Wall time", "wall-time", "Wall time"),
   createMetric("Max RSS", "max-rss", "Peak memory usage (resident set size)"),
-  createMetric("Binary size", "size:linked_artifact", "Size of the generated binary artifact")
+  createMetric(
+    "Binary size",
+    "size:linked_artifact",
+    "Size of the generated binary artifact"
+  ),
 ];
 </script>
 
 <template>
   <div class="quick-links">
     <div>Quick links:</div>
-    <div v-for="metric in metrics" :class="{ active: props.stat === metric.stat }" :title="metric.description">
+    <div
+      v-for="metric in metrics"
+      :class="{active: props.stat === metric.stat}"
+      :title="metric.description"
+    >
       <a :href="createUrlForMetric(metric.stat)">{{ metric.label }}</a>
     </div>
   </div>
@@ -37,16 +56,16 @@ const metrics = [
 
 <style scoped lang="scss">
 .quick-links {
-    display: flex;
-    flex-direction: row;
-    margin: 10px 0;
+  display: flex;
+  flex-direction: row;
+  margin: 10px 0;
 }
 
 .quick-links div {
-    margin-right: 10px;
+  margin-right: 10px;
 }
 
 .quick-links .active {
-    font-weight: bold;
+  font-weight: bold;
 }
 </style>

--- a/site/frontend/src/pages/compare/page.vue
+++ b/site/frontend/src/pages/compare/page.vue
@@ -5,7 +5,7 @@ import {
   createUrlFromParams,
   createUrlWithAppendedParams,
   getUrlParams,
-  navigateToUrlParams
+  navigateToUrlParams,
 } from "../../utils/navigation";
 import {computed, Ref, ref} from "vue";
 import {withLoading} from "../../utils/loading";
@@ -22,7 +22,7 @@ import {
   computeBenchmarkMap,
   computeSummary,
   computeTestCasesWithNonRelevant,
-  filterNonRelevant
+  filterNonRelevant,
 } from "./data";
 import OverallTable from "./summary/overall-table.vue";
 import Aggregations from "./summary/aggregations.vue";
@@ -35,11 +35,14 @@ function loadSelectorFromUrl(urlParams: Dict<string>): CompareSelector {
   return {
     start,
     end,
-    stat
+    stat,
   };
 }
 
-function loadFilterFromUrl(urlParams: Dict<string>, defaultFilter: DataFilter): DataFilter {
+function loadFilterFromUrl(
+  urlParams: Dict<string>,
+  defaultFilter: DataFilter
+): DataFilter {
   function getBoolOrDefault(name: string, defaultValue: boolean): boolean {
     if (urlParams.hasOwnProperty(name)) {
       return urlParams[name] === "true";
@@ -55,18 +58,27 @@ function loadFilterFromUrl(urlParams: Dict<string>, defaultFilter: DataFilter): 
       check: getBoolOrDefault("check", defaultFilter.profile.check),
       debug: getBoolOrDefault("debug", defaultFilter.profile.debug),
       opt: getBoolOrDefault("opt", defaultFilter.profile.opt),
-      doc: getBoolOrDefault("doc", defaultFilter.profile.doc)
+      doc: getBoolOrDefault("doc", defaultFilter.profile.doc),
     },
     scenario: {
       full: getBoolOrDefault("full", defaultFilter.scenario.full),
       incrFull: getBoolOrDefault("incrFull", defaultFilter.scenario.incrFull),
-      incrUnchanged: getBoolOrDefault("incrUnchanged", defaultFilter.scenario.incrUnchanged),
-      incrPatched: getBoolOrDefault("incrPatched", defaultFilter.scenario.incrPatched)
+      incrUnchanged: getBoolOrDefault(
+        "incrUnchanged",
+        defaultFilter.scenario.incrUnchanged
+      ),
+      incrPatched: getBoolOrDefault(
+        "incrPatched",
+        defaultFilter.scenario.incrPatched
+      ),
     },
     category: {
       primary: getBoolOrDefault("primary", defaultFilter.category.primary),
-      secondary: getBoolOrDefault("secondary", defaultFilter.category.secondary)
-    }
+      secondary: getBoolOrDefault(
+        "secondary",
+        defaultFilter.category.secondary
+      ),
+    },
   };
 }
 
@@ -74,8 +86,16 @@ function loadFilterFromUrl(urlParams: Dict<string>, defaultFilter: DataFilter): 
  * Stores the given filter parameters into URL, so that the current "view" can be shared with
  * others easily.
  */
-function storeFilterToUrl(filter: DataFilter, defaultFilter: DataFilter, urlParams: Dict<string>) {
-  function storeOrReset<T extends boolean | string>(name: string, value: T, defaultValue: T) {
+function storeFilterToUrl(
+  filter: DataFilter,
+  defaultFilter: DataFilter,
+  urlParams: Dict<string>
+) {
+  function storeOrReset<T extends boolean | string>(
+    name: string,
+    value: T,
+    defaultValue: T
+  ) {
     if (value === defaultValue) {
       if (urlParams.hasOwnProperty(name)) {
         delete urlParams[name];
@@ -93,11 +113,31 @@ function storeFilterToUrl(filter: DataFilter, defaultFilter: DataFilter, urlPara
   storeOrReset("opt", filter.profile.opt, defaultFilter.profile.opt);
   storeOrReset("doc", filter.profile.doc, defaultFilter.profile.doc);
   storeOrReset("full", filter.scenario.full, defaultFilter.scenario.full);
-  storeOrReset("incrFull", filter.scenario.incrFull, defaultFilter.scenario.incrFull);
-  storeOrReset("incrUnchanged", filter.scenario.incrUnchanged, defaultFilter.scenario.incrUnchanged);
-  storeOrReset("incrPatched", filter.scenario.incrPatched, defaultFilter.scenario.incrPatched);
-  storeOrReset("primary", filter.category.primary, defaultFilter.category.primary);
-  storeOrReset("secondary", filter.category.secondary, defaultFilter.category.secondary);
+  storeOrReset(
+    "incrFull",
+    filter.scenario.incrFull,
+    defaultFilter.scenario.incrFull
+  );
+  storeOrReset(
+    "incrUnchanged",
+    filter.scenario.incrUnchanged,
+    defaultFilter.scenario.incrUnchanged
+  );
+  storeOrReset(
+    "incrPatched",
+    filter.scenario.incrPatched,
+    defaultFilter.scenario.incrPatched
+  );
+  storeOrReset(
+    "primary",
+    filter.category.primary,
+    defaultFilter.category.primary
+  );
+  storeOrReset(
+    "secondary",
+    filter.category.secondary,
+    defaultFilter.category.secondary
+  );
 
   // Change URL without creating a history entry
   if (history.replaceState) {
@@ -105,12 +145,15 @@ function storeFilterToUrl(filter: DataFilter, defaultFilter: DataFilter, urlPara
   }
 }
 
-async function loadCompareData(selector: CompareSelector, loading: Ref<boolean>) {
+async function loadCompareData(
+  selector: CompareSelector,
+  loading: Ref<boolean>
+) {
   const response: CompareResponse = await withLoading(loading, async () => {
     const params = {
       start: selector.start,
       end: selector.end,
-      stat: selector.stat
+      stat: selector.stat,
     };
     return await postMsgpack<CompareResponse>(COMPARE_DATA_URL, params);
   });
@@ -118,11 +161,13 @@ async function loadCompareData(selector: CompareSelector, loading: Ref<boolean>)
 }
 
 function updateSelection(params: SelectionParams) {
-  navigateToUrlParams(createUrlWithAppendedParams({
-    start: params.start,
-    end: params.end,
-    stat: params.stat
-  }).searchParams);
+  navigateToUrlParams(
+    createUrlWithAppendedParams({
+      start: params.start,
+      end: params.end,
+      stat: params.stat,
+    }).searchParams
+  );
 }
 
 function updateFilter(newFilter: DataFilter) {
@@ -144,22 +189,26 @@ const defaultFilter: DataFilter = {
     check: true,
     debug: true,
     opt: true,
-    doc: true
+    doc: true,
   },
   scenario: {
     full: true,
     incrFull: true,
     incrUnchanged: true,
-    incrPatched: true
+    incrPatched: true,
   },
   category: {
     primary: true,
-    secondary: true
-  }
+    secondary: true,
+  },
 };
 const benchmarkMap = computed(() => computeBenchmarkMap(data.value));
-const allTestCases = computed(() => computeTestCasesWithNonRelevant(filter.value, data.value, benchmarkMap.value));
-const testCases = computed(() => filterNonRelevant(filter.value, allTestCases.value));
+const allTestCases = computed(() =>
+  computeTestCasesWithNonRelevant(filter.value, data.value, benchmarkMap.value)
+);
+const testCases = computed(() =>
+  filterNonRelevant(filter.value, allTestCases.value)
+);
 const filteredSummary = computed(() => computeSummary(testCases.value));
 
 const loading = ref(false);
@@ -175,28 +224,36 @@ loadCompareData(selector, loading);
 <template>
   <div>
     <Header :data="data" :selector="selector" />
-    <DataSelector :start="selector.start" :end="selector.end" :stat="selector.stat"
-                  :info="info" @change="updateSelection" />
+    <DataSelector
+      :start="selector.start"
+      :end="selector.end"
+      :stat="selector.stat"
+      :info="info"
+      @change="updateSelection"
+    />
     <div v-if="loading">
       <p>Loading ...</p>
     </div>
     <div v-if="data !== null">
       <QuickLinks :stat="selector.stat" />
-      <Filters :defaultFilter="defaultFilter"
-               :initialFilter="filter"
-               @change="updateFilter"
-               @export="exportData" />
+      <Filters
+        :defaultFilter="defaultFilter"
+        :initialFilter="filter"
+        @change="updateFilter"
+        @export="exportData"
+      />
       <OverallTable :summary="filteredSummary" />
       <Aggregations :cases="testCases" />
-      <Benchmarks :data="data"
-                  :test-cases="testCases"
-                  :all-test-cases="allTestCases"
-                  :filter="filter"
-                  :stat="selector.stat"
+      <Benchmarks
+        :data="data"
+        :test-cases="testCases"
+        :all-test-cases="allTestCases"
+        :filter="filter"
+        :stat="selector.stat"
       ></Benchmarks>
       <BootstrapTable :data="data" />
     </div>
   </div>
-  <br>
+  <br />
   <AsOf :info="info" />
 </template>

--- a/site/frontend/src/pages/compare/shared.ts
+++ b/site/frontend/src/pages/compare/shared.ts
@@ -1,10 +1,11 @@
 export function formatDate(dateString: string): string {
   const date = new Date(dateString);
   function padStr(i) {
-    return (i < 10) ? "0" + i : "" + i;
-
+    return i < 10 ? "0" + i : "" + i;
   }
-  return `${date.getUTCFullYear()}-${padStr(date.getUTCMonth() + 1)}-${padStr(date.getUTCDate())} `;
+  return `${date.getUTCFullYear()}-${padStr(date.getUTCMonth() + 1)}-${padStr(
+    date.getUTCDate()
+  )} `;
 }
 export function signIfPositive(pct: number): string {
   if (pct >= 0) {

--- a/site/frontend/src/pages/compare/summary/aggregations.vue
+++ b/site/frontend/src/pages/compare/summary/aggregations.vue
@@ -4,10 +4,13 @@ import Toggle from "../toggle.vue";
 import SummaryTable from "./summary-table.vue";
 
 const props = defineProps<{
-  cases: TestCase[]
+  cases: TestCase[];
 }>();
 
-function calculateSummary(keyAttribute: string, keyValue: string): SummaryGroup {
+function calculateSummary(
+  keyAttribute: string,
+  keyValue: string
+): SummaryGroup {
   const benchmarks = [];
   for (const benchmark of props.cases) {
     if (benchmark[keyAttribute].startsWith(keyValue)) {
@@ -27,21 +30,35 @@ function calculateSummary(keyAttribute: string, keyValue: string): SummaryGroup 
           <div class="aggregation-section">
             <div class="header">Profile</div>
             <div class="groups">
-              <div class="group" v-for="profile in ['check', 'debug', 'opt', 'doc']">
+              <div
+                class="group"
+                v-for="profile in ['check', 'debug', 'opt', 'doc']"
+              >
                 <div class="group-header">{{ profile }}</div>
-                <SummaryTable :summary="calculateSummary('profile', profile)"
-                              :withLegend="false"></SummaryTable>
+                <SummaryTable
+                  :summary="calculateSummary('profile', profile)"
+                  :withLegend="false"
+                ></SummaryTable>
               </div>
             </div>
           </div>
           <div class="aggregation-section">
             <div class="header">Scenario</div>
             <div class="groups">
-              <div class="group"
-                   v-for="scenario in ['full', 'incr-full', 'incr-unchanged', 'incr-patched']">
+              <div
+                class="group"
+                v-for="scenario in [
+                  'full',
+                  'incr-full',
+                  'incr-unchanged',
+                  'incr-patched',
+                ]"
+              >
                 <div class="group-header">{{ scenario }}</div>
-                <SummaryTable :summary="calculateSummary('scenario', scenario)"
-                              :withLegend="false"></SummaryTable>
+                <SummaryTable
+                  :summary="calculateSummary('scenario', scenario)"
+                  :withLegend="false"
+                ></SummaryTable>
               </div>
             </div>
           </div>
@@ -50,8 +67,10 @@ function calculateSummary(keyAttribute: string, keyValue: string): SummaryGroup 
             <div class="groups">
               <div class="group" v-for="category in ['primary', 'secondary']">
                 <div class="group-header">{{ category }}</div>
-                <SummaryTable :summary="calculateSummary('category', category)"
-                              :withLegend="false"></SummaryTable>
+                <SummaryTable
+                  :summary="calculateSummary('category', category)"
+                  :withLegend="false"
+                ></SummaryTable>
               </div>
             </div>
           </div>
@@ -63,29 +82,29 @@ function calculateSummary(keyAttribute: string, keyValue: string): SummaryGroup 
 
 <style scoped lang="scss">
 .aggregation-section > .header {
-    margin-top: 5px;
-    font-size: 16px;
-    text-align: center;
+  margin-top: 5px;
+  font-size: 16px;
+  text-align: center;
 }
 
 .aggregation-section > .groups {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
 }
 
 .aggregation-section .group {
-    min-width: 45%;
-    border: 1px dotted black;
-    padding: 5px;
-    margin: 10px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+  min-width: 45%;
+  border: 1px dotted black;
+  padding: 5px;
+  margin: 10px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .aggregation-section .group-header {
-    margin-bottom: 5px;
-    font-weight: bold;
+  margin-bottom: 5px;
+  font-weight: bold;
 }
 </style>

--- a/site/frontend/src/pages/compare/summary/count.vue
+++ b/site/frontend/src/pages/compare/summary/count.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 const props = defineProps<{
-  cases: number,
-  benchmarks: number
+  cases: number;
+  benchmarks: number;
 }>();
 </script>
 
 <template>
-  <span :title="cases + ' test case(s), ' + benchmarks + ' unique benchmark(s)'">{{ cases }} ({{ benchmarks }})</span>
+  <span :title="cases + ' test case(s), ' + benchmarks + ' unique benchmark(s)'"
+    >{{ cases }} ({{ benchmarks }})</span
+  >
 </template>

--- a/site/frontend/src/pages/compare/summary/overall-table.vue
+++ b/site/frontend/src/pages/compare/summary/overall-table.vue
@@ -5,7 +5,7 @@ import SummaryTable from "./summary-table.vue";
 import Tooltip from "../tooltip.vue";
 
 const props = defineProps<{
-  summary: SummaryGroup,
+  summary: SummaryGroup;
 }>();
 const summary = computed(() => props.summary);
 </script>
@@ -13,8 +13,8 @@ const summary = computed(() => props.summary);
 <template>
   <div class="main-summary">
     <SummaryTable :summary="summary"></SummaryTable>
-    <div style="position: absolute; right: 5px; top: 5px;">
-      <Tooltip style="margin-right: 1em;">
+    <div style="position: absolute; right: 5px; top: 5px">
+      <Tooltip style="margin-right: 1em">
         The table shows summaries of regressions, improvements and all changes
         calculated from data that is currently visible (data that passes the
         active filters).
@@ -25,12 +25,12 @@ const summary = computed(() => props.summary);
 
 <style scoped lang="scss">
 .main-summary {
-    border: 1px dashed;
-    padding: 4px;
-    border-radius: 6px;
+  border: 1px dashed;
+  padding: 4px;
+  border-radius: 6px;
 
-    display: flex;
-    justify-content: center;
-    position: relative;
+  display: flex;
+  justify-content: center;
+  position: relative;
 }
 </style>

--- a/site/frontend/src/pages/compare/summary/percent-value.vue
+++ b/site/frontend/src/pages/compare/summary/percent-value.vue
@@ -2,10 +2,13 @@
 import {computed} from "vue";
 import {signIfPositive} from "../shared";
 
-const props = withDefaults(defineProps<{
-  value: number,
-  padWidth?: number | null
-}>(), { padWidth: null });
+const props = withDefaults(
+  defineProps<{
+    value: number;
+    padWidth?: number | null;
+  }>(),
+  {padWidth: null}
+);
 
 const formattedValue = computed((): string => {
   return `${signIfPositive(props.value)}${props.value.toFixed(2)}`;

--- a/site/frontend/src/pages/compare/summary/range.vue
+++ b/site/frontend/src/pages/compare/summary/range.vue
@@ -8,7 +8,8 @@ const range = computed(() => props.range);
 
 <template>
   <div v-if="range.length > 0">
-    [<SummaryPercentValue :value="range[0]" :padWidth="6" />, <SummaryPercentValue :value="range[1]" :padWidth="6" />]
+    [<SummaryPercentValue :value="range[0]" :padWidth="6" />,
+    <SummaryPercentValue :value="range[1]" :padWidth="6" />]
   </div>
-  <div v-else style="text-align: center;">-</div>
+  <div v-else style="text-align: center">-</div>
 </template>

--- a/site/frontend/src/pages/compare/summary/summary-table.vue
+++ b/site/frontend/src/pages/compare/summary/summary-table.vue
@@ -5,18 +5,28 @@ import SummaryRange from "./range.vue";
 import SummaryCount from "./count.vue";
 import SummaryPercentValue from "./percent-value.vue";
 
-const props = withDefaults(defineProps<{
-  summary: SummaryGroup,
-  withLegend?: boolean
-}>(), {
-  withLegend: true
-});
+const props = withDefaults(
+  defineProps<{
+    summary: SummaryGroup;
+    withLegend?: boolean;
+  }>(),
+  {
+    withLegend: true,
+  }
+);
 const summary = computed(() => props.summary);
 </script>
 
 <template>
-  <div v-if="summary.all.count === 0"
-       style="flex-grow: 1; display: flex; flex-direction: column; justify-content: center;">
+  <div
+    v-if="summary.all.count === 0"
+    style="
+      flex-grow: 1;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+    "
+  >
     <span>No results</span>
   </div>
   <table v-else class="summary-table">
@@ -29,54 +39,61 @@ const summary = computed(() => props.summary);
       </tr>
     </thead>
     <tbody>
-    <tr class="positive">
-      <td title="Regressions" v-if="withLegend">❌</td>
-      <template v-if="summary.regressions.count !== 0">
+      <tr class="positive">
+        <td title="Regressions" v-if="withLegend">❌</td>
+        <template v-if="summary.regressions.count !== 0">
+          <td>
+            <SummaryRange :range="summary.regressions.range" />
+          </td>
+          <td>
+            <SummaryPercentValue :value="summary.regressions.average" />
+          </td>
+          <td>
+            <SummaryCount
+              :cases="summary.regressions.count"
+              :benchmarks="summary.regressions.benchmarks"
+            />
+          </td>
+        </template>
+        <template v-else>
+          <td colspan="3" style="text-align: center">No regressions</td>
+        </template>
+      </tr>
+      <tr class="negative">
+        <td title="Improvements" v-if="withLegend">✅</td>
+        <template v-if="summary.improvements.count !== 0">
+          <td>
+            <SummaryRange :range="summary.improvements.range" />
+          </td>
+          <td>
+            <SummaryPercentValue :value="summary.improvements.average" />
+          </td>
+          <td>
+            <SummaryCount
+              :cases="summary.improvements.count"
+              :benchmarks="summary.improvements.benchmarks"
+            />
+          </td>
+        </template>
+        <template v-else>
+          <td colspan="3" style="text-align: center">No improvements</td>
+        </template>
+      </tr>
+      <tr>
+        <td title="All changes" v-if="withLegend">❌,✅</td>
         <td>
-          <SummaryRange :range="summary.regressions.range" />
+          <SummaryRange :range="summary.all.range" />
         </td>
         <td>
-          <SummaryPercentValue :value="summary.regressions.average" />
+          <SummaryPercentValue :value="summary.all.average" />
         </td>
         <td>
-          <SummaryCount :cases="summary.regressions.count"
-                        :benchmarks="summary.regressions.benchmarks" />
+          <SummaryCount
+            :cases="summary.all.count"
+            :benchmarks="summary.all.benchmarks"
+          />
         </td>
-      </template>
-      <template v-else>
-        <td colspan="3" style="text-align: center;">No regressions</td>
-      </template>
-    </tr>
-    <tr class="negative">
-      <td title="Improvements" v-if="withLegend">✅</td>
-      <template v-if="summary.improvements.count !== 0">
-        <td>
-          <SummaryRange :range="summary.improvements.range" />
-        </td>
-        <td>
-          <SummaryPercentValue :value="summary.improvements.average" />
-        </td>
-        <td>
-          <SummaryCount :cases="summary.improvements.count"
-                        :benchmarks="summary.improvements.benchmarks" />
-        </td>
-      </template>
-      <template v-else>
-        <td colspan="3" style="text-align: center;">No improvements</td>
-      </template>
-    </tr>
-    <tr>
-      <td title="All changes" v-if="withLegend">❌,✅</td>
-      <td>
-        <SummaryRange :range="summary.all.range" />
-      </td>
-      <td>
-        <SummaryPercentValue :value="summary.all.average" />
-      </td>
-      <td>
-        <SummaryCount :cases="summary.all.count" :benchmarks="summary.all.benchmarks" />
-      </td>
-    </tr>
+      </tr>
     </tbody>
   </table>
 </template>
@@ -86,7 +103,8 @@ const summary = computed(() => props.summary);
   td {
     text-align: right;
   }
-  td, th {
+  td,
+  th {
     padding: 2px 5px;
     vertical-align: middle;
   }

--- a/site/frontend/src/pages/compare/toggle.vue
+++ b/site/frontend/src/pages/compare/toggle.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
 import {ref} from "vue";
 
-const props = withDefaults(defineProps<{
-  defaultOpened?: boolean
-}>(), {
-  defaultOpened: false
-});
+const props = withDefaults(
+  defineProps<{
+    defaultOpened?: boolean;
+  }>(),
+  {
+    defaultOpened: false,
+  }
+);
 
 const opened = ref(props.defaultOpened);
 </script>
@@ -13,7 +16,7 @@ const opened = ref(props.defaultOpened);
 <template>
   <legend class="toggle section-heading" @click="opened = !opened">
     <slot name="label"></slot>
-    <span>{{opened ? ' ▼' : ' ▶'}}</span>
+    <span>{{ opened ? " ▼" : " ▶" }}</span>
   </legend>
   <div v-show="opened">
     <slot name="content"></slot>
@@ -22,6 +25,6 @@ const opened = ref(props.defaultOpened);
 
 <style scoped lang="scss">
 .toggle {
-    cursor: pointer;
+  cursor: pointer;
 }
 </style>

--- a/site/frontend/src/pages/compare/tooltip.vue
+++ b/site/frontend/src/pages/compare/tooltip.vue
@@ -1,45 +1,46 @@
 <template>
-<div class="tooltip">?
-  <span class="tooltiptext">
-    <slot></slot>
-  </span>
-</div>
+  <div class="tooltip">
+    ?
+    <span class="tooltiptext">
+      <slot></slot>
+    </span>
+  </div>
 </template>
 
 <style scoped lang="scss">
 .tooltip {
-    position: relative;
-    border-radius: 50%;
-    font-size: 12px;
-    margin: 0 4px;
-    border: 1px solid #7d6969;
-    width: 16px;
-    text-align: center;
-    font-weight: bold;
-    background: #d6d3d3;
-    cursor: pointer;
-    display: inline-block;
+  position: relative;
+  border-radius: 50%;
+  font-size: 12px;
+  margin: 0 4px;
+  border: 1px solid #7d6969;
+  width: 16px;
+  text-align: center;
+  font-weight: bold;
+  background: #d6d3d3;
+  cursor: pointer;
+  display: inline-block;
 }
 
 .tooltip .tooltiptext {
-    width: 180px;
-    visibility: hidden;
-    color: white;
-    background-color: #524d4d;
-    text-align: center;
-    padding: 5px;
-    border-radius: 6px;
+  width: 180px;
+  visibility: hidden;
+  color: white;
+  background-color: #524d4d;
+  text-align: center;
+  padding: 5px;
+  border-radius: 6px;
 
-    position: absolute;
-    bottom: 125%;
-    margin-left: -60px;
+  position: absolute;
+  bottom: 125%;
+  margin-left: -60px;
 
-    opacity: 0;
-    transition: opacity 0.3s, visibility 0.3s;
+  opacity: 0;
+  transition: opacity 0.3s, visibility 0.3s;
 }
 
 .tooltip:hover .tooltiptext {
-    visibility: visible;
-    opacity: 1;
+  visibility: visible;
+  opacity: 1;
 }
 </style>

--- a/site/frontend/src/pages/compare/types.ts
+++ b/site/frontend/src/pages/compare/types.ts
@@ -17,7 +17,7 @@ export interface DataFilter {
   category: {
     primary: boolean;
     secondary: boolean;
-  }
+  };
 }
 
 export type Profile = "check" | "debug" | "opt" | "doc";

--- a/site/frontend/src/pages/dashboard.ts
+++ b/site/frontend/src/pages/dashboard.ts
@@ -4,79 +4,84 @@ import {DASHBOARD_DATA_URL} from "../urls";
 import {getJson} from "../utils/requests";
 
 interface DashboardCases {
-    clean_averages: [number],
-    base_incr_averages: [number],
-    clean_incr_averages: [number],
-    println_incr_averages: [number],
+  clean_averages: [number];
+  base_incr_averages: [number];
+  clean_incr_averages: [number];
+  println_incr_averages: [number];
 }
 
 interface DashboardResponse {
-    Ok: {
-        versions: [string],
-        check: DashboardCases,
-        debug: DashboardCases,
-        opt: DashboardCases,
-        doc: DashboardCases,
-    }
+  Ok: {
+    versions: [string];
+    check: DashboardCases;
+    debug: DashboardCases;
+    opt: DashboardCases;
+    doc: DashboardCases;
+  };
 }
 
 type Profile = "check" | "debug" | "opt" | "doc";
 
-function render(element: string, name: Profile, data: DashboardCases, versions: [string]) {
-    let articles = {"check": "a", "debug": "a", "opt": "an", "doc": "a"};
-    new Highcharts.chart(document.getElementById(element), {
-        chart: {
-            zoomType: "xy",
-            renderTo: document.getElementById(element),
-            type: "line",
-        },
-        title: {
-            text: `Average time for ${articles[name]} ${name} build`,
-        },
-        yAxis: {
-            title: {text: "Seconds"},
-            min: 0,
-        },
-        xAxis: {
-            categories: versions,
-            title: {text: "Version"},
-        },
-        series: [
-            {
-                name: "full",
-                animation: false,
-                data: data.clean_averages,
-            },
-            {
-                name: "incremental full",
-                animation: false,
-                data: data.base_incr_averages,
-            },
-            {
-                name: "incremental unchanged",
-                animation: false,
-                data: data.clean_incr_averages,
-            },
-            {
-                name: "incremental patched: println",
-                animation: false,
-                data: data.println_incr_averages,
-            },
-        ],
-    });
+function render(
+  element: string,
+  name: Profile,
+  data: DashboardCases,
+  versions: [string]
+) {
+  let articles = {check: "a", debug: "a", opt: "an", doc: "a"};
+  new Highcharts.chart(document.getElementById(element), {
+    chart: {
+      zoomType: "xy",
+      renderTo: document.getElementById(element),
+      type: "line",
+    },
+    title: {
+      text: `Average time for ${articles[name]} ${name} build`,
+    },
+    yAxis: {
+      title: {text: "Seconds"},
+      min: 0,
+    },
+    xAxis: {
+      categories: versions,
+      title: {text: "Version"},
+    },
+    series: [
+      {
+        name: "full",
+        animation: false,
+        data: data.clean_averages,
+      },
+      {
+        name: "incremental full",
+        animation: false,
+        data: data.base_incr_averages,
+      },
+      {
+        name: "incremental unchanged",
+        animation: false,
+        data: data.clean_incr_averages,
+      },
+      {
+        name: "incremental patched: println",
+        animation: false,
+        data: data.println_incr_averages,
+      },
+    ],
+  });
 }
 
 function populate_data(response: DashboardResponse) {
-    const data = response.Ok;
-    render("check-average-times", "check", data.check, data.versions);
-    render("debug-average-times", "debug", data.debug, data.versions);
-    render("opt-average-times", "opt", data.opt, data.versions);
-    render("doc-average-times", "doc", data.doc, data.versions);
+  const data = response.Ok;
+  render("check-average-times", "check", data.check, data.versions);
+  render("debug-average-times", "debug", data.debug, data.versions);
+  render("opt-average-times", "opt", data.opt, data.versions);
+  render("doc-average-times", "doc", data.doc, data.versions);
 }
 
 async function make_data() {
-    const response = await getJson<DashboardResponse>(DASHBOARD_DATA_URL);
-    populate_data(response);
+  const response = await getJson<DashboardResponse>(DASHBOARD_DATA_URL);
+  populate_data(response);
 }
 
 make_data();

--- a/site/frontend/src/pages/detailed-query.ts
+++ b/site/frontend/src/pages/detailed-query.ts
@@ -8,7 +8,7 @@ function to_seconds(time) {
 
 function fmt_delta(to, delta, is_integral_delta) {
   let from = to - delta;
-  let pct = (to - from) / from * 100;
+  let pct = ((to - from) / from) * 100;
   if (from == to) {
     pct = 0;
   }
@@ -36,17 +36,22 @@ function fmt_delta(to, delta, is_integral_delta) {
   } else {
     text += `-`.padStart(10, " ");
   }
-  return `<span class="${classes}" title="${from.toFixed(3)} to ${to.toFixed(3)} ≈ ${delta.toFixed(3)}">${text}</span>`;
+  return `<span class="${classes}" title="${from.toFixed(3)} to ${to.toFixed(
+    3
+  )} ≈ ${delta.toFixed(3)}">${text}</span>`;
 }
 
 function populate_data(data, state: Selector) {
-  let txt = `${state.commit.substring(0, 10)}: Self profile results for ${state.benchmark} run ${state.scenario}`;
+  let txt = `${state.commit.substring(0, 10)}: Self profile results for ${
+    state.benchmark
+  } run ${state.scenario}`;
   if (state.base_commit) {
-    let self_href =
-      `/detailed-query.html?sort_idx=${state.sort_idx}&commit=${state.commit}&scenario=${state.scenario}&benchmark=${state.benchmark}`;
-    let base_href =
-      `/detailed-query.html?sort_idx=${state.sort_idx}&commit=${state.base_commit}&scenario=${state.scenario}&benchmark=${state.benchmark}`;
-    txt += `<br>diff vs base ${state.base_commit.substring(0, 10)}, <a href="${base_href}">query info for just base commit</a>`;
+    let self_href = `/detailed-query.html?sort_idx=${state.sort_idx}&commit=${state.commit}&scenario=${state.scenario}&benchmark=${state.benchmark}`;
+    let base_href = `/detailed-query.html?sort_idx=${state.sort_idx}&commit=${state.base_commit}&scenario=${state.scenario}&benchmark=${state.benchmark}`;
+    txt += `<br>diff vs base ${state.base_commit.substring(
+      0,
+      10
+    )}, <a href="${base_href}">query info for just base commit</a>`;
     txt += `<br><a href="${self_href}">query info for just this commit</a>`;
   }
   document.querySelector("#title").innerHTML = txt;
@@ -62,13 +67,16 @@ function populate_data(data, state: Selector) {
     return `<a href="${url}">${ty}</a>`;
   };
   let processed_crox_url = (commit, bench, run) => {
-    let crox_url = window.location.origin + processed_url(commit, bench, run, "crox");
+    let crox_url =
+      window.location.origin + processed_url(commit, bench, run, "crox");
     return encodeURIComponent(crox_url);
   };
   let speedscope_link = (commit, bench, run) => {
     let benchmark_name = `${bench} run ${run}`;
     let crox_url = processed_crox_url(commit, bench, run);
-    let speedscope_url = `https://www.speedscope.app/#profileURL=${crox_url}&title=${encodeURIComponent(benchmark_name)}`;
+    let speedscope_url = `https://www.speedscope.app/#profileURL=${crox_url}&title=${encodeURIComponent(
+      benchmark_name
+    )}`;
     return `<a href="${speedscope_url}">speedscope.app</a>`;
   };
   let firefox_profiler_link = (commit, bench, run) => {
@@ -79,13 +87,32 @@ function populate_data(data, state: Selector) {
   txt = "";
   if (state.base_commit) {
     txt += `Download/view
-                    ${dl_link(state.base_commit, state.benchmark, state.scenario)},
+                    ${dl_link(
+                      state.base_commit,
+                      state.benchmark,
+                      state.scenario
+                    )},
                     ${processed_link(state.base_commit, state, "flamegraph")},
                     ${processed_link(state.base_commit, state, "crox")},
-                    ${processed_link(state.base_commit, state, "codegen-schedule")}
-                    (${speedscope_link(state.base_commit, state.benchmark, state.scenario)},
-                     ${firefox_profiler_link(state.base_commit, state.benchmark, state.scenario)})
-                    results for ${state.base_commit.substring(0, 10)} (base commit)`;
+                    ${processed_link(
+                      state.base_commit,
+                      state,
+                      "codegen-schedule"
+                    )}
+                    (${speedscope_link(
+                      state.base_commit,
+                      state.benchmark,
+                      state.scenario
+                    )},
+                     ${firefox_profiler_link(
+                       state.base_commit,
+                       state.benchmark,
+                       state.scenario
+                     )})
+                    results for ${state.base_commit.substring(
+                      0,
+                      10
+                    )} (base commit)`;
     txt += "<br>";
   }
   txt += `Download/view
@@ -93,38 +120,72 @@ function populate_data(data, state: Selector) {
                 ${processed_link(state.commit, state, "flamegraph")},
                 ${processed_link(state.commit, state, "crox")},
                 ${processed_link(state.commit, state, "codegen-schedule")}
-                (${speedscope_link(state.commit, state.benchmark, state.scenario)},
-                 ${firefox_profiler_link(state.commit, state.benchmark, state.scenario)})
+                (${speedscope_link(
+                  state.commit,
+                  state.benchmark,
+                  state.scenario
+                )},
+                 ${firefox_profiler_link(
+                   state.commit,
+                   state.benchmark,
+                   state.scenario
+                 )})
                 results for ${state.commit.substring(0, 10)} (new commit)`;
-  let profile = b => b.endsWith("-opt") ? "Opt" :
-    b.endsWith("-doc") ? "Doc" :
-      b.endsWith("-debug") ? "Debug" :
-        b.endsWith("-check") ? "Check" : "???";
-  let bench_name = b => b.replace(/-[^-]*$/, "");
-  let scenario_filter = s => s == "full" ? "Full" :
-    s == "incr-full" ? "IncrFull" :
-      s == "incr-unchanged" ? "IncrUnchanged" :
-        s.startsWith("incr-patched") ? "IncrPatched" :
-          "???";
+  let profile = (b) =>
+    b.endsWith("-opt")
+      ? "Opt"
+      : b.endsWith("-doc")
+      ? "Doc"
+      : b.endsWith("-debug")
+      ? "Debug"
+      : b.endsWith("-check")
+      ? "Check"
+      : "???";
+  let bench_name = (b) => b.replace(/-[^-]*$/, "");
+  let scenario_filter = (s) =>
+    s == "full"
+      ? "Full"
+      : s == "incr-full"
+      ? "IncrFull"
+      : s == "incr-unchanged"
+      ? "IncrUnchanged"
+      : s.startsWith("incr-patched")
+      ? "IncrPatched"
+      : "???";
   if (state.base_commit) {
     txt += "<br>";
     txt += `Diff: <a
                         href="/perf/processed-self-profile?commit=${state.commit}&base_commit=${state.base_commit}&benchmark=${state.benchmark}&scenario=${state.scenario}&type=codegen-schedule"
                         >codegen-schedule</a>`;
-    txt += "<br>Local profile (base): <code>" +
+    txt +=
+      "<br>Local profile (base): <code>" +
       `./target/release/collector profile_local cachegrind
-                    +${state.base_commit} --include ${bench_name(state.benchmark)} --profiles
-                ${profile(state.benchmark)} --scenarios ${scenario_filter(state.scenario)}</code>`;
+                    +${state.base_commit} --include ${bench_name(
+        state.benchmark
+      )} --profiles
+                ${profile(state.benchmark)} --scenarios ${scenario_filter(
+        state.scenario
+      )}</code>`;
   }
-  txt += "<br>Local profile (new): <code>" +
+  txt +=
+    "<br>Local profile (new): <code>" +
     `./target/release/collector profile_local cachegrind
-                +${state.commit} --include ${bench_name(state.benchmark)} --profiles
-                ${profile(state.benchmark)} --scenarios ${scenario_filter(state.scenario)}</code>`;
+                +${state.commit} --include ${bench_name(
+      state.benchmark
+    )} --profiles
+                ${profile(state.benchmark)} --scenarios ${scenario_filter(
+      state.scenario
+    )}</code>`;
   if (state.base_commit) {
-    txt += "<br>Local profile (diff): <code>" +
+    txt +=
+      "<br>Local profile (diff): <code>" +
       `./target/release/collector profile_local cachegrind
-                +${state.base_commit} --rustc2 +${state.commit} --include ${bench_name(state.benchmark)} --profiles
-                ${profile(state.benchmark)} --scenarios ${scenario_filter(state.scenario)}</code>`;
+                +${state.base_commit} --rustc2 +${
+        state.commit
+      } --include ${bench_name(state.benchmark)} --profiles
+                ${profile(state.benchmark)} --scenarios ${scenario_filter(
+        state.scenario
+      )}</code>`;
   }
   document.querySelector("#raw-urls").innerHTML = txt;
   let sort_idx = state.sort_idx;
@@ -132,7 +193,7 @@ function populate_data(data, state: Selector) {
     document.body.classList.add("hide-delta");
   }
   let header = document.getElementById("table-header");
-  for (let th of (header.querySelectorAll("th") as any as HTMLElement[])) {
+  for (let th of header.querySelectorAll("th") as any as HTMLElement[]) {
     // Skip non-sortable columns
     if (!th.attributes["data-sort-idx"]) {
       continue;
@@ -158,7 +219,9 @@ function populate_data(data, state: Selector) {
       }
     }
     let inner = th.innerHTML;
-    th.innerHTML = `<a href="${createUrlWithAppendedParams(clickState).toString()}">${inner}</a>`;
+    th.innerHTML = `<a href="${createUrlWithAppendedParams(
+      clickState
+    ).toString()}">${inner}</a>`;
   }
 
   if (!state.scenario.includes("incr-")) {
@@ -193,7 +256,10 @@ function populate_data(data, state: Selector) {
 
     td(row, cur.label);
     if (cur.percent_total_time < 0) {
-      td(row, "-").setAttribute("title", "No wall-time stat collected for this run");
+      td(row, "-").setAttribute(
+        "title",
+        "No wall-time stat collected for this run"
+      );
     } else {
       let t = td(row, cur.percent_total_time.toFixed(2) + "%");
       if (idx == 0) {
@@ -203,26 +269,41 @@ function populate_data(data, state: Selector) {
     }
     td(row, to_seconds(cur.self_time).toFixed(3));
     if (delta) {
-      td(row, fmt_delta(to_seconds(cur.self_time), to_seconds(delta.self_time), false), true);
+      td(
+        row,
+        fmt_delta(
+          to_seconds(cur.self_time),
+          to_seconds(delta.self_time),
+          false
+        ),
+        true
+      );
     } else {
       td(row, "-", true);
     }
     td(row, cur.invocation_count);
     if (delta) {
-      td(row, fmt_delta(cur.invocation_count, delta.invocation_count, true), true);
+      td(
+        row,
+        fmt_delta(cur.invocation_count, delta.invocation_count, true),
+        true
+      );
     } else {
       td(row, "-", true);
     }
-    td(row,
-      to_seconds(cur.incremental_load_time).toFixed(3)).classList.add("incr");
+    td(row, to_seconds(cur.incremental_load_time).toFixed(3)).classList.add(
+      "incr"
+    );
     if (delta) {
-      td(row,
+      td(
+        row,
         fmt_delta(
           to_seconds(cur.incremental_load_time),
           to_seconds(delta.incremental_load_time),
           false
         ),
-        true).classList.add("incr");
+        true
+      ).classList.add("incr");
     } else {
       td(row, "-", true).classList.add("incr");
     }
@@ -244,7 +325,10 @@ function populate_data(data, state: Selector) {
     const label = td(row, element.label);
     label.style.textAlign = "center";
     td(row, element.bytes);
-    if (data.base_profile_delta && data.base_profile_delta.artifact_sizes[idx]) {
+    if (
+      data.base_profile_delta &&
+      data.base_profile_delta.artifact_sizes[idx]
+    ) {
       td(row, data.base_profile_delta.artifact_sizes[idx].bytes);
     }
     artifactTable.appendChild(row);
@@ -273,20 +357,25 @@ function to_object(element) {
       element.number_of_cache_hits,
       element.invocation_count,
       element.blocked_time,
-      element.incremental_load_time
+      element.incremental_load_time,
     ];
   }
   let [
-    label, self_time, percent_total_time, _cache_misses,
-    _cache_hits, invocation_count, _blocked_time,
-    incremental_load_time
+    label,
+    self_time,
+    percent_total_time,
+    _cache_misses,
+    _cache_hits,
+    invocation_count,
+    _blocked_time,
+    incremental_load_time,
   ] = element;
   return {
     label,
     self_time,
     percent_total_time,
     invocation_count,
-    incremental_load_time
+    incremental_load_time,
   };
 }
 
@@ -306,7 +395,7 @@ async function loadData() {
     base_commit: base_commit ?? null,
     benchmark,
     scenario,
-    sort_idx: sort_idx ?? "-2"
+    sort_idx: sort_idx ?? "-2",
   };
 
   const response = await postMsgpack(SELF_PROFILE_DATA_URL, selector);

--- a/site/frontend/src/pages/graphs.ts
+++ b/site/frontend/src/pages/graphs.ts
@@ -3,6 +3,6 @@ import {createApp} from "vue";
 import WithSuspense from "../components/with-suspense.vue";
 
 const app = createApp(WithSuspense, {
-  component: Graphs
+  component: Graphs,
 });
 app.mount("#app");

--- a/site/frontend/src/pages/graphs/data-selector.vue
+++ b/site/frontend/src/pages/graphs/data-selector.vue
@@ -17,7 +17,7 @@ interface Props extends SelectionParams {
 const props = defineProps<Props>();
 
 const emit = defineEmits<{
-  (e: "change", params: SelectionParams): void
+  (e: "change", params: SelectionParams): void;
 }>();
 
 const startRef = ref<HTMLInputElement | null>(null);
@@ -45,16 +45,17 @@ function submitSettings() {
 
 <template>
   <div id="settings">
-    start: <input placeholder="yyyy-mm-dd or commit" ref="startRef" />
-    end: <input placeholder="yyyy-mm-dd or commit" ref="endRef" />
-    Graph kind: <select ref="kindRef">
-    <option value="raw">Raw</option>
-    <option value="percentfromfirst">Percent Delta from First</option>
-    <option value="percentrelative">Percent Delta from Previous</option>
-  </select>
+    start: <input placeholder="yyyy-mm-dd or commit" ref="startRef" /> end:
+    <input placeholder="yyyy-mm-dd or commit" ref="endRef" /> Graph kind:
+    <select ref="kindRef">
+      <option value="raw">Raw</option>
+      <option value="percentfromfirst">Percent Delta from First</option>
+      <option value="percentrelative">Percent Delta from Previous</option>
+    </select>
     <select ref="statRef">
-      <option v-for="value in info.stats" :value="value">{{ value }}
-      </option>
-    </select>&nbsp;<a href="#" @click.prevent="submitSettings">Submit</a>
+      <option v-for="value in info.stats" :value="value">
+        {{ value }}
+      </option></select
+    >&nbsp;<a href="#" @click.prevent="submitSettings">Submit</a>
   </div>
 </template>

--- a/site/frontend/src/pages/graphs/page.vue
+++ b/site/frontend/src/pages/graphs/page.vue
@@ -4,7 +4,11 @@ import {withLoading} from "../../utils/loading";
 import {GraphData, GraphKind, GraphsSelector} from "./state";
 import {GRAPH_DATA_URL} from "../../urls";
 import DataSelector, {SelectionParams} from "./data-selector.vue";
-import {createUrlWithAppendedParams, getUrlParams, navigateToUrlParams} from "../../utils/navigation";
+import {
+  createUrlWithAppendedParams,
+  getUrlParams,
+  navigateToUrlParams,
+} from "../../utils/navigation";
 import {renderPlots} from "./plots";
 import {getJson} from "../../utils/requests";
 import {BenchmarkInfo, loadBenchmarkInfo} from "../../api";
@@ -13,7 +17,7 @@ import AsOf from "../../components/as-of.vue";
 function loadSelectorFromUrl(urlParams: Dict<string>): GraphsSelector {
   const start = urlParams["start"] ?? "";
   const end = urlParams["end"] ?? "";
-  const kind: GraphKind = urlParams["kind"] as GraphKind ?? "raw";
+  const kind: GraphKind = (urlParams["kind"] as GraphKind) ?? "raw";
   const stat = urlParams["stat"] ?? "instructions:u";
   const benchmark = urlParams["benchmark"] ?? null;
   const scenario = urlParams["scenario"] ?? null;
@@ -25,16 +29,20 @@ function loadSelectorFromUrl(urlParams: Dict<string>): GraphsSelector {
     stat,
     benchmark,
     scenario,
-    profile
+    profile,
   };
 }
 
-function filterBenchmarks(data: GraphData, filter: (key: string) => boolean): GraphData {
-  const benchmarks = Object.fromEntries(Object.entries(data.benchmarks)
-    .filter(([key, _]) => filter(key)));
+function filterBenchmarks(
+  data: GraphData,
+  filter: (key: string) => boolean
+): GraphData {
+  const benchmarks = Object.fromEntries(
+    Object.entries(data.benchmarks).filter(([key, _]) => filter(key))
+  );
   return {
     ...data,
-    benchmarks
+    benchmarks,
   };
 }
 
@@ -60,7 +68,7 @@ async function loadGraphData(selector: GraphsSelector, loading: Ref<boolean>) {
       stat: selector.stat,
       benchmark: selector.benchmark,
       scenario: selector.scenario,
-      profile: selector.profile
+      profile: selector.profile,
     };
     return await getJson<GraphData>(GRAPH_DATA_URL, params);
   });
@@ -78,24 +86,31 @@ async function loadGraphData(selector: GraphsSelector, loading: Ref<boolean>) {
     // So, first render everything but the less important benchmarks about artifact sizes.
     // This keeps the grouping and alignment of 4 charts per row where all 4 charts are about a
     // given benchmark. So, we exclude the benchmarks ending in "-tiny".
-    const withoutTiny = filterBenchmarks(graphData, (benchName) => !benchName.endsWith("-tiny"));
+    const withoutTiny = filterBenchmarks(
+      graphData,
+      (benchName) => !benchName.endsWith("-tiny")
+    );
     renderPlots(withoutTiny, selector, "#charts");
 
     // Then, render only the size-related ones in their own dedicated section as they are less
     // important than having the better grouping. So, we only include the benchmarks ending in
     // "-tiny" and render them in the appropriate section.
-    const onlyTiny = filterBenchmarks(graphData, (benchName) => benchName.endsWith("-tiny"));
+    const onlyTiny = filterBenchmarks(graphData, (benchName) =>
+      benchName.endsWith("-tiny")
+    );
     renderPlots(onlyTiny, selector, "#size-charts");
   }
 }
 
 function updateSelection(params: SelectionParams) {
-  navigateToUrlParams(createUrlWithAppendedParams({
-    start: params.start,
-    end: params.end,
-    kind: params.kind,
-    stat: params.stat
-  }).searchParams);
+  navigateToUrlParams(
+    createUrlWithAppendedParams({
+      start: params.start,
+      end: params.end,
+      kind: params.kind,
+      stat: params.stat,
+    }).searchParams
+  );
 }
 
 const info: BenchmarkInfo = await loadBenchmarkInfo();
@@ -107,16 +122,22 @@ loadGraphData(selector, loading);
 </script>
 
 <template>
-  <DataSelector :start="selector.start" :end="selector.end" :kind="selector.kind"
-                :stat="selector.stat" :info="info" @change="updateSelection"></DataSelector>
+  <DataSelector
+    :start="selector.start"
+    :end="selector.end"
+    :kind="selector.kind"
+    :stat="selector.stat"
+    :info="info"
+    @change="updateSelection"
+  ></DataSelector>
   <div>
-    See <a href="/compare.html">compare page</a> for descriptions of what
-    the names mean.
+    See <a href="/compare.html">compare page</a> for descriptions of what the
+    names mean.
   </div>
   <div>
-    <strong>Note:</strong> pink in the graphs represent data points that are interpolated
-    due to missing data. Interpolated data is simply the last known data point repeated until
-    another known data point is found.
+    <strong>Note:</strong> pink in the graphs represent data points that are
+    interpolated due to missing data. Interpolated data is simply the last known
+    data point repeated until another known data point is found.
   </div>
   <div v-if="loading">
     <h2>Loading &amp; rendering data..</h2>
@@ -124,18 +145,29 @@ loadGraphData(selector, loading);
   </div>
   <div v-else>
     <div id="charts"></div>
-    <div v-if="!hasSpecificSelection(selector)"
-         style="margin-top: 50px; border-top: 1px solid #ccc;">
-      <div style="padding: 20px 0"><strong>Benchmarks for artifact sizes</strong></div>
+    <div
+      v-if="!hasSpecificSelection(selector)"
+      style="margin-top: 50px; border-top: 1px solid #ccc"
+    >
+      <div style="padding: 20px 0">
+        <strong>Benchmarks for artifact sizes</strong>
+      </div>
       <div id="size-charts"></div>
     </div>
     <AsOf :info="info" />
   </div>
   <a href="https://github.com/rust-lang-nursery/rustc-perf">
     <img
-      style="position: absolute; top: 0; right: 0; border: 0; clip-path: polygon(8% 0%, 100% 92%, 100% 0%);"
+      style="
+        position: absolute;
+        top: 0;
+        right: 0;
+        border: 0;
+        clip-path: polygon(8% 0%, 100% 92%, 100% 0%);
+      "
       src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67"
       alt="Fork me on GitHub"
-      data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+      data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"
+    />
   </a>
 </template>

--- a/site/frontend/src/pages/graphs/plots.ts
+++ b/site/frontend/src/pages/graphs/plots.ts
@@ -2,339 +2,388 @@ import uPlot, {TypedArray} from "uplot";
 import {GraphData, GraphsSelector} from "./state";
 
 const commonCacheStateColors = {
-    "full": "#7cb5ec",
-    "incr-full": "#434348",
-    "incr-unchanged": "#90ed7d",
-    "incr-patched: println": "#f7a35c",
+  full: "#7cb5ec",
+  "incr-full": "#434348",
+  "incr-unchanged": "#90ed7d",
+  "incr-patched: println": "#f7a35c",
 };
 
-const otherCacheStateColors = ["#8085e9", "#f15c80", "#e4d354", "#2b908f", "#f45b5b", "#91e8e1"];
+const otherCacheStateColors = [
+  "#8085e9",
+  "#f15c80",
+  "#e4d354",
+  "#2b908f",
+  "#f45b5b",
+  "#91e8e1",
+];
 const interpolatedColor = "#fcb0f1";
 const profiles = ["Check", "Debug", "Opt", "Doc"];
 
-function tooltipPlugin({onclick, commits, isInterpolated, absoluteMode, shiftX = 10, shiftY = 10}) {
-    let tooltipLeftOffset = 0;
-    let tooltipTopOffset = 0;
+function tooltipPlugin({
+  onclick,
+  commits,
+  isInterpolated,
+  absoluteMode,
+  shiftX = 10,
+  shiftY = 10,
+}) {
+  let tooltipLeftOffset = 0;
+  let tooltipTopOffset = 0;
 
-    const tooltip = document.createElement("div");
-    tooltip.className = "u-tooltip";
+  const tooltip = document.createElement("div");
+  tooltip.className = "u-tooltip";
 
-    let seriesIdx = null;
-    let dataIdx = null;
+  let seriesIdx = null;
+  let dataIdx = null;
 
-    const fmtDate = uPlot.fmtDate("{M}/{D}/{YY} {h}:{mm}:{ss} {AA}");
+  const fmtDate = uPlot.fmtDate("{M}/{D}/{YY} {h}:{mm}:{ss} {AA}");
 
-    let over;
+  let over;
 
-    let tooltipVisible = false;
+  let tooltipVisible = false;
 
-    function showTooltip() {
-        if (!tooltipVisible) {
-            tooltip.style.display = "block";
-            over.style.cursor = "pointer";
-            tooltipVisible = true;
-        }
+  function showTooltip() {
+    if (!tooltipVisible) {
+      tooltip.style.display = "block";
+      over.style.cursor = "pointer";
+      tooltipVisible = true;
     }
+  }
 
-    function hideTooltip() {
-        if (tooltipVisible) {
-            tooltip.style.display = "none";
-            over.style.cursor = null;
-            tooltipVisible = false;
-        }
+  function hideTooltip() {
+    if (tooltipVisible) {
+      tooltip.style.display = "none";
+      over.style.cursor = null;
+      tooltipVisible = false;
     }
+  }
 
-    function setTooltip(u) {
-        showTooltip();
+  function setTooltip(u) {
+    showTooltip();
 
-        let top = u.valToPos(u.data[seriesIdx][dataIdx], 'y');
-        let lft = u.valToPos(u.data[0][dataIdx], 'x');
+    let top = u.valToPos(u.data[seriesIdx][dataIdx], "y");
+    let lft = u.valToPos(u.data[0][dataIdx], "x");
 
-        tooltip.style.top = (tooltipTopOffset + top + shiftX) + "px";
-        tooltip.style.left = (tooltipLeftOffset + lft + shiftY) + "px";
+    tooltip.style.top = tooltipTopOffset + top + shiftX + "px";
+    tooltip.style.left = tooltipLeftOffset + lft + shiftY + "px";
 
-        tooltip.style.borderColor = isInterpolated(dataIdx) ?
-            interpolatedColor :
-            u.series[seriesIdx].stroke;
+    tooltip.style.borderColor = isInterpolated(dataIdx)
+      ? interpolatedColor
+      : u.series[seriesIdx].stroke;
 
-        let trailer = "";
-        if (absoluteMode) {
-            let pctSinceStart = (((u.data[seriesIdx][dataIdx] - u.data[seriesIdx][0]) / u.data[seriesIdx][0]) * 100).toFixed(2);
-            trailer = uPlot.fmtNum(u.data[seriesIdx][dataIdx]) + " (" +
-                pctSinceStart + "% since start)";
-        } else {
-            trailer = uPlot.fmtNum(u.data[seriesIdx][dataIdx]) + "% since start";
-        }
-        tooltip.textContent = (
-            fmtDate(new Date(u.data[0][dataIdx] * 1e3)) + " - " +
-            commits[dataIdx][1].slice(0, 10) + "\n" + trailer
-        );
+    let trailer = "";
+    if (absoluteMode) {
+      let pctSinceStart = (
+        ((u.data[seriesIdx][dataIdx] - u.data[seriesIdx][0]) /
+          u.data[seriesIdx][0]) *
+        100
+      ).toFixed(2);
+      trailer =
+        uPlot.fmtNum(u.data[seriesIdx][dataIdx]) +
+        " (" +
+        pctSinceStart +
+        "% since start)";
+    } else {
+      trailer = uPlot.fmtNum(u.data[seriesIdx][dataIdx]) + "% since start";
     }
+    tooltip.textContent =
+      fmtDate(new Date(u.data[0][dataIdx] * 1e3)) +
+      " - " +
+      commits[dataIdx][1].slice(0, 10) +
+      "\n" +
+      trailer;
+  }
 
-    return {
-        hooks: {
-            ready: [
-                u => {
-                    over = u.root.querySelector(".u-over");
+  return {
+    hooks: {
+      ready: [
+        (u) => {
+          over = u.root.querySelector(".u-over");
 
-                    tooltipLeftOffset = parseFloat(over.style.left);
-                    tooltipTopOffset = parseFloat(over.style.top);
-                    u.root.querySelector(".u-wrap").appendChild(tooltip);
+          tooltipLeftOffset = parseFloat(over.style.left);
+          tooltipTopOffset = parseFloat(over.style.top);
+          u.root.querySelector(".u-wrap").appendChild(tooltip);
 
-                    let clientX;
-                    let clientY;
+          let clientX;
+          let clientY;
 
-                    over.addEventListener("mousedown", e => {
-                        clientX = e.clientX;
-                        clientY = e.clientY;
-                    });
+          over.addEventListener("mousedown", (e) => {
+            clientX = e.clientX;
+            clientY = e.clientY;
+          });
 
-                    over.addEventListener("mouseup", e => {
-                        // clicked in-place
-                        if (e.clientX == clientX && e.clientY == clientY) {
-                            if (seriesIdx != null && dataIdx != null) {
-                                onclick(u, seriesIdx, dataIdx);
-                            }
-                        }
-                    });
-                }
-            ],
-            setCursor: [
-                u => {
-                    let c = u.cursor;
+          over.addEventListener("mouseup", (e) => {
+            // clicked in-place
+            if (e.clientX == clientX && e.clientY == clientY) {
+              if (seriesIdx != null && dataIdx != null) {
+                onclick(u, seriesIdx, dataIdx);
+              }
+            }
+          });
+        },
+      ],
+      setCursor: [
+        (u) => {
+          let c = u.cursor;
 
-                    if (dataIdx != c.idx) {
-                        dataIdx = c.idx;
+          if (dataIdx != c.idx) {
+            dataIdx = c.idx;
 
-                        if (seriesIdx != null)
-                            setTooltip(u);
-                    }
-                }
-            ],
-            setSeries: [
-                (u, sidx) => {
-                    if (seriesIdx != sidx) {
-                        seriesIdx = sidx;
+            if (seriesIdx != null) setTooltip(u);
+          }
+        },
+      ],
+      setSeries: [
+        (u, sidx) => {
+          if (seriesIdx != sidx) {
+            seriesIdx = sidx;
 
-                        if (sidx == null)
-                            hideTooltip();
-                        else if (dataIdx != null)
-                            setTooltip(u);
-                    }
-                }
-            ],
-        }
-    };
+            if (sidx == null) hideTooltip();
+            else if (dataIdx != null) setTooltip(u);
+          }
+        },
+      ],
+    },
+  };
 }
 
 function genPlotOpts({
-                         title, width, height, yAxisLabel, series, commits,
-                         stat, isInterpolated, alpha = 0.3, prox = 5, absoluteMode
-                     }) {
-    return {
-        title,
-        width,
-        height,
-        series,
-        legend: {
-            live: false,
+  title,
+  width,
+  height,
+  yAxisLabel,
+  series,
+  commits,
+  stat,
+  isInterpolated,
+  alpha = 0.3,
+  prox = 5,
+  absoluteMode,
+}) {
+  return {
+    title,
+    width,
+    height,
+    series,
+    legend: {
+      live: false,
+    },
+    focus: {
+      alpha,
+    },
+    cursor: {
+      focus: {
+        prox,
+      },
+      drag: {
+        x: true,
+        y: true,
+      },
+    },
+    scales: {
+      y: {
+        range: (self, dataMin, dataMax) =>
+          uPlot.rangeNum(absoluteMode ? 0 : dataMin, dataMax, 0.2, true),
+      },
+    },
+    axes: [
+      {
+        grid: {
+          show: false,
         },
-        focus: {
-            alpha,
+      },
+      {
+        label: yAxisLabel,
+        space: 24,
+        values: (self, splits) => {
+          return splits.map((v) => {
+            return v >= 1e12
+              ? v / 1e12 + "T"
+              : v >= 1e9
+              ? v / 1e9 + "G"
+              : v >= 1e6
+              ? v / 1e6 + "M"
+              : v >= 1e3
+              ? v / 1e3 + "k"
+              : v;
+          });
         },
-        cursor: {
-            focus: {
-                prox,
-            },
-            drag: {
-                x: true,
-                y: true,
-            },
-        },
-        scales: {
-            y: {
-                range: (self, dataMin, dataMax) => uPlot.rangeNum(absoluteMode ? 0 : dataMin, dataMax, 0.2, true)
-            }
-        },
-        axes: [
-            {
-                grid: {
-                    show: false,
+      },
+    ],
+    plugins: [
+      {
+        hooks: {
+          drawAxes: [
+            (u) => {
+              let {ctx} = u;
+              let {left, top, width, height} = u.bbox;
+
+              const interpolatedColorWithAlpha = "#fcb0f15f";
+
+              ctx.strokeStyle = interpolatedColorWithAlpha;
+              ctx.beginPath();
+
+              let [i0, i1] = u.series[0].idxs;
+
+              for (let j = i0; j <= i1; j++) {
+                let v = u.data[0][j];
+
+                if (isInterpolated(j)) {
+                  let cx = Math.round(u.valToPos(v, "x", true));
+                  ctx.moveTo(cx, top);
+                  ctx.lineTo(cx, top + height);
                 }
+              }
+
+              ctx.closePath();
+              ctx.stroke();
             },
-            {
-                label: yAxisLabel,
-                space: 24,
-                values: (self, splits) => {
-                    return splits.map(v => {
-                        return (
-                            v >= 1e12 ? v / 1e12 + "T" :
-                                v >= 1e9 ? v / 1e9 + "G" :
-                                    v >= 1e6 ? v / 1e6 + "M" :
-                                        v >= 1e3 ? v / 1e3 + "k" :
-                                            v
-                        );
-                    });
-                },
-            },
-        ],
-        plugins: [
-            {
-                hooks: {
-                    drawAxes: [
-                        u => {
-                            let {ctx} = u;
-                            let {left, top, width, height} = u.bbox;
-
-                            const interpolatedColorWithAlpha = "#fcb0f15f";
-
-                            ctx.strokeStyle = interpolatedColorWithAlpha;
-                            ctx.beginPath();
-
-                            let [i0, i1] = u.series[0].idxs;
-
-                            for (let j = i0; j <= i1; j++) {
-                                let v = u.data[0][j];
-
-                                if (isInterpolated(j)) {
-                                    let cx = Math.round(u.valToPos(v, 'x', true));
-                                    ctx.moveTo(cx, top);
-                                    ctx.lineTo(cx, top + height);
-                                }
-                            }
-
-                            ctx.closePath();
-                            ctx.stroke();
-                        },
-                    ]
-                },
-            },
-            tooltipPlugin({
-                onclick(u, seriesIdx, dataIdx) {
-                    let thisCommit = commits[dataIdx][1];
-                    let prevCommit = (commits[dataIdx - 1] || [null, null])[1];
-                    window.open(`/compare.html?start=${prevCommit}&end=${thisCommit}&stat=${stat}`);
-                },
-                commits,
-                isInterpolated,
-                absoluteMode,
-            }),
-        ],
-    };
+          ],
+        },
+      },
+      tooltipPlugin({
+        onclick(u, seriesIdx, dataIdx) {
+          let thisCommit = commits[dataIdx][1];
+          let prevCommit = (commits[dataIdx - 1] || [null, null])[1];
+          window.open(
+            `/compare.html?start=${prevCommit}&end=${thisCommit}&stat=${stat}`
+          );
+        },
+        commits,
+        isInterpolated,
+        absoluteMode,
+      }),
+    ],
+  };
 }
 
 function normalizeData(data: GraphData) {
-    function optInterpolated(profile) {
-        for (const scenario in profile) {
-            profile[scenario].interpolated_indices = new Set(profile[scenario].interpolated_indices);
-        }
-
-        return profile;
+  function optInterpolated(profile) {
+    for (const scenario in profile) {
+      profile[scenario].interpolated_indices = new Set(
+        profile[scenario].interpolated_indices
+      );
     }
 
-    for (const name of Object.keys(data.benchmarks)) {
-        for (const profile of profiles) {
-            if (data.benchmarks[name].hasOwnProperty(profile)) {
-                data.benchmarks[name][profile.toLowerCase()] = optInterpolated(data.benchmarks[name][profile]);
-                delete data.benchmarks[name][profile];
-            }
-        }
+    return profile;
+  }
+
+  for (const name of Object.keys(data.benchmarks)) {
+    for (const profile of profiles) {
+      if (data.benchmarks[name].hasOwnProperty(profile)) {
+        data.benchmarks[name][profile.toLowerCase()] = optInterpolated(
+          data.benchmarks[name][profile]
+        );
+        delete data.benchmarks[name][profile];
+      }
     }
+  }
 }
 
 // Renders the plots data with the given parameters from the `selector`, into a DOM node optionally
 // selected by the `elementSelector` query.
-export function renderPlots(data: GraphData, selector: GraphsSelector, elementSelector: string) {
-    normalizeData(data);
+export function renderPlots(
+  data: GraphData,
+  selector: GraphsSelector,
+  elementSelector: string
+) {
+  normalizeData(data);
 
-    const names = Object.keys(data.benchmarks).sort();
+  const names = Object.keys(data.benchmarks).sort();
 
-    for (const benchName of names) {
-        let benchKinds = data.benchmarks[benchName];
+  for (const benchName of names) {
+    let benchKinds = data.benchmarks[benchName];
 
-        let i = 0;
+    let i = 0;
 
-        for (let benchKind in benchKinds) {
-            let cacheStates = benchKinds[benchKind];
-            let cacheStateNames = Object.keys(cacheStates);
-            cacheStateNames.sort();
+    for (let benchKind in benchKinds) {
+      let cacheStates = benchKinds[benchKind];
+      let cacheStateNames = Object.keys(cacheStates);
+      cacheStateNames.sort();
 
-            let yAxis = selector.stat;
-            let yAxisUnit = null;
-            if (selector.stat == "instructions:u") {
-                yAxis = "CPU instructions";
-                yAxisUnit = "count";
-            } else if (selector.stat == "cycles:u") {
-                yAxis = "CPU cycles";
-                yAxisUnit = "count";
-            } else if (selector.stat == "cpu-clock") {
-                yAxis = "CPU clock";
-                yAxisUnit = "seconds";
-            } else if (selector.stat == "task-clock") {
-                yAxis = "Task clock";
-                yAxisUnit = "seconds";
-            } else if (selector.stat == "wall-time") {
-                yAxis = "Wall time";
-                yAxisUnit = "seconds";
-            } else if (selector.stat == "max-rss") {
-                yAxis = "Maximum resident set size";
-                yAxisUnit = "kB";
-            } else if (selector.stat == "faults") {
-                yAxis = "Faults";
-                yAxisUnit = "count";
-            }
+      let yAxis = selector.stat;
+      let yAxisUnit = null;
+      if (selector.stat == "instructions:u") {
+        yAxis = "CPU instructions";
+        yAxisUnit = "count";
+      } else if (selector.stat == "cycles:u") {
+        yAxis = "CPU cycles";
+        yAxisUnit = "count";
+      } else if (selector.stat == "cpu-clock") {
+        yAxis = "CPU clock";
+        yAxisUnit = "seconds";
+      } else if (selector.stat == "task-clock") {
+        yAxis = "Task clock";
+        yAxisUnit = "seconds";
+      } else if (selector.stat == "wall-time") {
+        yAxis = "Wall time";
+        yAxisUnit = "seconds";
+      } else if (selector.stat == "max-rss") {
+        yAxis = "Maximum resident set size";
+        yAxisUnit = "kB";
+      } else if (selector.stat == "faults") {
+        yAxis = "Faults";
+        yAxisUnit = "count";
+      }
 
-            if (selector.kind == "raw" && benchName == "Summary") {
-                yAxisUnit = "relative";
-            } else if (selector.kind == "percentfromfirst") {
-                yAxisUnit = "% change from first";
-            } else if (selector.kind == "percentrelative") {
-                yAxisUnit = "% change from previous";
-            }
+      if (selector.kind == "raw" && benchName == "Summary") {
+        yAxisUnit = "relative";
+      } else if (selector.kind == "percentfromfirst") {
+        yAxisUnit = "% change from first";
+      } else if (selector.kind == "percentrelative") {
+        yAxisUnit = "% change from previous";
+      }
 
-            yAxis = yAxisUnit ? `${yAxis} (${yAxisUnit})` : yAxis;
-            let yAxisLabel = i == 0 ? yAxis : null;
+      yAxis = yAxisUnit ? `${yAxis} (${yAxisUnit})` : yAxis;
+      let yAxisLabel = i == 0 ? yAxis : null;
 
-            let seriesOpts = [{}];
+      let seriesOpts = [{}];
 
-            let xVals = data.commits.map(c => c[0]);
+      let xVals = data.commits.map((c) => c[0]);
 
-            let plotData = [xVals];
+      let plotData = [xVals];
 
-            let otherColorIdx = 0;
+      let otherColorIdx = 0;
 
-            for (let cacheState of cacheStateNames) {
-                let yVals = cacheStates[cacheState].points;
-                let color = commonCacheStateColors[cacheState] || otherCacheStateColors[otherColorIdx++];
+      for (let cacheState of cacheStateNames) {
+        let yVals = cacheStates[cacheState].points;
+        let color =
+          commonCacheStateColors[cacheState] ||
+          otherCacheStateColors[otherColorIdx++];
 
-                plotData.push(yVals);
+        plotData.push(yVals);
 
-                seriesOpts.push({
-                    label: cacheState,
-                    width: devicePixelRatio,
-                    stroke: color
-                });
-            }
+        seriesOpts.push({
+          label: cacheState,
+          width: devicePixelRatio,
+          stroke: color,
+        });
+      }
 
-            let indices = cacheStates[Object.keys(cacheStates)[0]].interpolated_indices;
+      let indices =
+        cacheStates[Object.keys(cacheStates)[0]].interpolated_indices;
 
-            let plotOpts = genPlotOpts({
-                title: benchName + "-" + benchKind,
-                width: Math.floor(window.innerWidth / 4) - 40,
-                height: 300,
-                yAxisLabel,
-                series: seriesOpts,
-                commits: data.commits,
-                stat: selector.stat,
-                isInterpolated(dataIdx) {
-                    return indices.has(dataIdx);
-                },
-                absoluteMode: selector.kind == "raw",
-            });
+      let plotOpts = genPlotOpts({
+        title: benchName + "-" + benchKind,
+        width: Math.floor(window.innerWidth / 4) - 40,
+        height: 300,
+        yAxisLabel,
+        series: seriesOpts,
+        commits: data.commits,
+        stat: selector.stat,
+        isInterpolated(dataIdx) {
+          return indices.has(dataIdx);
+        },
+        absoluteMode: selector.kind == "raw",
+      });
 
-            new uPlot(plotOpts, plotData as any as TypedArray[], document.querySelector<HTMLElement>(elementSelector));
+      new uPlot(
+        plotOpts,
+        plotData as any as TypedArray[],
+        document.querySelector<HTMLElement>(elementSelector)
+      );
 
-            i++;
-        }
+      i++;
     }
+  }
 }

--- a/site/frontend/src/pages/graphs/state.ts
+++ b/site/frontend/src/pages/graphs/state.ts
@@ -2,22 +2,22 @@ export type GraphKind = "raw" | "percentfromfirst" | "percentrelative";
 
 // Parameters used to filter graph data
 export interface GraphsSelector {
-    start: string;
-    end: string;
-    kind: GraphKind;
-    stat: string;
-    benchmark: string | null;
-    scenario: string | null;
-    profile: string | null;
+  start: string;
+  end: string;
+  kind: GraphKind;
+  stat: string;
+  benchmark: string | null;
+  scenario: string | null;
+  profile: string | null;
 }
 
 export interface Series {
-    points: [number],
-    interpolated_indices: Set<number>
+  points: [number];
+  interpolated_indices: Set<number>;
 }
 
 // Graph data received from the server
 export interface GraphData {
-    commits: [[number, string]],
-    benchmarks: Dict<Dict<Dict<Series>>>,
+  commits: [[number, string]];
+  benchmarks: Dict<Dict<Dict<Series>>>;
 }

--- a/site/frontend/src/pages/status.ts
+++ b/site/frontend/src/pages/status.ts
@@ -3,21 +3,21 @@ import {STATUS_DATA_URL} from "../urls";
 import {getJson} from "../utils/requests";
 
 interface Commit {
-    sha: string;
-    date: string;
-    type: "Try" | "Master";
+  sha: string;
+  date: string;
+  type: "Try" | "Master";
 }
 
 interface BenchmarkStatus {
-    name: string;
-    error: string;
+  name: string;
+  error: string;
 }
 
 interface Step {
-    step: string;
-    is_done: boolean;
-    expected_duration: number;
-    current_progress: number;
+  step: string;
+  is_done: boolean;
+  expected_duration: number;
+  current_progress: number;
 }
 
 /**
@@ -26,185 +26,203 @@ interface Step {
  * TS).
  */
 interface CurrentState {
-    artifact: any;
-    progress: [Step];
+  artifact: any;
+  progress: [Step];
 }
 
 interface StatusResponse {
-    last_commit: Commit | null
-    benchmarks: [BenchmarkStatus],
-    missing: [[Commit, any]],
-    current: CurrentState | null,
-    most_recent_end: number | null,
+  last_commit: Commit | null;
+  benchmarks: [BenchmarkStatus];
+  missing: [[Commit, any]];
+  current: CurrentState | null;
+  most_recent_end: number | null;
 }
 
 function populate_data(data: StatusResponse) {
-    let state_div = document.querySelector("#benchmark-state");
-    if (data.last_commit !== null) {
-        let element = document.createElement("p");
-        element.innerHTML = `SHA: ${data.last_commit.sha}, date: ${data.last_commit.date}`;
-        state_div.appendChild(element);
-    }
-    for (let benchmark of data.benchmarks) {
-        let element = document.createElement("div");
-        element.innerHTML = `<details open>
+  let state_div = document.querySelector("#benchmark-state");
+  if (data.last_commit !== null) {
+    let element = document.createElement("p");
+    element.innerHTML = `SHA: ${data.last_commit.sha}, date: ${data.last_commit.date}`;
+    state_div.appendChild(element);
+  }
+  for (let benchmark of data.benchmarks) {
+    let element = document.createElement("div");
+    element.innerHTML = `<details open>
                     <summary>${benchmark.name} - error</summary>
                     <pre class="benchmark-error"></pre>
                 </details>`;
-        element.querySelector<HTMLElement>(".benchmark-error").innerText = benchmark.error;
-        state_div.appendChild(element);
-    }
-    let missing_div = document.querySelector("#data-insert-js");
-    if (data.current !== null) {
-        let table = document.createElement("table");
-        let tr = document.createElement("tr");
-        let th = document.createElement("th");
-        th.innerText = "Step";
-        tr.appendChild(th);
-        th = document.createElement("th");
-        tr.appendChild(th);
-        th = document.createElement("th");
-        th.innerText = "Took";
-        tr.appendChild(th);
-        th = document.createElement("th");
-        th.innerText = "Expected";
-        tr.appendChild(th);
-        table.appendChild(tr);
-
-        let left = 0;
-        for (let step of data.current.progress) {
-            let tr = document.createElement("tr");
-            let td = document.createElement("td");
-            td.innerText = step.step;
-            tr.appendChild(td);
-            td = document.createElement("td");
-            let progress = document.createElement("progress");
-            progress.setAttribute("max", step.expected_duration.toString());
-            progress.setAttribute("value", (step.is_done ? step.expected_duration : step.current_progress).toString());
-            td.appendChild(progress);
-            tr.appendChild(td);
-            td = document.createElement("td");
-            td.innerHTML = step.current_progress == 0 ? "" :
-                format_duration(step.current_progress);
-            td.style.textAlign = "right";
-            tr.appendChild(td);
-            td = document.createElement("td");
-            td.innerHTML = format_duration(step.expected_duration);
-            td.style.textAlign = "right";
-            tr.appendChild(td);
-            if (!step.is_done) {
-                left += step.expected_duration - step.current_progress;
-            }
-            table.appendChild(tr);
-        }
-        let element = document.createElement("p");
-        let artifact_desc = "";
-        if (data.current.artifact.Commit) {
-            artifact_desc = commit_url(data.current.artifact.Commit);
-        } else {
-            artifact_desc = data.current.artifact.Tag;
-        }
-        element.innerHTML = `Currently benchmarking: ${artifact_desc}.
-                <br>Time left: ${format_duration(left)}`;
-        missing_div.appendChild(element);
-        missing_div.appendChild(table);
-    } else {
-        let element = document.createElement("p");
-        if (data.most_recent_end) {
-            let end = new Date(data.most_recent_end * 1000);
-            element.innerHTML = `No current collection in progress. Last one
-                    finished at ${end.toLocaleString()} local time,
-                    ${format_duration(Math.trunc((Date.now() - end.getTime()) / 1000))} ago.`;
-        } else {
-            element.innerHTML = "No current collection in progress.";
-        }
-        missing_div.appendChild(element);
-    }
-    {
-        let element = document.createElement("p");
-        element.innerHTML = `Queue (${data.missing.length} total):<br> Times are local.`;
-        missing_div.appendChild(element);
-    }
+    element.querySelector<HTMLElement>(".benchmark-error").innerText =
+      benchmark.error;
+    state_div.appendChild(element);
+  }
+  let missing_div = document.querySelector("#data-insert-js");
+  if (data.current !== null) {
     let table = document.createElement("table");
-    table.id = "missing-commits";
-    {
-        let row = document.createElement("tr");
-        row.innerHTML = `<th>Commit Date</th><th>SHA</th><th>Reason</th>`;
-        table.appendChild(row);
+    let tr = document.createElement("tr");
+    let th = document.createElement("th");
+    th.innerText = "Step";
+    tr.appendChild(th);
+    th = document.createElement("th");
+    tr.appendChild(th);
+    th = document.createElement("th");
+    th.innerText = "Took";
+    tr.appendChild(th);
+    th = document.createElement("th");
+    th.innerText = "Expected";
+    tr.appendChild(th);
+    table.appendChild(tr);
+
+    let left = 0;
+    for (let step of data.current.progress) {
+      let tr = document.createElement("tr");
+      let td = document.createElement("td");
+      td.innerText = step.step;
+      tr.appendChild(td);
+      td = document.createElement("td");
+      let progress = document.createElement("progress");
+      progress.setAttribute("max", step.expected_duration.toString());
+      progress.setAttribute(
+        "value",
+        (step.is_done
+          ? step.expected_duration
+          : step.current_progress
+        ).toString()
+      );
+      td.appendChild(progress);
+      tr.appendChild(td);
+      td = document.createElement("td");
+      td.innerHTML =
+        step.current_progress == 0
+          ? ""
+          : format_duration(step.current_progress);
+      td.style.textAlign = "right";
+      tr.appendChild(td);
+      td = document.createElement("td");
+      td.innerHTML = format_duration(step.expected_duration);
+      td.style.textAlign = "right";
+      tr.appendChild(td);
+      if (!step.is_done) {
+        left += step.expected_duration - step.current_progress;
+      }
+      table.appendChild(tr);
     }
-    for (let [commit, reason] of data.missing) {
-        let row = document.createElement("tr");
-        {
-            let date = new Date(commit.date);
-            let element = document.createElement("td");
-            if (date.getUTCFullYear() == 2001) {
-                element.innerHTML = "try commit";
-                element.style.textAlign = "center";
-            } else {
-                element.innerHTML = new Date(commit.date).toLocaleString();
-            }
-            row.appendChild(element);
-        }
-        {
-            let element = document.createElement("td");
-            element.innerHTML = commit_url(commit);
-            row.appendChild(element);
-        }
-        {
-            let element = document.createElement("td");
-            element.innerHTML = reason_to_string(reason);
-            row.appendChild(element);
-        }
-        table.appendChild(row);
+    let element = document.createElement("p");
+    let artifact_desc = "";
+    if (data.current.artifact.Commit) {
+      artifact_desc = commit_url(data.current.artifact.Commit);
+    } else {
+      artifact_desc = data.current.artifact.Tag;
     }
+    element.innerHTML = `Currently benchmarking: ${artifact_desc}.
+                <br>Time left: ${format_duration(left)}`;
+    missing_div.appendChild(element);
     missing_div.appendChild(table);
+  } else {
+    let element = document.createElement("p");
+    if (data.most_recent_end) {
+      let end = new Date(data.most_recent_end * 1000);
+      element.innerHTML = `No current collection in progress. Last one
+                    finished at ${end.toLocaleString()} local time,
+                    ${format_duration(
+                      Math.trunc((Date.now() - end.getTime()) / 1000)
+                    )} ago.`;
+    } else {
+      element.innerHTML = "No current collection in progress.";
+    }
+    missing_div.appendChild(element);
+  }
+  {
+    let element = document.createElement("p");
+    element.innerHTML = `Queue (${data.missing.length} total):<br> Times are local.`;
+    missing_div.appendChild(element);
+  }
+  let table = document.createElement("table");
+  table.id = "missing-commits";
+  {
+    let row = document.createElement("tr");
+    row.innerHTML = `<th>Commit Date</th><th>SHA</th><th>Reason</th>`;
+    table.appendChild(row);
+  }
+  for (let [commit, reason] of data.missing) {
+    let row = document.createElement("tr");
+    {
+      let date = new Date(commit.date);
+      let element = document.createElement("td");
+      if (date.getUTCFullYear() == 2001) {
+        element.innerHTML = "try commit";
+        element.style.textAlign = "center";
+      } else {
+        element.innerHTML = new Date(commit.date).toLocaleString();
+      }
+      row.appendChild(element);
+    }
+    {
+      let element = document.createElement("td");
+      element.innerHTML = commit_url(commit);
+      row.appendChild(element);
+    }
+    {
+      let element = document.createElement("td");
+      element.innerHTML = reason_to_string(reason);
+      row.appendChild(element);
+    }
+    table.appendChild(row);
+  }
+  missing_div.appendChild(table);
 }
 
 function reason_to_string(reason) {
-    if (typeof reason == 'string') {
-        return reason;
-    } else if (reason.InProgress) {
-        return `${reason_to_string(reason.InProgress)} - in progress`;
-    } else if (reason["Master"] != undefined && reason.Master.pr) {
-        return `<a href="https://github.com/rust-lang/rust/pull/${reason["Master"].pr}">
-                    #${reason["Master"].pr}</a>${reason.Master.is_try_parent ? " - Try commit parent" : ""
-        }`;
-    } else if (reason["Master"] != undefined && reason.Master.pr == 0) {
-        return "Master";
-    } else if (reason["Try"] != undefined && reason.Try.pr) {
-        return `
+  if (typeof reason == "string") {
+    return reason;
+  } else if (reason.InProgress) {
+    return `${reason_to_string(reason.InProgress)} - in progress`;
+  } else if (reason["Master"] != undefined && reason.Master.pr) {
+    return `<a href="https://github.com/rust-lang/rust/pull/${
+      reason["Master"].pr
+    }">
+                    #${reason["Master"].pr}</a>${
+      reason.Master.is_try_parent ? " - Try commit parent" : ""
+    }`;
+  } else if (reason["Master"] != undefined && reason.Master.pr == 0) {
+    return "Master";
+  } else if (reason["Try"] != undefined && reason.Try.pr) {
+    return `
                 Try for
                 <a href="https://github.com/rust-lang/rust/pull/${reason["Try"].pr}">
                     #${reason["Try"].pr}
                 </a>`;
-    } else {
-        // Should never happen, but a good fallback
-        return JSON.stringify(reason);
-    }
+  } else {
+    // Should never happen, but a good fallback
+    return JSON.stringify(reason);
+  }
 }
 
 function commit_url(commit) {
-    return `<a href="https://github.com/rust-lang/rust/commit/${commit.sha}">${commit.sha.substr(0, 13)}</a>`;
+  return `<a href="https://github.com/rust-lang/rust/commit/${
+    commit.sha
+  }">${commit.sha.substr(0, 13)}</a>`;
 }
 
 function format_duration(seconds) {
-    let secs = seconds % 60;
-    let mins = Math.trunc(seconds / 60);
-    let hours = Math.trunc(mins / 60);
-    mins -= hours * 60;
+  let secs = seconds % 60;
+  let mins = Math.trunc(seconds / 60);
+  let hours = Math.trunc(mins / 60);
+  mins -= hours * 60;
 
-    let s = "";
-    if (hours > 0) {
-        s = `${hours}h${mins < 10 ? "0" + mins : mins}m${secs < 10 ? "0" + secs : secs}s`;
-    } else {
-        s = `${mins < 10 ? " " + mins : mins}m${secs < 10 ? "0" + secs : secs}s`;
-    }
-    return s;
+  let s = "";
+  if (hours > 0) {
+    s = `${hours}h${mins < 10 ? "0" + mins : mins}m${
+      secs < 10 ? "0" + secs : secs
+    }s`;
+  } else {
+    s = `${mins < 10 ? " " + mins : mins}m${secs < 10 ? "0" + secs : secs}s`;
+  }
+  return s;
 }
 
 async function make_data() {
-    const response = await getJson<StatusResponse>(STATUS_DATA_URL);
-    populate_data(response);
+  const response = await getJson<StatusResponse>(STATUS_DATA_URL);
+  populate_data(response);
 }
 
 make_data();

--- a/site/frontend/src/typings/vue.ts
+++ b/site/frontend/src/typings/vue.ts
@@ -1,5 +1,5 @@
 declare module "*.vue";
 
 interface Dict<T> {
-    [key: string]: T;
+  [key: string]: T;
 }

--- a/site/frontend/src/utils/loading.ts
+++ b/site/frontend/src/utils/loading.ts
@@ -3,11 +3,14 @@ import {Ref} from "vue";
 /**
  * Manages a loading variable for an asynchronous function.
  */
-export async function withLoading<T>(loading: Ref<boolean>, callback: () => Promise<T>): Promise<T> {
-    loading.value = true;
-    try {
-        return await callback();
-    } finally {
-        loading.value = false;
-    }
+export async function withLoading<T>(
+  loading: Ref<boolean>,
+  callback: () => Promise<T>
+): Promise<T> {
+  loading.value = true;
+  try {
+    return await callback();
+  } finally {
+    loading.value = false;
+  }
 }

--- a/site/frontend/src/utils/navigation.ts
+++ b/site/frontend/src/utils/navigation.ts
@@ -3,42 +3,42 @@
  * the passed parameters to the URL.
  */
 export function createUrlWithAppendedParams(params: Dict<any>): URL {
-    const originalUrl = window.location.toString();
-    const url = new URL(originalUrl);
-    for (const [key, value] of Object.entries(params)) {
-        if (value !== null && value !== undefined) {
-            const stringified = value.toString();
-            if (stringified !== "") {
-                url.searchParams.set(key, stringified);
-            }
-        }
+  const originalUrl = window.location.toString();
+  const url = new URL(originalUrl);
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== null && value !== undefined) {
+      const stringified = value.toString();
+      if (stringified !== "") {
+        url.searchParams.set(key, stringified);
+      }
     }
-    return url;
+  }
+  return url;
 }
 
 /**
  * Creates a URL with the current window location and the passed parameters.
  */
 export function createUrlFromParams(params: Dict<string>): URL {
-    const url = new URL(window.location.toString());
-    const searchParams = new URLSearchParams();
-    for (const [key, value] of Object.entries(params)) {
-        searchParams.set(key, value);
-    }
-    url.search = searchParams.toString();
-    return url;
+  const url = new URL(window.location.toString());
+  const searchParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    searchParams.set(key, value);
+  }
+  url.search = searchParams.toString();
+  return url;
 }
 
 export function getUrlParams(): Dict<string> {
-    const url = new URL(window.location.toString());
+  const url = new URL(window.location.toString());
 
-    const params = {};
-    url.searchParams.forEach((value, key) => {
-        params[key] = value;
-    });
-    return params;
+  const params = {};
+  url.searchParams.forEach((value, key) => {
+    params[key] = value;
+  });
+  return params;
 }
 
 export function navigateToUrlParams(params: URLSearchParams) {
-    window.location.search = params.toString();
+  window.location.search = params.toString();
 }

--- a/site/frontend/src/utils/requests.ts
+++ b/site/frontend/src/utils/requests.ts
@@ -3,12 +3,15 @@ import {decode} from "msgpack-lite";
 export async function postJson<T>(path: string, body: any): Promise<T> {
   const response = await fetch(path, {
     method: "POST",
-    body: JSON.stringify(body)
+    body: JSON.stringify(body),
   });
   return await response.json();
 }
 
-export async function getJson<T>(path: string, params: Dict<string> = {}): Promise<T> {
+export async function getJson<T>(
+  path: string,
+  params: Dict<string> = {}
+): Promise<T> {
   let url = path;
 
   if (Object.keys(params).length > 0) {
@@ -29,7 +32,7 @@ export async function postMsgpack(path: string, body: any) {
   const response = await fetch(path, {
     method: "POST",
     body: JSON.stringify(body),
-    mode: "cors"
+    mode: "cors",
   });
   if (response.ok) {
     const buffer = await response.clone().arrayBuffer();


### PR DESCRIPTION
I wanted to use 2 spaces for Vue templates (HTML) and 4 for everything else, but prettier [doesn't support that](https://github.com/prettier/prettier/issues/14755), so I just kept two spaces for everything. Formatting is now also checked in CI.