### PR TITLE
Fix `cg_diff --mod-filename` regex.

### DIFF
--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -314,7 +314,7 @@ fn cg_diff(cgout1: &Path, cgout2: &Path, path: &Path) -> anyhow::Result<()> {
         anyhow::bail!("`cg_diff` not installed.");
     }
     let output = Command::new("cg_diff")
-        .arg("--mod-filename=s#/rustc/[^/]*/##")
+        .arg(r"--mod-filename=s/\/rustc\/[^\/]*\///")
         .arg("--mod-funcname=s/[.]llvm[.].*//")
         .arg(cgout1)
         .arg(cgout2)


### PR DESCRIPTION
In Valgrind 3.21 `cg_diff` was rewritten, and it's no longer possible to use separators other than `/` in the command line regexes.