### PR TITLE
Update stale website build instructions in README

### DIFF
--- a/collector/README.md
+++ b/collector/README.md
@@ -169,11 +169,10 @@ the relevant rustc executables.
 
 ### How to view the measurements on your own machine
 
-Once the benchmarks have been run, start the website:
-```
-./target/release/site <DATABASE>
-```
-wait for the "Loading complete" message to be printed, and then visit
+Once the benchmarks have been run, build and start the website.
+You can find instructions on how to do that [here](../site/README.md).
+
+Wait for the "Loading complete" message to be printed, and then visit
 `localhost:2346/compare.html` in a web browser.
 
 Enter the IDs for two runs in the "Commit/Date A" and "Commit/Date B" text

--- a/collector/compile-benchmarks/README.md
+++ b/collector/compile-benchmarks/README.md
@@ -222,6 +222,7 @@ Rust code being written today.
       --profiles=Check,Debug,Opt --scenarios=Full --include=$NEW,helloworld
     target/release/site results.db
     ```
+    (See [here](../../site/README.md) for instructions on how to build the website).
     Then switch to wall-times, compare `Test` against itself, and toggle the
     "Show non-relevant results"/"Display raw data" check boxes to make sure it
     hasn't changed drastically.


### PR DESCRIPTION
They now points to the `site` README, to keep them updated in the future.

Noticed in https://github.com/rust-lang/rustc-perf/issues/1597.