### PR TITLE
Embed information about stable benchmarks into the `site` binary

### DIFF
--- a/collector/src/benchmark/mod.rs
+++ b/collector/src/benchmark/mod.rs
@@ -24,7 +24,7 @@ fn default_runs() -> usize {
 /// This is the internal representation of an individual benchmark's
 /// perf-config.json file.
 #[derive(Debug, Clone, serde::Deserialize)]
-struct BenchmarkConfig {
+pub struct BenchmarkConfig {
     cargo_opts: Option<String>,
     cargo_rustc_opts: Option<String>,
     cargo_toml: Option<String>,
@@ -51,6 +51,12 @@ struct BenchmarkConfig {
     /// They will be ignored during benchmarking.
     #[serde(default)]
     excluded_scenarios: HashSet<Scenario>,
+}
+
+impl BenchmarkConfig {
+    pub fn category(&self) -> Category {
+        self.category
+    }
 }
 
 #[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Hash)]


### PR DESCRIPTION
This fixes a long-standing FIXME, where the list of stable benchmarks was hard-coded, rather than being loaded from the filesystem. I checked that it doesn't regress compile times too much, in release it was basically the same, in debug it was ~1s slower. It adds about ~50 KiB to the release binary size after stripping.