### PR TITLE
Update database and glossary documentation

### DIFF
--- a/database/schema.md
+++ b/database/schema.md
@@ -65,6 +65,8 @@ id          name        date        type
 
 A "collection" of benchmarks tied only differing by the statistic collected.
 
+This corresponds to a [`test result`](../docs/glossary.md#testing).
+
 This is a way to collect statistics together signifying that they belong to the same logical benchmark run.
 
 Currently, the collection also marks the git sha of the currently running collector binary.
@@ -124,6 +126,8 @@ of a crate, profile, scenario and the metric being collected.
 * profile: what type of compilation is happening - check build, optimized build (a.k.a. release build), debug build, or doc build.
 * cache (aka `scenario`): describes how much of the incremental cache is full. An empty incremental cache means that the compiler must do a full build.
 * statistic (aka `metric`): the type of metric being collected
+
+This corresponds to a [`statistic description`](../docs/glossary.md).
 
 There is a separate table for this collection to avoid duplicating crates, prfiles, scenarios etc.
 many times in the `pstat` table.

--- a/database/schema.md
+++ b/database/schema.md
@@ -2,18 +2,19 @@
 
 Below is an explanation of the current database schema. This schema is duplicated across the (currently) two database backends we support: sqlite and postgres.
 
-
 ## Overview
 
 In general, the database is used to track three groups of things:
-* Performance run statistics (e.g., instruction count) on a per benchmark, profile, and cache-state basis.
+* Performance run statistics (e.g., instruction count) for compile time benchmarks on a per benchmark, profile, and scenario basis.
+* Performance run statistics (e.g., instruction count) for runtime benchmarks on a per benchmark basis.
 * Self profile data gathered with `-Zself-profile`.
-* State when running GitHub bots and the performance runs (e.g., how long it took for a performance suite to run, errors encountered a long the way, etc.)
+* State when running GitHub bots and the performance runs (e.g., how long it took for a performance suite to run, errors encountered along the way, etc.)
 
 Below are some diagrams showing the basic layout of the database schema for these three uses:
 
 ### Performance run statistics
 
+Here is the diagram for compile-time benchmarks:
 ```
   ┌────────────┐  ┌───────────────┐  ┌────────────┐   
   │ benchmark  │  │ collection    │  │ artifact   │
@@ -36,111 +37,43 @@ Below are some diagrams showing the basic layout of the database schema for thes
   └───────────────┘  └──────────┘
 ```
 
-### Self profile data
-
-**TODO**
-
-### Miscellaneous State
-
-**TODO**
+For runtime benchmarks the schema very similar, but there are different table names:
+- `benchmark` => `runtime_benchmark`
+- `pstat` => `runtime_pstat`
+- `pstat_series` => `runtime_pstat_series`
+  - There are different attributes here, `benchmark` and `metric`.
 
 ## Tables
 
-### benchmark
-
-The different types of benchmarks that are run. 
-
-The table stores the name of the benchmark as well as whether it is capable of being run using the stable compiler.  The benchmark name is used as a foreign key in many of the other tables. 
-
-```
-sqlite> select * from benchmark limit 1;
-name        stabilized
-----------  ----------
-helloworld  0   
-```
-
 ### artifact
 
-A description of a rustc compiler artifact being benchmarked. 
+A description of a rustc compiler artifact being benchmarked.
 
 This description includes:
 * name: usually a commit sha or a tag like "1.51.0" but is free-form text so can be anything.
-* date: the date associated with this compiler artifact (usually only when the name is a commit) 
+* date: the date associated with this compiler artifact (usually only when the name is a commit)
 * type: currently one of "master" (i.e., we're testing a merge commit), "try" (someone is testing a PR), and "release" (usually a release candidate - though local compilers also get labeled like this).
 
 ```
 sqlite> select * from artifact limit 1;
-id          name        date        type      
-----------  ----------  ----------  ----------
-1           LOCAL_TEST              release  
+id          name        date        type   
+----------  ----------  ----------  -------
+1           LOCAL_TEST              release
 ```
 
 ### collection
 
 A "collection" of benchmarks tied only differing by the statistic collected.
 
-This is a way to collect statistics together signifying that they belong to the same logical benchmark run. 
+This is a way to collect statistics together signifying that they belong to the same logical benchmark run.
 
-Currently the collection also marks the git sha of the currently running collector binary.
+Currently, the collection also marks the git sha of the currently running collector binary.
 
 ```
 sqlite> select * from collection limit 1;
-id          perf_commit                              
-----------  -----------------------------------------
+id          perf_commit 
+----------  ----------------------------------------
 1           d9fd96f409a15429757030f225b082744a72516c
-```
-
-### pstat_series
-
-A unique collection of crate, profile, cache and statistic.
-
-* crate: the benchmarked crate which might be a crate from crates.io or a crate made specifically to stress some part of the compiler.
-* profile: what type of compilation is happening - check build, optimized build (a.k.a. release build), debug build, or doc build.
-* cache: how much of the incremental cache is full. An empty incremental cache means that the compiler must do a full build.
-* statistic: the type of stat being collected
-
-```
-sqlite> select * from pstat_series limit 1;
-id          crate       profile     cache       statistic   
-----------  ----------  ----------  ----------  ------------
-1           helloworld  check       full        task-clock:u
-```
-
-### pstat
-
-A statistic that is unique to a pstat_series, artifact and collection.
-
-This stat is unique across a benchmarked crate, profile, cache state, statistic, rustc artifact, and benchmarks "collection".
-
-```
-sqlite> select * from pstat limit 1;
-series      aid         cid         value     
-----------  ----------  ----------  ----------
-1           1           1           24.93   
-```
-
-
-### self_profile_query_series
-
-**TODO**
-
-### self_profile_query
-
-**TODO**
-
-### pull_request_build
-
-**TODO**
-
-### artifact_collection_duration
-
-Records how long benchmarking takes in seconds.
-
-```
-sqlite> select * from artifact_collection_duration limit 1;
-aid         date_recorded  duration  
-----------  -------------  ----------
-1           1625829965     4 
 ```
 
 ### collector_progress
@@ -149,19 +82,207 @@ Keeps track of the collector's start and finish time as well as which step it's 
 
 ```
 sqlite> select * from collector_progress limit 1;
-aid         step        start       end       
+aid         step        start       end
 ----------  ----------  ----------  ----------
 1           helloworld  1625829961  1625829965
 ```
 
+### artifact_collection_duration
+
+Records how long benchmarking takes in seconds.
+
+```
+sqlite> select * from artifact_collection_duration limit 1;
+aid         date_recorded  duration
+----------  -------------  ----------
+1           1625829965     4
+```
+
+### benchmark
+
+The different types of compile-time benchmarks that are run. 
+
+The table stores the name of the benchmark as well as whether it is capable of being run using the stable compiler and what is its category.
+The benchmark name is used as a foreign key in many of the other tables.
+
+Category is either `primary` (real-world benchmark) or `secondary` (stress test).
+Stable benchmarks have `category` set to `primary` and `stabilized` set to `1`.
+
+```
+sqlite> select * from runtime_benchmark limit 1;
+name        stabilized  category
+----------  ----------  ----------
+helloworld  0           primary
+```
+
+### pstat_series
+
+Describes the parametrization of a compile-time benchmark. Contains a unique combination
+of a crate, profile, scenario and the metric being collected.
+
+* crate (aka `benchmark`): the benchmarked crate which might be a crate from crates.io or a crate made specifically to stress some part of the compiler.
+* profile: what type of compilation is happening - check build, optimized build (a.k.a. release build), debug build, or doc build.
+* cache (aka `scenario`): describes how much of the incremental cache is full. An empty incremental cache means that the compiler must do a full build.
+* statistic (aka `metric`): the type of metric being collected
+
+There is a separate table for this collection to avoid duplicating crates, prfiles, scenarios etc.
+many times in the `pstat` table.
+
+```
+sqlite> select * from pstat_series limit 1;
+id          crate       profile     cache       statistic
+----------  ----------  ----------  ----------  ------------
+1           helloworld  check       full        task-clock:u
+```
+
+### pstat
+
+A measured value of a compile-time metric that is unique to a `pstat_series`, `artifact` and a `collection`.
+
+Each measured combination of a collection, rustc artifact, benchmarked crate, profile, scenario and a metric
+has its own unique entry in this table.
+
+```
+sqlite> select * from pstat limit 1;
+series      aid         cid         value
+----------  ----------  ----------  ----------
+1           1           1           24.93
+```
+
+### runtime_benchmark
+
+The different types of runtime benchmarks that are run.
+
+The table currently stores only the name of the benchmark.
+
+```
+sqlite> select * from runtime_benchmark limit 1;
+name
+---------
+nbody-10k
+```
+
+### runtime_pstat_series
+
+Describes the parametrization of a runtime benchmark. Contains a unique combination
+of a benchmark and the metric being collected.
+
+This table exists to avoid duplicating crates, profiles, scenarios etc. many times in the `runtime_pstat` table.
+
+```
+sqlite> select * from runtime_pstat_series limit 1;
+id          benchmark  metric
+----------  ---------  --------------
+1           nbody-10k  instructions:u
+```
+
+### runtime_pstat
+
+A measured value of a runtime metric that is unique to a `runtime_pstat_series`, `artifact` and a `collection`.
+
+Each measured combination of a collection, rustc artifact, benchmark and a metric
+has its own unique entry in this table.
+
+```
+sqlite> select * from runtime_pstat limit 1;
+series      aid         cid         value
+----------  ----------  ----------  ----------
+1           1           1           24.93
+```
+
+### self_profile_query_series
+
+Describes a parametrization of a self-profile query. Contains a unique combination
+of a benchmark, profile, scenario and a `rustc` self-profile query.
+
+This table exists to avoid duplicating benchmarks, profiles, scenarios etc. many times in the `self_profile_query` table.
+
+```
+sqlite> select * from runtime_pstat limit 1;
+id  crate        profile  cache       query
+--  -----        -------  ----------  -----
+1   hello-world  debug    full        hir_crate
+```
+
+### self_profile_query
+
+A measured value of a single `rustc` self-profile query that is unique to a `self_profile_query_series`, `artifact` and a `collection`.
+
+```
+sqlite> select * from runtime_pstat limit 1;
+series  aid    cid  self_time  blocked_time  incremental_load_time  number_of_cache_hits  invocation_count
+--      -----  ---  ---------  ------------  ---------------------  --------------------  ----------------
+1       42     58   11.8       10.2          8.4                    224                   408
+```
+
 ### rustc_compilation
 
-**TODO**
+Records the duration of compiling a `rustc` crate for a given artifact and collection.
+
+```
+sqlite> select * from runtime_pstat limit 1;
+aid  cid  crate                duration
+---  ---  ----------           --------
+1    42   rustc_mir_transform  28.096
+```
+
+### raw_self_profile
+
+Records that a given combination of artifact, collection, benchmark, profile and scenario
+has a self profile archive available. This profile is then downloaded through an endpoint -
+it is not stored in the database directly.
+
+```
+sqlite> select * from raw_self_profile limit 1;
+aid  cid  crate        profile  cache
+---  ---  -----        -------  -----
+1    42   hello-world  debug    full
+```
+
+### pull_request_build
+
+Records a pull request commit that is waiting in a queue to be benchmarked.
+
+First a merge commit is queued, then its artifacts are built by bors, and once the commit
+is attached to the entry in this table, it can be benchmarked.
+
+* bors_sha: SHA of the commit that should be benchmarked
+* pr: number of the PR
+* parent_sha: SHA of the parent commit, to which will the PR be compared
+* complete: bool specifying whether this commit has been already benchmarked or not
+* requested: when was the commit queued
+* include: which benchmarks should be included (corresponds to the `--include` benchmark parameter)
+* exclude: which benchmarks should be excluded (corresponds to the `--exclude` benchmark parameter)
+* runs: how many iterations should be used by default for the benchmark run
+* commit_date: when was the commit created
+
+```
+sqlite> select * from pull_request_build limit 1;
+bors_sha    pr  parent_sha  complete  requested    include  exclude  runs  commit_date
+----------  --  ----------  --------  ---------    -------  -------  ----  -----------
+1w0p83...   42  fq24xq...   true      <timestamp>                    3     <timestamp>
+```
 
 ### error_series
 
-**TODO**
+Records a compile-time benchmark that caused an error.
+
+This table exists to avoid duplicating benchmarks many times in the `error` table.
+
+```
+sqlite> select * from error_series limit 1;
+id          crate
+----------  -----------
+1           hello-world
+```
 
 ### error
 
-**TODO**
+Records a compilation error for an artifact and an entry in `error_series`.
+
+```
+sqlite> select * from error limit 1;
+series      aid  error
+----------  ---  -----
+1           42   Failed to compile...
+```

--- a/database/schema.md
+++ b/database/schema.md
@@ -104,8 +104,8 @@ aid         date_recorded  duration
 
 The different types of compile-time benchmarks that are run. 
 
-The table stores the name of the benchmark as well as whether it is capable of being run using the stable compiler and what is its category.
-The benchmark name is used as a foreign key in many of the other tables.
+The table stores the name of the benchmark, whether it is capable of being run using the stable compiler,
+and its category. The benchmark name is used as a foreign key in many of the other tables.
 
 Category is either `primary` (real-world benchmark) or `secondary` (stress test).
 Stable benchmarks have `category` set to `primary` and `stabilized` set to `1`.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -6,12 +6,21 @@ The following is a glossary of domain specific terminology. Although benchmarks 
 
 * **metric**: a name of a quantifiable metric being measured (e.g., instruction count).
 * **artifact**: a specific rustc binary labeled by some identifier tag (usually a commit sha or some sort of human readable id like "1.51.0" or "test").
+* **benchmark suite**: an entire collection of benchmarks, either compile-time or runtime.
 
 ## Compile-time benchmark terms
 
 * **benchmark**: the source of a crate which will be used to benchmark rustc. For example, ["hello world"](https://github.com/rust-lang/rustc-perf/tree/master/collector/compile-benchmarks/helloworld).
-* **profile**: a [cargo profile](https://doc.rust-lang.org/cargo/reference/profiles.html). Note: the database uses "opt" whereas cargo uses "release". 
-* **scenario**: The scenario under which a user is compiling their code. Currently, this is the incremental cache state and an optional change in the source since last compilation (e.g., full incremental cache and a `println!` statement is added).  
+* **profile**: a compilation configuration.
+  - `check` corresponds to running `cargo check`.
+  - `debug` corresponds to running `cargo build`.
+  - `opt` corresponds to running `cargo build --release`.
+  - `doc` corresponds to running rustdoc. 
+* **scenario**: describes the incremental cache state and an optional change in the source since last compilation.
+  - `full`: incremental compilation is not used.
+  - `incr-full`: incremental compilation is used, with an empty incremental cache.
+  - `incr-unchanged`: incremental compilation is used, with a full incremental cache and no code changes made.
+  - `incr-patched`: incremental compilation is used, with a full incremental cache and some code changes made.
 * **category**: a high-level group of benchmarks. Currently, there are three categories, primary (mostly real-world crates), secondary (mostly stress tests), and stable (old real-world crates, only used for the dashboard).
 
 ### Types of compile-time benchmarks

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -2,30 +2,40 @@
 
 The following is a glossary of domain specific terminology. Although benchmarks are a seemingly simple domain, they have a surprising amount of complexity. It is therefore useful to ensure that the vocabulary used to describe the domain is consistent and precise to avoid confusion. 
 
-## Basic terms
+## Common terms
+
+* **metric**: a name of a quantifiable metric being measured (e.g., instruction count).
+* **artifact**: a specific rustc binary labeled by some identifier tag (usually a commit sha or some sort of human readable id like "1.51.0" or "test").
+
+## Compile-time benchmark terms
 
 * **benchmark**: the source of a crate which will be used to benchmark rustc. For example, ["hello world"](https://github.com/rust-lang/rustc-perf/tree/master/collector/compile-benchmarks/helloworld).
 * **profile**: a [cargo profile](https://doc.rust-lang.org/cargo/reference/profiles.html). Note: the database uses "opt" whereas cargo uses "release". 
 * **scenario**: The scenario under which a user is compiling their code. Currently, this is the incremental cache state and an optional change in the source since last compilation (e.g., full incremental cache and a `println!` statement is added).  
-* **metric**: a name of a quantifiable metric being measured (e.g., instruction count)
-* **artifact**: a specific rustc binary labeled by some identifier tag (usually a commit sha or some sort of human readable id like "1.51.0" or "test")
 * **category**: a high-level group of benchmarks. Currently, there are three categories, primary (mostly real-world crates), secondary (mostly stress tests), and stable (old real-world crates, only used for the dashboard).
 
-## Benchmarks
+### Types of compile-time benchmarks
 
-* **stress test benchmark**: a benchmark that is specifically designed to stress a certain part of the compiler. For example, [projection-caching](https://github.com/rust-lang/rustc-perf/tree/master/collector/compile-benchmarks/projection-caching) stresses the compiler's projection caching mechanisms.
-* **real world benchmark**: a benchmark based on a real world crate. These are typically copied as-is from crates.io. For example, [serde](https://github.com/rust-lang/rustc-perf/tree/master/collector/compile-benchmarks/serde-1.0.136) is a popular crate and the benchmark has not been altered from a release of serde on crates.io. 
+* **stress test benchmark**: a benchmark that is specifically designed to stress a certain part of the compiler. For example, [projection-caching](https://github.com/rust-lang/rustc-perf/tree/master/collector/compile-benchmarks/projection-caching) stresses the compiler's projection caching mechanisms. Corresponds to the `secondary` category.
+* **real world benchmark**: a benchmark based on a real world crate. These are typically copied as-is from crates.io. For example, [serde](https://github.com/rust-lang/rustc-perf/tree/master/collector/compile-benchmarks/serde-1.0.136) is a popular crate and the benchmark has not been altered from a release of serde on crates.io. Corresponds to the `primary` or `stable` categories.
 
-## Testing 
+## Runtime benchmark terms
 
-* **test case**: a combination of a benchmark, a profile, and a scenario.
-* **test**: the act of running an artifact under a test case. Each test result is composed of many iterations.
-* **test iteration**: a single iteration that makes up a test. Note: we currently normally run 2 test iterations for each test. 
-* **test result**: the result of the collection of all statistics from running a test. Currently, the minimum value of a statistic from all the test iterations is used.
-* **statistic**: a single value of a metric in a test result
+* **benchmark**: a function compiled by rustc, which function will be benchmarked.
+* **benchmark group**: a crate that contains a set of runtime benchmarks.
+
+## Testing
+
+* **test case**: a combination of parameters that describe the measurement of a single (compile-time or runtime) benchmark - a single `test`
+    - For compile-time benchmarks, it is a combination of a benchmark, a profile, and a scenario.
+    - For runtime benchmarks, it is currently only the benchmark name.
+* **test**: the act of running an artifact under a test case. Each test is composed of many iterations.
+* **test iteration**: a single iteration that makes up a test. Note: we currently normally run 3 test iterations for each test. 
+* **test result**: the result of the collection of all statistics from running a test. Currently, the minimum value of a statistic from all the test iterations is used for analysis calculations and the website.
+* **statistic**: a single measured value of a metric in a test result
 * **statistic description**: the combination of a metric and a test case which describes a statistic.
 * **statistic series**: statistics for the same statistic description over time.
-* **run**: a collection of test results for all currently available test cases run on a given artifact. 
+* **run**: a set of tests for all currently available test cases measured on a given artifact. 
 
 ## Analysis
 


### PR DESCRIPTION
This PR updates the documentation of the DB and glossary to:
1) Fill in gaps
2) Unify the DB terminology better with the existing glossary
3) Add the notion of runtime benchmarks