### PR TITLE
Remove the now-unused ctfe step limit from the ctfe stress test

### DIFF
--- a/collector/compile-benchmarks/ctfe-stress-5/src/lib.rs
+++ b/collector/compile-benchmarks/ctfe-stress-5/src/lib.rs
@@ -1,6 +1,4 @@
 #![allow(dead_code)]
-#![feature(const_eval_limit)]
-#![const_eval_limit = "10000000"]
 use std::mem::MaybeUninit;
 
 // Try to make CTFE actually do a lot of computation, without producing a big result.


### PR DESCRIPTION
This does not affect perf, it only affects whether the test builds at all. https://github.com/rust-lang/rust/pull/103877 wants to remove those limites entirely, so we first need to remove the (unstable) attribute here, in order to be able to perf test (and subsequently land) that PR