### PR TITLE
Refactor `site` to make it easier to introduce runtime benchmarks

### DIFF
--- a/collector/benchlib/src/benchmark.rs
+++ b/collector/benchlib/src/benchmark.rs
@@ -110,12 +110,12 @@ impl BenchmarkGroup {
 pub fn passes_filter(name: &str, exclude: Option<&str>, include: Option<&str>) -> bool {
     match (exclude, include) {
         (Some(exclude), Some(include)) => {
-            let included = include.split(",").any(|filter| name.starts_with(filter));
-            let excluded = exclude.split(",").any(|filter| name.starts_with(filter));
+            let included = include.split(',').any(|filter| name.starts_with(filter));
+            let excluded = exclude.split(',').any(|filter| name.starts_with(filter));
             included && !excluded
         }
-        (None, Some(include)) => include.split(",").any(|filter| name.starts_with(filter)),
-        (Some(exclude), None) => !exclude.split(",").any(|filter| name.starts_with(filter)),
+        (None, Some(include)) => include.split(',').any(|filter| name.starts_with(filter)),
+        (Some(exclude), None) => !exclude.split(',').any(|filter| name.starts_with(filter)),
         (None, None) => true,
     }
 }

--- a/collector/src/benchmark/mod.rs
+++ b/collector/src/benchmark/mod.rs
@@ -88,7 +88,7 @@ impl Benchmark {
             }
         }
 
-        let mut patches: Vec<_> = patches.into_iter().map(|p| Patch::new(p)).collect();
+        let mut patches: Vec<_> = patches.into_iter().map(Patch::new).collect();
         patches.sort_by_key(|p| p.index);
 
         let config_path = path.join("perf-config.json");
@@ -205,7 +205,7 @@ impl Benchmark {
         let iterations = iterations.unwrap_or(self.config.runs);
 
         let profiles: Vec<Profile> = profiles
-            .into_iter()
+            .iter()
             .copied()
             .filter(|profile| !self.config.excluded_profiles.contains(profile))
             .collect();
@@ -216,7 +216,7 @@ impl Benchmark {
         }
 
         let scenarios: Vec<Scenario> = scenarios
-            .into_iter()
+            .iter()
             .copied()
             .filter(|scenario| !self.config.excluded_scenarios.contains(scenario))
             .collect();
@@ -346,7 +346,7 @@ impl Benchmark {
                                     processor,
                                     Scenario::IncrPatched,
                                     &scenario_str,
-                                    Some(&patch),
+                                    Some(patch),
                                 )
                                 .run_rustc(true)?;
                         }

--- a/collector/src/benchmark/patch.rs
+++ b/collector/src/benchmark/patch.rs
@@ -30,7 +30,7 @@ impl Patch {
         assert!(path.is_file());
         let (index, name) = {
             let file_name = path.file_name().unwrap().to_string_lossy();
-            let mut parts = file_name.split("-");
+            let mut parts = file_name.split('-');
             let index = parts.next().unwrap().parse().unwrap_or_else(|e| {
                 panic!(
                     "{:?} should be in the format 000-name.patch, \
@@ -61,7 +61,7 @@ impl Patch {
         log::debug!("applying {} to {:?}", self.name, dir);
 
         let mut cmd = Command::new("git");
-        cmd.current_dir(dir).args(&["apply"]).arg(&*self.path);
+        cmd.current_dir(dir).args(["apply"]).arg(&*self.path);
 
         command_output(&mut cmd)?;
 

--- a/collector/src/bin/bootstrap-rustc.rs
+++ b/collector/src/bin/bootstrap-rustc.rs
@@ -15,9 +15,9 @@ fn run() -> i32 {
     let status = cmd.status().expect("spawned");
 
     if status.success() {
-        return 0;
+        0
     } else {
-        return 1;
+        1
     }
 }
 

--- a/collector/src/execute/bencher.rs
+++ b/collector/src/execute/bencher.rs
@@ -179,12 +179,10 @@ impl<'a> Processor for BenchProcessor<'a> {
             } else {
                 PerfTool::BenchTool(Bencher::XperfStatSelfProfile)
             }
+        } else if cfg!(unix) {
+            PerfTool::BenchTool(Bencher::PerfStat)
         } else {
-            if cfg!(unix) {
-                PerfTool::BenchTool(Bencher::PerfStat)
-            } else {
-                PerfTool::BenchTool(Bencher::XperfStat)
-            }
+            PerfTool::BenchTool(Bencher::XperfStat)
         }
     }
 

--- a/collector/src/execute/etw_parser.rs
+++ b/collector/src/execute/etw_parser.rs
@@ -169,7 +169,7 @@ fn parse_events(r: &mut dyn BufRead, headers: Vec<EventHeader>) -> anyhow::Resul
             .columns
             .iter()
             .position(|c| c == name)
-            .expect(&format!("failed to find column {}", name))
+            .unwrap_or_else(|| panic!("failed to find column {}", name))
             + 1
     };
 
@@ -222,7 +222,7 @@ fn parse_events(r: &mut dyn BufRead, headers: Vec<EventHeader>) -> anyhow::Resul
 
         let pid = process_name[l_paren + 1..r_paran].trim();
         pid.parse()
-            .expect(&format!("failed to parse '{}' to pid", pid))
+            .unwrap_or_else(|_| panic!("failed to parse '{}' to pid", pid))
     }
 
     let mut buffer = Vec::new();
@@ -454,7 +454,7 @@ pub fn parse_etw_file(path: &str) -> anyhow::Result<Counters> {
 
     let events = parse_events(&mut file, headers)?;
 
-    Ok(process_events(events)?)
+    process_events(events)
 }
 
 #[cfg(test)]

--- a/collector/src/execute/profiler.rs
+++ b/collector/src/execute/profiler.rs
@@ -101,7 +101,7 @@ impl<'a> Processor for ProfileProcessor<'a> {
             // post-process them with `summarize`, `flamegraph`, and `crox` to
             // produce several data files in the output dir.
             Profiler::SelfProfile => {
-                let tmp_zsp_dir = filepath(data.cwd.as_ref(), "Zsp");
+                let tmp_zsp_dir = filepath(data.cwd, "Zsp");
                 let zsp_dir = filepath(self.output_dir, &out_file("Zsp"));
                 let zsp_files_prefix = filepath(&zsp_dir, "Zsp");
                 let summarize_file = filepath(self.output_dir, &out_file("summarize"));
@@ -140,8 +140,8 @@ impl<'a> Processor for ProfileProcessor<'a> {
                 let mut summarize_cmd = Command::new("summarize");
                 summarize_cmd.arg("summarize").arg(&zsp_files_prefix);
                 fs::write(
-                    &summarize_file,
-                    &summarize_cmd.output().context("summarize")?.stdout,
+                    summarize_file,
+                    summarize_cmd.output().context("summarize")?.stdout,
                 )?;
 
                 // Run `flamegraph`.
@@ -161,10 +161,10 @@ impl<'a> Processor for ProfileProcessor<'a> {
             // We copy it from the temp dir to the output dir, giving it a new
             // name in the process.
             Profiler::PerfRecord => {
-                let tmp_perf_file = filepath(data.cwd.as_ref(), "perf");
+                let tmp_perf_file = filepath(data.cwd, "perf");
                 let perf_file = filepath(self.output_dir, &out_file("perf"));
 
-                fs::copy(&tmp_perf_file, &perf_file)?;
+                fs::copy(tmp_perf_file, perf_file)?;
             }
 
             // OProfile produces (via rustc-fake) a data directory called
@@ -172,7 +172,7 @@ impl<'a> Processor for ProfileProcessor<'a> {
             // giving it a new name in the process, and then post-process it
             // twice to produce another two data files in the output dir.
             Profiler::Oprofile => {
-                let tmp_opout_dir = filepath(data.cwd.as_ref(), "oprofile_data");
+                let tmp_opout_dir = filepath(data.cwd, "oprofile_data");
                 let opout_dir = filepath(self.output_dir, &out_file("opout"));
                 let oprep_file = filepath(self.output_dir, &out_file("oprep"));
                 let opann_file = filepath(self.output_dir, &out_file("opann"));
@@ -181,7 +181,7 @@ impl<'a> Processor for ProfileProcessor<'a> {
                 if opout_dir.exists() {
                     fs::remove_dir_all(&opout_dir)?;
                 }
-                utils::fs::rename(&tmp_opout_dir, &opout_dir)?;
+                utils::fs::rename(tmp_opout_dir, &opout_dir)?;
 
                 let mut session_dir_arg = "--session-dir=".to_string();
                 session_dir_arg.push_str(opout_dir.to_str().unwrap());
@@ -195,7 +195,7 @@ impl<'a> Processor for ProfileProcessor<'a> {
                     .arg("--threshold")
                     .arg("0.5")
                     .arg(&session_dir_arg);
-                fs::write(oprep_file, &op_report_cmd.output()?.stdout)?;
+                fs::write(oprep_file, op_report_cmd.output()?.stdout)?;
 
                 let mut op_annotate_cmd = Command::new("opannotate");
                 // Other possibly useful args: --assembly
@@ -204,17 +204,17 @@ impl<'a> Processor for ProfileProcessor<'a> {
                     .arg("--threshold")
                     .arg("0.5")
                     .arg(&session_dir_arg);
-                fs::write(opann_file, &op_annotate_cmd.output()?.stdout)?;
+                fs::write(opann_file, op_annotate_cmd.output()?.stdout)?;
             }
 
             // Samply produces (via rustc-fake) a data file called
             // `profile.json`. We copy it from the temp dir to the output dir,
             // giving it a new name in the process.
             Profiler::Samply => {
-                let tmp_samply_file = filepath(data.cwd.as_ref(), "profile.json");
+                let tmp_samply_file = filepath(data.cwd, "profile.json");
                 let samply_file = filepath(self.output_dir, &out_file("samply"));
 
-                fs::copy(&tmp_samply_file, &samply_file)?;
+                fs::copy(tmp_samply_file, samply_file)?;
             }
 
             // Cachegrind produces (via rustc-fake) a data file called `cgout`.
@@ -222,7 +222,7 @@ impl<'a> Processor for ProfileProcessor<'a> {
             // name in the process, and then post-process it to produce another
             // data file in the output dir.
             Profiler::Cachegrind => {
-                let tmp_cgout_file = filepath(data.cwd.as_ref(), "cgout");
+                let tmp_cgout_file = filepath(data.cwd, "cgout");
                 let cgout_file = filepath(self.output_dir, &out_file("cgout"));
                 let cgann_file = filepath(self.output_dir, &out_file("cgann"));
 
@@ -272,7 +272,7 @@ impl<'a> Processor for ProfileProcessor<'a> {
                     .arg("--auto=yes")
                     .arg("--show-percs=yes")
                     .arg(&cgout_file);
-                fs::write(cgann_file, &cg_annotate_cmd.output()?.stdout)?;
+                fs::write(cgann_file, cg_annotate_cmd.output()?.stdout)?;
             }
 
             // Callgrind produces (via rustc-fake) a data file called `clgout`.
@@ -280,55 +280,55 @@ impl<'a> Processor for ProfileProcessor<'a> {
             // name in the process, and then post-process it to produce another
             // data file in the output dir.
             Profiler::Callgrind => {
-                let tmp_clgout_file = filepath(data.cwd.as_ref(), "clgout");
+                let tmp_clgout_file = filepath(data.cwd, "clgout");
                 let clgout_file = filepath(self.output_dir, &out_file("clgout"));
                 let clgann_file = filepath(self.output_dir, &out_file("clgann"));
 
-                fs::copy(&tmp_clgout_file, &clgout_file)?;
+                fs::copy(tmp_clgout_file, &clgout_file)?;
 
                 let mut clg_annotate_cmd = Command::new("callgrind_annotate");
                 clg_annotate_cmd
                     .arg("--auto=yes")
                     .arg("--show-percs=yes")
                     .arg(&clgout_file);
-                fs::write(clgann_file, &clg_annotate_cmd.output()?.stdout)?;
+                fs::write(clgann_file, clg_annotate_cmd.output()?.stdout)?;
             }
 
             // DHAT produces (via rustc-fake) a data file called `dhout`. We
             // copy it from the temp dir to the output dir, giving it a new
             // name in the process.
             Profiler::Dhat => {
-                let tmp_dhout_file = filepath(data.cwd.as_ref(), "dhout");
+                let tmp_dhout_file = filepath(data.cwd, "dhout");
                 let dhout_file = filepath(self.output_dir, &out_file("dhout"));
 
-                fs::copy(&tmp_dhout_file, &dhout_file)?;
+                fs::copy(tmp_dhout_file, dhout_file)?;
             }
 
             // DHAT (in copy mode) produces (via rustc-fake) a data file called
             // `dhcopy`. We copy it from the temp dir to the output dir, giving
             // it a new name in the process.
             Profiler::DhatCopy => {
-                let tmp_dhcopy_file = filepath(data.cwd.as_ref(), "dhcopy");
+                let tmp_dhcopy_file = filepath(data.cwd, "dhcopy");
                 let dhcopy_file = filepath(self.output_dir, &out_file("dhcopy"));
 
-                fs::copy(&tmp_dhcopy_file, &dhcopy_file)?;
+                fs::copy(tmp_dhcopy_file, dhcopy_file)?;
             }
 
             // Massif produces (via rustc-fake) a data file called `msout`. We
             // copy it from the temp dir to the output dir, giving it a new
             // name in the process.
             Profiler::Massif => {
-                let tmp_msout_file = filepath(data.cwd.as_ref(), "msout");
+                let tmp_msout_file = filepath(data.cwd, "msout");
                 let msout_file = filepath(self.output_dir, &out_file("msout"));
 
-                fs::copy(&tmp_msout_file, &msout_file)?;
+                fs::copy(tmp_msout_file, msout_file)?;
             }
 
             // Bytehound produces (via rustc-fake) a data file called
             // `bytehound.dat`. We copy it from the temp dir to the output dir, giving
             // it a new name in the process.
             Profiler::Bytehound => {
-                let tmp_bytehound_file = filepath(data.cwd.as_ref(), "bytehound.dat");
+                let tmp_bytehound_file = filepath(data.cwd, "bytehound.dat");
                 let target_file = filepath(self.output_dir, &out_file("bhout"));
                 fs::copy(tmp_bytehound_file, target_file)?;
             }
@@ -337,7 +337,7 @@ impl<'a> Processor for ProfileProcessor<'a> {
             // called `eprintln`. We copy it from the temp dir to the output
             // dir, giving it a new name in the process.
             Profiler::Eprintln => {
-                let tmp_eprintln_file = filepath(data.cwd.as_ref(), "eprintln");
+                let tmp_eprintln_file = filepath(data.cwd, "eprintln");
                 let eprintln_file = filepath(self.output_dir, &out_file("eprintln"));
 
                 let mut final_file = io::BufWriter::new(std::fs::File::create(&eprintln_file)?);
@@ -359,7 +359,7 @@ impl<'a> Processor for ProfileProcessor<'a> {
             // called `mono-items`. We copy it from the temp dir to the output
             // dir, giving it a new name in the process.
             Profiler::MonoItems => {
-                let tmp_file = filepath(data.cwd.as_ref(), "mono-items");
+                let tmp_file = filepath(data.cwd, "mono-items");
                 let out_dir = self.output_dir.join(&out_file("mono-items"));
                 let _ = fs::create_dir_all(&out_dir);
                 let result_file = filepath(&out_dir, "raw");
@@ -382,7 +382,7 @@ impl<'a> Processor for ProfileProcessor<'a> {
                     };
 
                     for cgu in cgus.split(' ') {
-                        let cgu_name_end = cgu.rfind('[').expect(&cgu);
+                        let cgu_name_end = cgu.rfind('[').expect(cgu);
                         let cgu_name = &cgu[..cgu_name_end];
                         let linkage = &cgu[cgu_name_end + 1..cgu.len() - 1];
                         by_cgu.entry(cgu_name).or_default().push((name, linkage));
@@ -401,24 +401,24 @@ impl<'a> Processor for ProfileProcessor<'a> {
             }
 
             Profiler::DepGraph => {
-                let tmp_file = filepath(data.cwd.as_ref(), "dep_graph.txt");
+                let tmp_file = filepath(data.cwd, "dep_graph.txt");
                 let output =
                     filepath(self.output_dir, &out_file("dep-graph")).with_extension("txt");
 
-                fs::copy(&tmp_file, &output)?;
+                fs::copy(tmp_file, output)?;
 
-                let tmp_file = filepath(data.cwd.as_ref(), "dep_graph.dot");
+                let tmp_file = filepath(data.cwd, "dep_graph.dot");
                 let output =
                     filepath(self.output_dir, &out_file("dep-graph")).with_extension("dot");
 
                 // May not exist if not incremental, but then that's OK.
-                fs::copy(&tmp_file, &output)?;
+                fs::copy(tmp_file, output)?;
             }
 
             Profiler::LlvmIr => {
-                let tmp_file = filepath(data.cwd.as_ref(), "llvm-ir");
+                let tmp_file = filepath(data.cwd, "llvm-ir");
                 let output = filepath(self.output_dir, &out_file("llir"));
-                fs::copy(&tmp_file, &output)?;
+                fs::copy(tmp_file, output)?;
             }
 
             // `cargo llvm-lines` writes its output to stdout. We copy that
@@ -426,7 +426,7 @@ impl<'a> Processor for ProfileProcessor<'a> {
             Profiler::LlvmLines => {
                 let ll_file = filepath(self.output_dir, &out_file("ll"));
 
-                fs::write(ll_file, &output.stdout)?;
+                fs::write(ll_file, output.stdout)?;
             }
         }
         Ok(Retry::No)

--- a/collector/src/execute/rustc.rs
+++ b/collector/src/execute/rustc.rs
@@ -26,7 +26,7 @@ pub fn measure(
 ) -> anyhow::Result<()> {
     eprintln!("Running rustc");
 
-    checkout(&artifact).context("checking out rust-lang/rust")?;
+    checkout(artifact).context("checking out rust-lang/rust")?;
 
     record(rt, conn, compiler, artifact, aid)?;
 
@@ -86,7 +86,7 @@ fn record(
             .canonicalize()
             .context("configure script canonicalize")?,
     )
-    .current_dir(&checkout)
+    .current_dir(checkout)
     .arg("--set")
     .arg("llvm.download-ci-llvm=true")
     .arg("--set")
@@ -95,7 +95,7 @@ fn record(
     .arg("rust.deny-warnings=false")
     .arg("--set")
     .arg(&format!("build.rustc={}", fake_rustc.to_str().unwrap()))
-    .env("RUSTC_PERF_REAL_RUSTC", &compiler.rustc)
+    .env("RUSTC_PERF_REAL_RUSTC", compiler.rustc)
     .arg("--set")
     .arg(&format!("build.cargo={}", compiler.cargo.to_str().unwrap()))
     .status()
@@ -110,8 +110,8 @@ fn record(
                     .canonicalize()
                     .context("x.py script canonicalize")?,
             )
-            .current_dir(&checkout)
-            .env("RUSTC_PERF_REAL_RUSTC", &compiler.rustc)
+            .current_dir(checkout)
+            .env("RUSTC_PERF_REAL_RUSTC", compiler.rustc)
             .arg("build")
             .arg("--stage")
             .arg("0")
@@ -134,7 +134,7 @@ fn record(
             let crate_name = iter.next().expect("has crate name");
             let _ = iter.next().expect("test:false");
             let timing = iter.next().expect("test:false");
-            let timing = Duration::from_secs_f64(timing.parse::<f64>().expect(&timing));
+            let timing = Duration::from_secs_f64(timing.parse::<f64>().expect(timing));
             *timing_data
                 .entry(crate_name)
                 .or_insert_with(|| Duration::new(0, 0)) += timing;

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -94,7 +94,7 @@ impl<'de> Deserialize<'de> for Bound {
 
                 let bound = value
                     .parse::<chrono::NaiveDate>()
-                    .map(|d| Bound::Date(d))
+                    .map(Bound::Date)
                     .unwrap_or(Bound::Commit(value.to_string()));
                 Ok(bound)
             }
@@ -116,7 +116,7 @@ where
 }
 
 pub fn version_supports_doc(version_str: &str) -> bool {
-    if let Some(version) = version_str.parse::<semver::Version>().ok() {
+    if let Ok(version) = version_str.parse::<semver::Version>() {
         version >= semver::Version::new(1, 46, 0)
     } else {
         assert!(version_str.starts_with("beta") || version_str.starts_with("master"));
@@ -125,7 +125,7 @@ pub fn version_supports_doc(version_str: &str) -> bool {
 }
 
 pub fn version_supports_incremental(version_str: &str) -> bool {
-    if let Some(version) = version_str.parse::<semver::Version>().ok() {
+    if let Ok(version) = version_str.parse::<semver::Version>() {
         version >= semver::Version::new(1, 24, 0)
     } else {
         assert!(version_str.starts_with("beta") || version_str.starts_with("master"));

--- a/collector/src/runtime/benchmark.rs
+++ b/collector/src/runtime/benchmark.rs
@@ -37,7 +37,7 @@ impl BenchmarkSuite {
         self.benchmark_names()
             .filter(|benchmark| {
                 passes_filter(
-                    &benchmark,
+                    benchmark,
                     filter.exclude.as_deref(),
                     filter.include.as_deref(),
                 )

--- a/collector/src/runtime/mod.rs
+++ b/collector/src/runtime/mod.rs
@@ -68,7 +68,7 @@ pub async fn bench_runtime(
 
                     print_stats(&result);
                     record_stats(
-                        &conn,
+                        conn.as_ref(),
                         collector.artifact_row_id,
                         &rustc_perf_version,
                         result,
@@ -86,13 +86,13 @@ pub async fn bench_runtime(
 
 /// Records the results (stats) of a benchmark into the database.
 async fn record_stats(
-    conn: &Box<dyn Connection>,
+    conn: &dyn Connection,
     artifact_id: ArtifactIdNumber,
     rustc_perf_version: &str,
     result: BenchmarkResult,
 ) {
     fn record<'a>(
-        conn: &'a Box<dyn Connection>,
+        conn: &'a dyn Connection,
         artifact_id: ArtifactIdNumber,
         collection_id: CollectionId,
         result: &'a BenchmarkResult,
@@ -182,10 +182,10 @@ fn execute_runtime_benchmark_binary(
     command.arg(&iterations.to_string());
 
     if let Some(ref exclude) = filter.exclude {
-        command.args(&["--exclude", exclude]);
+        command.args(["--exclude", exclude]);
     }
     if let Some(ref include) = filter.include {
-        command.args(&["--include", include]);
+        command.args(["--include", include]);
     }
 
     command.stdout(Stdio::piped());

--- a/collector/src/runtime/mod.rs
+++ b/collector/src/runtime/mod.rs
@@ -1,4 +1,3 @@
-use std::future::Future;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
 use std::process::{Command, Stdio};
@@ -91,25 +90,23 @@ async fn record_stats(
     rustc_perf_version: &str,
     result: BenchmarkResult,
 ) {
-    fn record<'a>(
+    async fn record<'a>(
         conn: &'a dyn Connection,
         artifact_id: ArtifactIdNumber,
         collection_id: CollectionId,
         result: &'a BenchmarkResult,
         value: Option<u64>,
         metric: &'a str,
-    ) -> impl Future<Output = ()> + 'a {
-        async move {
-            if let Some(value) = value {
-                conn.record_runtime_statistic(
-                    collection_id,
-                    artifact_id,
-                    &result.name,
-                    metric,
-                    value as f64,
-                )
-                .await;
-            }
+    ) {
+        if let Some(value) = value {
+            conn.record_runtime_statistic(
+                collection_id,
+                artifact_id,
+                &result.name,
+                metric,
+                value as f64,
+            )
+            .await;
         }
     }
 

--- a/collector/src/toolchain.rs
+++ b/collector/src/toolchain.rs
@@ -22,7 +22,7 @@ impl Sysroot {
     pub fn install(sha: String, triple: &str) -> anyhow::Result<Self> {
         let unpack_into = "cache";
 
-        fs::create_dir_all(&unpack_into)?;
+        fs::create_dir_all(unpack_into)?;
 
         let download = SysrootDownload {
             directory: unpack_into.into(),
@@ -170,13 +170,13 @@ impl SysrootDownload {
             }
         }
 
-        return Err(anyhow!(
+        Err(anyhow!(
             "unable to download sha {} triple {} module {} from any of {:?}",
             self.rust_sha,
             self.triple,
             variant,
             urls
-        ));
+        ))
     }
 
     fn extract<T: Read>(&self, variant: ModuleVariant, reader: T) -> anyhow::Result<()> {
@@ -201,7 +201,7 @@ impl SysrootDownload {
             } else {
                 continue;
             };
-            fs::create_dir_all(&path.parent().unwrap()).with_context(|| {
+            fs::create_dir_all(path.parent().unwrap()).with_context(|| {
                 format!(
                     "could not create intermediate directories for {}",
                     path.display()
@@ -271,7 +271,7 @@ pub fn get_local_toolchain(
     // (e.g., `rustc +stage1`).
     let (rustc, id) = if let Some(toolchain) = rustc.strip_prefix('+') {
         let output = Command::new("rustup")
-            .args(&["which", "rustc", "--toolchain", &toolchain])
+            .args(["which", "rustc", "--toolchain", toolchain])
             .output()
             .context("failed to run `rustup which rustc`")?;
 
@@ -289,7 +289,7 @@ pub fn get_local_toolchain(
             }
 
             if !Command::new("rustup-toolchain-install-master")
-                .arg(&toolchain)
+                .arg(toolchain)
                 .status()
                 .context("failed to run `rustup-toolchain-install-master`")?
                 .success()
@@ -302,7 +302,7 @@ pub fn get_local_toolchain(
         }
 
         let output = Command::new("rustup")
-            .args(&["which", "rustc", "--toolchain", &toolchain])
+            .args(["which", "rustc", "--toolchain", toolchain])
             .output()
             .context("failed to run `rustup which rustc`")?;
 
@@ -370,7 +370,7 @@ pub fn get_local_toolchain(
     } else {
         // Use the nightly cargo from `rustup`.
         let output = Command::new("rustup")
-            .args(&["which", "cargo", "--toolchain=nightly"])
+            .args(["which", "cargo", "--toolchain=nightly"])
             .output()
             .context("failed to run `rustup which cargo --toolchain=nightly`")?;
         if !output.status.success() {

--- a/collector/src/utils/fs.rs
+++ b/collector/src/utils/fs.rs
@@ -97,7 +97,7 @@ pub fn get_file_count_and_size(path: &Path) -> std::io::Result<(u64, u64)> {
     let (count, size) = if path.is_dir() {
         let mut file_count = 0;
         let mut total_size = 0;
-        for entry in fs::read_dir(&path)? {
+        for entry in fs::read_dir(path)? {
             let path = entry?.path();
             let (count, size) = get_file_count_and_size(&path)?;
             file_count += count;

--- a/database/src/bin/import-sqlite.rs
+++ b/database/src/bin/import-sqlite.rs
@@ -77,7 +77,7 @@ async fn main() {
                     .record_statistic(
                         cid,
                         postgres_aid,
-                        &benchmark.to_string(),
+                        &benchmark,
                         profile,
                         scenario,
                         metric.as_str(),

--- a/database/src/bin/postgres-to-sqlite.rs
+++ b/database/src/bin/postgres-to-sqlite.rs
@@ -541,8 +541,8 @@ async fn main() -> anyhow::Result<()> {
         .unwrap();
 
     if matches.get_flag("fast-unsafe") {
-        sqlite.pragma_update(None, "journal_mode", &"OFF").unwrap();
-        sqlite.pragma_update(None, "synchronous", &"OFF").unwrap();
+        sqlite.pragma_update(None, "journal_mode", "OFF").unwrap();
+        sqlite.pragma_update(None, "synchronous", "OFF").unwrap();
     }
 
     // Postgres repeatable-read transactions use a snapshot of the database, and

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -43,7 +43,7 @@ impl std::str::FromStr for Date {
             Ok(value) => Ok(Date(value.with_timezone(&Utc))),
             Err(error) => Err(DateParseError {
                 input: s.to_string(),
-                format: format!("RFC 3339"),
+                format: "RFC 3339".to_string(),
                 error,
             }),
         }
@@ -199,7 +199,7 @@ impl Eq for Commit {}
 
 impl PartialOrd for Commit {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(&other))
+        Some(self.cmp(other))
     }
 }
 
@@ -288,9 +288,8 @@ impl std::str::FromStr for Scenario {
             "incr-full" => Scenario::IncrementalEmpty,
             "incr-unchanged" => Scenario::IncrementalFresh,
             _ => {
-                // FIXME: use str::strip_prefix when stabilized
-                if s.starts_with("incr-patched: ") {
-                    Scenario::IncrementalPatch(PatchName::from(&s["incr-patched: ".len()..]))
+                if let Some(stripped) = s.strip_prefix("incr-patched: ") {
+                    Scenario::IncrementalPatch(PatchName::from(stripped))
                 } else {
                     return Err(format!("{} is not a scenario", s));
                 }
@@ -313,9 +312,9 @@ impl fmt::Display for Scenario {
 impl Scenario {
     pub fn to_id(&self) -> String {
         match self {
-            Scenario::Empty => format!("full"),
-            Scenario::IncrementalEmpty => format!("incr-full"),
-            Scenario::IncrementalFresh => format!("incr-unchanged"),
+            Scenario::Empty => "full".to_string(),
+            Scenario::IncrementalEmpty => "incr-full".to_string(),
+            Scenario::IncrementalFresh => "incr-unchanged".to_string(),
             Scenario::IncrementalPatch(name) => format!("incr-patched-{}", name),
         }
     }
@@ -626,7 +625,7 @@ impl Index {
         self.commits()
             .into_iter()
             .find(|c| c.sha == *commit)
-            .map(|c| ArtifactId::Commit(c))
+            .map(ArtifactId::Commit)
             .or_else(|| {
                 self.artifacts()
                     .find(|a| *a == commit)

--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -38,6 +38,7 @@ pub trait Connection: Send + Sync {
     async fn collection_id(&self, version: &str) -> CollectionId;
     async fn artifact_id(&self, artifact: &ArtifactId) -> ArtifactIdNumber;
 
+    #[allow(clippy::too_many_arguments)]
     async fn record_statistic(
         &self,
         collection: CollectionId,
@@ -68,6 +69,7 @@ pub trait Connection: Send + Sync {
         profile: Profile,
         scenario: Scenario,
     );
+    #[allow(clippy::too_many_arguments)]
     async fn record_self_profile_query(
         &self,
         collection: CollectionId,

--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -39,14 +39,14 @@ lazy_static::lazy_static! {
 async fn make_client(db_url: &str) -> anyhow::Result<tokio_postgres::Client> {
     if db_url.contains("rds.amazonaws.com") {
         let cert = &CERTIFICATE_PEM[..];
-        let cert = Certificate::from_pem(&cert).context("made certificate")?;
+        let cert = Certificate::from_pem(cert).context("made certificate")?;
         let connector = TlsConnector::builder()
             .add_root_certificate(cert)
             .build()
             .context("built TlsConnector")?;
         let connector = MakeTlsConnector::new(connector);
 
-        let (db_client, connection) = match tokio_postgres::connect(&db_url, connector).await {
+        let (db_client, connection) = match tokio_postgres::connect(db_url, connector).await {
             Ok(v) => v,
             Err(e) => {
                 anyhow::bail!("failed to connect to DB: {}", e);
@@ -62,7 +62,7 @@ async fn make_client(db_url: &str) -> anyhow::Result<tokio_postgres::Client> {
     } else {
         eprintln!("Warning: Non-TLS connection to non-RDS DB");
         let (db_client, connection) =
-            match tokio_postgres::connect(&db_url, tokio_postgres::NoTls).await {
+            match tokio_postgres::connect(db_url, tokio_postgres::NoTls).await {
                 Ok(v) => v,
                 Err(e) => {
                     anyhow::bail!("failed to connect to DB: {}", e);
@@ -241,7 +241,7 @@ impl ConnectionManager for Postgres {
             for mid in (version.unwrap_or(0) as usize + 1)..MIGRATIONS.len() {
                 let sql = MIGRATIONS[mid];
                 let tx = client.transaction().await.unwrap();
-                tx.batch_execute(&sql).await.unwrap();
+                tx.batch_execute(sql).await.unwrap();
                 tx.execute(
                     "insert into migrations (id, query) VALUES ($1, $2)",
                     &[&(mid as i32), &sql],
@@ -302,9 +302,9 @@ pub struct PostgresConnection {
     conn: tokio_postgres::Client,
 }
 
-impl Into<tokio_postgres::Client> for PostgresConnection {
-    fn into(self) -> tokio_postgres::Client {
-        self.conn
+impl From<PostgresConnection> for tokio_postgres::Client {
+    fn from(val: PostgresConnection) -> Self {
+        val.conn
     }
 }
 
@@ -331,10 +331,10 @@ impl<'a> PClient for PostgresTransaction<'a> {
 impl PClient for ManagedConnection<PostgresConnection> {
     type Client = tokio_postgres::Client;
     fn conn(&self) -> &Self::Client {
-        &(&**self).conn
+        &(**self).conn
     }
     fn conn_mut(&mut self) -> &mut Self::Client {
-        &mut (&mut **self).conn
+        &mut (**self).conn
     }
     fn statements(&self) -> &Arc<CachedStatements> {
         &self.statements
@@ -498,7 +498,7 @@ where
                                 let timestamp: Option<DateTime<Utc>> = row.get(2);
                                 match timestamp {
                                     Some(t) => Date(t),
-                                    None => Date(Utc.with_ymd_and_hms(2001, 01, 01, 0, 0, 0).unwrap()),
+                                    None => Date(Utc.with_ymd_and_hms(2001, 1, 1, 0, 0, 0).unwrap()),
                                 }
                             },
                             r#type: CommitType::from_str(&row.get::<_, String>(3)).unwrap()
@@ -734,7 +734,7 @@ where
         self.conn()
             .execute(
                 &self.statements().insert_pstat,
-                &[&sid, &(artifact.0 as i32), &(collection.0 as i32), &stat],
+                &[&sid, &(artifact.0 as i32), &{ collection.0 }, &stat],
             )
             .await
             .unwrap();
@@ -762,7 +762,7 @@ where
                 &self.statements().insert_rustc,
                 &[
                     &(artifact.0 as i32),
-                    &(collection.0 as i32),
+                    &{ collection.0 },
                     &krate,
                     &(value.as_nanos() as i64),
                 ],
@@ -852,9 +852,9 @@ where
             .execute(
                 &self.statements().insert_self_profile_query,
                 &[
-                    &(sid as i32),
+                    &{ sid },
                     &(artifact.0 as i32),
-                    &(collection.0 as i32),
+                    &{ collection.0 },
                     &i64::try_from(qd.self_time.as_nanos()).unwrap(),
                     &i64::try_from(qd.blocked_time.as_nanos()).unwrap(),
                     &i64::try_from(qd.incremental_load_time.as_nanos()).unwrap(),
@@ -1024,7 +1024,7 @@ where
                     date: row
                         .get::<_, Option<_>>(1)
                         .map(Date)
-                        .unwrap_or_else(|| Date::ymd_hms(2001, 01, 01, 0, 0, 0)),
+                        .unwrap_or_else(|| Date::ymd_hms(2001, 1, 1, 0, 0, 0)),
                     r#type: CommitType::from_str(&ty).unwrap(),
                 }),
                 "release" => ArtifactId::Tag(row.get(0)),

--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -238,8 +238,11 @@ impl ConnectionManager for Postgres {
                 .await
                 .unwrap();
             let version: Option<i32> = version.get(0);
-            for mid in (version.unwrap_or(0) as usize + 1)..MIGRATIONS.len() {
-                let sql = MIGRATIONS[mid];
+            for (mid, sql) in MIGRATIONS
+                .iter()
+                .enumerate()
+                .skip(version.unwrap_or(0) as usize + 1)
+            {
                 let tx = client.transaction().await.unwrap();
                 tx.batch_execute(sql).await.unwrap();
                 tx.execute(

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -361,8 +361,8 @@ impl ConnectionManager for Sqlite {
                     |row| row.get(0),
                 )
                 .unwrap();
-            for mid in (version as usize + 1)..MIGRATIONS.len() {
-                MIGRATIONS[mid].execute(&mut conn, mid as i32);
+            for (mid, migration) in MIGRATIONS.iter().enumerate().skip(version as usize + 1) {
+                migration.execute(&mut conn, mid as i32);
             }
         });
 

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -104,8 +104,8 @@ impl Migration {
     fn execute(&self, conn: &mut rusqlite::Connection, migration_id: i32) {
         if self.foreign_key_constraints_enabled {
             let tx = conn.transaction().unwrap();
-            tx.execute_batch(&self.sql).unwrap();
-            tx.pragma_update(None, "user_version", &migration_id)
+            tx.execute_batch(self.sql).unwrap();
+            tx.pragma_update(None, "user_version", migration_id)
                 .unwrap();
             tx.commit().unwrap();
             return;
@@ -115,7 +115,7 @@ impl Migration {
         // from the section titled, "Making Other Kinds Of Table Schema Changes".
 
         // 1.  If foreign key constraints are enabled, disable them using PRAGMA foreign_keys=OFF.
-        conn.pragma_update(None, "foreign_keys", &"OFF").unwrap();
+        conn.pragma_update(None, "foreign_keys", "OFF").unwrap();
 
         // 2.  Start a transaction.
         let tx = conn.transaction().unwrap();
@@ -145,7 +145,7 @@ impl Migration {
         // 9.  If any views refer to table X in a way that is affected by the schema change, then
         //     drop those views using DROP VIEW and recreate them with whatever changes are
         //     necessary to accommodate the schema change using CREATE VIEW.
-        tx.execute_batch(&self.sql).unwrap();
+        tx.execute_batch(self.sql).unwrap();
 
         // 10. If foreign key constraints were originally enabled then run PRAGMA foreign_key_check
         //     to verify that the schema change did not break any foreign key constraints.
@@ -178,14 +178,14 @@ impl Migration {
         })
         .unwrap();
 
-        tx.pragma_update(None, "user_version", &migration_id)
+        tx.pragma_update(None, "user_version", migration_id)
             .unwrap();
 
         // 11. Commit the transaction started in step 2.
         tx.commit().unwrap();
 
         // 12. If foreign keys constraints were originally enabled, reenable them now.
-        conn.pragma_update(None, "foreign_keys", &"ON").unwrap();
+        conn.pragma_update(None, "foreign_keys", "ON").unwrap();
     }
 }
 
@@ -349,9 +349,9 @@ impl ConnectionManager for Sqlite {
     type Connection = Mutex<rusqlite::Connection>;
     async fn open(&self) -> Self::Connection {
         let mut conn = rusqlite::Connection::open(&self.0).unwrap();
-        conn.pragma_update(None, "cache_size", &-128000).unwrap();
-        conn.pragma_update(None, "journal_mode", &"WAL").unwrap();
-        conn.pragma_update(None, "foreign_keys", &"ON").unwrap();
+        conn.pragma_update(None, "cache_size", -128000).unwrap();
+        conn.pragma_update(None, "journal_mode", "WAL").unwrap();
+        conn.pragma_update(None, "foreign_keys", "ON").unwrap();
 
         self.1.call_once(|| {
             let version: i32 = conn
@@ -439,7 +439,7 @@ impl Connection for SqliteConnection {
                             let timestamp: Option<i64> = row.get(2)?;
                             match timestamp {
                                 Some(t) => Date(Utc.timestamp_opt(t, 0).unwrap()),
-                                None => Date(Utc.with_ymd_and_hms(2001, 01, 01, 0, 0, 0).unwrap()),
+                                None => Date(Utc.with_ymd_and_hms(2001, 1, 1, 0, 0, 0).unwrap()),
                             }
                         },
                         r#type: CommitType::from_str(&row.get::<_, String>(3)?).unwrap(),
@@ -957,7 +957,7 @@ impl Connection for SqliteConnection {
                     date: date
                         .map(|d| Utc.timestamp_opt(d, 0).unwrap())
                         .map(Date)
-                        .unwrap_or_else(|| Date::ymd_hms(2001, 01, 01, 0, 0, 0)),
+                        .unwrap_or_else(|| Date::ymd_hms(2001, 1, 1, 0, 0, 0)),
                     r#type: CommitType::from_str(&ty).unwrap(),
                 }),
                 "release" => ArtifactId::Tag(name),
@@ -1087,7 +1087,7 @@ impl Connection for SqliteConnection {
     }
 
     async fn get_bootstrap(&self, aids: &[ArtifactIdNumber]) -> Vec<Option<Duration>> {
-        aids.into_iter()
+        aids.iter()
             .map(|aid| {
                 self.raw_ref()
                     .prepare(

--- a/intern/src/lib.rs
+++ b/intern/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::type_complexity)]
+
 use arc_swap::ArcSwap;
 use bumpalo::Bump;
 use hashbrown::HashSet;
@@ -8,6 +10,7 @@ use std::ptr;
 use std::ptr::NonNull;
 use std::sync::Arc;
 
+#[allow(clippy::missing_safety_doc)]
 pub trait InternString {
     unsafe fn to_interned(s: ArenaStr) -> Self;
 }
@@ -188,9 +191,9 @@ pub fn intern<T: InternString>(value: &str) -> T {
 #[serde(into = "&'static str")]
 pub struct ArenaStr(NonNull<u8>);
 
-impl Into<&'static str> for ArenaStr {
-    fn into(self) -> &'static str {
-        self.as_str()
+impl From<ArenaStr> for &'static str {
+    fn from(val: ArenaStr) -> Self {
+        val.as_str()
     }
 }
 

--- a/site/frontend/src/pages/compare/data.ts
+++ b/site/frontend/src/pages/compare/data.ts
@@ -2,7 +2,7 @@ import {
   BenchmarkMap,
   Category,
   CompareResponse,
-  Comparison,
+  CompileBenchmarkComparison,
   DataFilter,
   Profile,
 } from "./types";
@@ -86,8 +86,8 @@ export function computeTestCasesWithNonRelevant(
     );
   }
 
-  let testCases = data.comparisons
-    .map((c: Comparison): TestCase => {
+  let testCases = data.compile_comparisons
+    .map((c: CompileBenchmarkComparison): TestCase => {
       const datumA = c.statistics[0];
       const datumB = c.statistics[1];
       const percent = 100 * ((datumB - datumA) / datumA);
@@ -191,7 +191,7 @@ export function computeBenchmarkMap(
   if (data === null) return {};
 
   const benchmarks = {};
-  for (const benchmark of data.benchmark_data) {
+  for (const benchmark of data.compile_benchmark_data) {
     benchmarks[benchmark.name] = {
       category: benchmark.category,
     };

--- a/site/frontend/src/pages/compare/types.ts
+++ b/site/frontend/src/pages/compare/types.ts
@@ -31,7 +31,7 @@ export interface CompareSelector {
   stat: string;
 }
 
-export interface BenchmarkDescription {
+export interface CompileBenchmarkDescription {
   name: string;
   category: Category;
 }
@@ -44,7 +44,7 @@ export interface ArtifactDescription {
   bootstrap_total: number;
 }
 
-export interface Comparison {
+export interface CompileBenchmarkComparison {
   benchmark: string;
   profile: Profile;
   scenario: string;
@@ -62,7 +62,7 @@ export interface CompareResponse {
   a: ArtifactDescription;
   b: ArtifactDescription;
 
-  comparisons: [Comparison];
+  compile_comparisons: [CompileBenchmarkComparison];
   new_errors: Array<[string, string]>;
-  benchmark_data: [BenchmarkDescription];
+  compile_benchmark_data: [CompileBenchmarkDescription];
 }

--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -154,7 +154,7 @@ pub mod comparison {
         fn from(data: CompileBenchmark) -> Self {
             Self {
                 name: data.name,
-                category: data.category.to_string(),
+                category: data.category,
             }
         }
     }

--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -166,7 +166,7 @@ pub mod comparison {
 
         pub a: ArtifactDescription,
         pub b: ArtifactDescription,
-        pub comparisons: Vec<Comparison>,
+        pub compile_comparisons: Vec<CompileBenchmarkComparison>,
 
         pub new_errors: Vec<(String, String)>,
 
@@ -176,7 +176,7 @@ pub mod comparison {
         /// If `a` and `b` are adjacent artifacts (i.e., `a` is the parent of
         /// `b`).
         pub is_contiguous: bool,
-        pub benchmark_data: Vec<BenchmarkInfo>,
+        pub compile_benchmark_data: Vec<BenchmarkInfo>,
     }
 
     #[derive(Debug, Clone, Serialize)]
@@ -190,7 +190,7 @@ pub mod comparison {
 
     /// A serializable wrapper for `comparison::ArtifactData`.
     #[derive(Debug, Clone, Serialize)]
-    pub struct Comparison {
+    pub struct CompileBenchmarkComparison {
         pub benchmark: String,
         pub profile: String,
         pub scenario: String,

--- a/site/src/average.rs
+++ b/site/src/average.rs
@@ -97,11 +97,11 @@ mod tests {
 
         let a = average.next().unwrap();
         assert_eq!(a, ("a", 50.0));
-        assert_eq!(a.interpolated(), false);
+        assert!(!a.interpolated());
 
         let b = average.next().unwrap();
         assert_eq!(b, ("b", 250.0));
-        assert_eq!(b.interpolated(), false);
+        assert!(!b.interpolated());
 
         assert!(average.next().is_none());
     }
@@ -126,11 +126,11 @@ mod tests {
 
         let a = average.next().unwrap();
         assert_eq!(a, (("a", Some(50.0)), IsInterpolated::No));
-        assert_eq!(a.interpolated(), false);
+        assert!(!a.interpolated());
 
         let b = average.next().unwrap();
         assert_eq!(b, (("b", Some(150.0)), IsInterpolated::Yes));
-        assert_eq!(b.interpolated(), true);
+        assert!(b.interpolated());
 
         assert!(average.next().is_none());
     }

--- a/site/src/bin/fetch-latest.rs
+++ b/site/src/bin/fetch-latest.rs
@@ -11,7 +11,7 @@ fn main() -> anyhow::Result<()> {
     let resp = resp.error_for_status().context("fetching database")?;
     let mut decoder = FrameDecoder::new(std::io::BufReader::new(resp));
     let mut file = std::io::BufWriter::new(
-        std::fs::File::create(&destination).context("creating destination file")?,
+        std::fs::File::create(destination).context("creating destination file")?,
     );
     std::io::copy(&mut decoder, &mut file).context("decoding into file")?;
     file.flush().context("flushing into file")?;

--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -952,10 +952,14 @@ where
         } else {
             continue;
         };
-        let benchmark = *response.path.get::<Benchmark>().unwrap();
-        let profile = *response.path.get::<Profile>().unwrap();
-        let scenario = *response.path.get::<Scenario>().unwrap();
-        stats.insert((benchmark, profile, scenario), value);
+        stats.insert(
+            (
+                response.key.benchmark,
+                response.key.profile,
+                response.key.scenario,
+            ),
+            value,
+        );
     }
     stats
 }

--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -46,7 +46,7 @@ pub async fn unroll_rollup(
                     let head = format_commit(&c.rolled_up_head, true);
                     format!("❌ conflicts merging '{head}' into previous master ❌")
                 });
-            write!(&mut string, "|#{pr}|{commit}|\n", pr = c.original_pr_number).unwrap();
+            writeln!(&mut string, "|#{pr}|{commit}|", pr = c.original_pr_number).unwrap();
             string
         });
     let previous_master = format_commit(previous_master, true);
@@ -176,7 +176,7 @@ pub async fn rollup_pr_number(
     }
 
     let number = ROLLUP_PR_NUMBER
-        .captures(&message)
+        .captures(message)
         .and_then(|c| c.get(1))
         .map(|m| m.as_str().parse::<u64>())
         .transpose()
@@ -196,7 +196,7 @@ pub async fn rollup_pr_number(
         .labels
         .iter()
         .any(|l| l.name == "rollup")
-        .then(|| issue.number))
+        .then_some(issue.number))
 }
 
 pub async fn enqueue_shas(
@@ -209,7 +209,7 @@ pub async fn enqueue_shas(
     let mut msg = String::new();
     for commit in commits {
         let mut commit_response = ci_client
-            .get_commit(&commit)
+            .get_commit(commit)
             .await
             .map_err(|e| e.to_string())?;
         if commit_response.parents.len() != 2 {
@@ -335,7 +335,7 @@ fn github_request(url: &str) -> reqwest::RequestBuilder {
         .get(url)
         .header("Content-Type", "application/json")
         .header("User-Agent", "rustc-perf");
-    if let Some(token) = std::env::var("GITHUB_TOKEN").ok() {
+    if let Ok(token) = std::env::var("GITHUB_TOKEN") {
         let mut value =
             reqwest::header::HeaderValue::from_str(&format!("token {}", token)).unwrap();
         value.set_sensitive(true);

--- a/site/src/github/client.rs
+++ b/site/src/github/client.rs
@@ -88,7 +88,7 @@ impl Client {
             anyhow::bail!("{:?} != 201 CREATED", response.status());
         }
 
-        Ok(response.json().await.context("deserializing failed")?)
+        response.json().await.context("deserializing failed")
     }
 
     pub async fn update_branch(&self, branch: &str, sha: &str) -> anyhow::Result<()> {
@@ -216,7 +216,7 @@ impl Client {
         let body = body.into();
         let req = self
             .inner
-            .post(&format!(
+            .post(format!(
                 "{}/issues/{}/comments",
                 self.repository_url, pr_number
             ))

--- a/site/src/github/comparison_summary.rs
+++ b/site/src/github/comparison_summary.rs
@@ -189,7 +189,7 @@ async fn summarize_run(
 
     let (inst_primary, inst_secondary) = inst_comparison
         .clone()
-        .summarize_by_category(&benchmark_map);
+        .summarize_compile_by_category(&benchmark_map);
 
     let direction = inst_primary.direction().join(inst_secondary.direction());
     let overall_result = match direction {
@@ -262,7 +262,7 @@ async fn summarize_run(
             make_comparison_url(&commit, metric)
         ));
 
-        let (primary, secondary) = comparison.summarize_by_category(&benchmark_map);
+        let (primary, secondary) = comparison.summarize_compile_by_category(&benchmark_map);
         write_metric_summary(primary, secondary, visibility, &mut message);
     }
 

--- a/site/src/github/comparison_summary.rs
+++ b/site/src/github/comparison_summary.rs
@@ -23,7 +23,7 @@ pub async fn post_finished(ctxt: &SiteCtxt) {
     let mut known_commits = index
         .commits()
         .into_iter()
-        .map(|c| c.sha.to_string())
+        .map(|c| c.sha)
         .collect::<HashSet<_>>();
     let (master_commits, queued_pr_commits, in_progress_artifacts) = futures::join!(
         collector::master_commits(),
@@ -178,8 +178,8 @@ async fn summarize_run(
     let errors = if !inst_comparison.newly_failed_benchmarks.is_empty() {
         let benchmarks = inst_comparison
             .newly_failed_benchmarks
-            .iter()
-            .map(|(benchmark, _)| format!("- {benchmark}"))
+            .keys()
+            .map(|benchmark| format!("- {benchmark}"))
             .collect::<Vec<_>>()
             .join("\n");
         format!("\n**Warning ⚠**: The following benchmark(s) failed to build:\n{benchmarks}\n")

--- a/site/src/interpolate.rs
+++ b/site/src/interpolate.rs
@@ -101,7 +101,7 @@ where
         match item.value() {
             Some(pt) => {
                 self.last_seen = Some(pt);
-                return Some((item, IsInterpolated::No));
+                Some((item, IsInterpolated::No))
             }
             None => {
                 if let Some(last) = self.last_seen {

--- a/site/src/load.rs
+++ b/site/src/load.rs
@@ -288,7 +288,7 @@ fn parse_published_artifact_tag(line: &str) -> Option<String> {
         static ref VERSION_REGEX: Regex = Regex::new(r"(\d+\.\d+.\d+)").unwrap();
     }
 
-    let mut parts = line.rsplit("/").into_iter();
+    let mut parts = line.rsplit('/');
     let name = parts.next();
     let date = parts.next();
 
@@ -459,7 +459,7 @@ fn sort_queue(
 }
 
 // Copy of Iterator::partition_in_place, which is currently unstable.
-fn partition_in_place<'a, I, T: 'a, P>(mut iter: I, ref mut predicate: P) -> usize
+fn partition_in_place<'a, I, T: 'a, P>(mut iter: I, mut predicate: P) -> usize
 where
     I: Sized + DoubleEndedIterator<Item = &'a mut T>,
     P: FnMut(&T) -> bool,
@@ -488,8 +488,8 @@ where
 
     // Repeatedly find the first `false` and swap it with the last `true`.
     let mut true_count = 0;
-    while let Some(head) = iter.find(is_false(predicate, &mut true_count)) {
-        if let Some(tail) = iter.rfind(is_true(predicate)) {
+    while let Some(head) = iter.find(is_false(&mut predicate, &mut true_count)) {
+        if let Some(tail) = iter.rfind(is_true(&mut predicate)) {
             std::mem::swap(head, tail);
             true_count += 1;
         } else {

--- a/site/src/main.rs
+++ b/site/src/main.rs
@@ -1,5 +1,3 @@
-use env_logger;
-
 use futures::future::FutureExt;
 use parking_lot::RwLock;
 use site::load;

--- a/site/src/request_handlers/bootstrap.rs
+++ b/site/src/request_handlers/bootstrap.rs
@@ -21,7 +21,7 @@ pub async fn handle_bootstrap(
     let conn = ctxt.conn().await;
     let ids = commits
         .iter()
-        .map(|c| conn.artifact_id(&c))
+        .map(|c| conn.artifact_id(c))
         .collect::<FuturesOrdered<_>>()
         .collect::<Vec<_>>()
         .await;

--- a/site/src/request_handlers/dashboard.rs
+++ b/site/src/request_handlers/dashboard.rs
@@ -84,7 +84,7 @@ pub async fn handle_dashboard(ctxt: Arc<SiteCtxt>) -> ServerResult<dashboard::Re
         static ref STABLE_BENCHMARKS: Vec<String> = get_stable_benchmarks();
     }
 
-    let query = selector::CompileBenchmarkQuery::new()
+    let query = selector::CompileBenchmarkQuery::default()
         .benchmark(selector::Selector::Subset(STABLE_BENCHMARKS.clone()))
         .metric(selector::Selector::One(Metric::WallTime));
 

--- a/site/src/request_handlers/github.rs
+++ b/site/src/request_handlers/github.rs
@@ -153,8 +153,8 @@ async fn handle_rust_timer(
 
     enqueue_shas(
         &ctxt,
-        &main_client,
-        &ci_client,
+        main_client,
+        ci_client,
         issue.number,
         build_captures(&comment.body).map(|(commit, _)| commit),
     )
@@ -166,7 +166,7 @@ async fn handle_rust_timer(
 /// Run the `@rust-timer build` regex over the comment message extracting the commit and the other captures
 fn build_captures(comment_body: &str) -> impl Iterator<Item = (&str, regex::Captures)> {
     BODY_TIMER_BUILD
-        .captures_iter(&comment_body)
+        .captures_iter(comment_body)
         .filter_map(|captures| {
             captures.get(1).map(|m| {
                 let commit = m

--- a/site/src/request_handlers/graph.rs
+++ b/site/src/request_handlers/graph.rs
@@ -166,6 +166,7 @@ fn master_artifact_ids_for_range(ctxt: &SiteCtxt, start: Bound, end: Bound) -> V
         .collect()
 }
 
+#[allow(clippy::type_complexity)]
 /// Creates a summary "benchmark" that averages the results of all other
 /// test cases per profile type
 fn create_summary(

--- a/site/src/request_handlers/graph.rs
+++ b/site/src/request_handlers/graph.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use crate::api::graphs::GraphKind;
 use crate::api::{graph, graphs, ServerResult};
-use crate::db::{self, ArtifactId, Benchmark, Profile, Scenario};
+use crate::db::{self, ArtifactId, Profile, Scenario};
 use crate::interpolate::IsInterpolated;
 use crate::load::SiteCtxt;
 use crate::selector::{CompileBenchmarkQuery, Selector, SeriesResponse};
@@ -119,9 +119,9 @@ async fn create_graphs(
     }
 
     for response in interpolated_responses {
-        let benchmark = response.path.get::<Benchmark>()?.to_string();
-        let profile = *response.path.get::<Profile>()?;
-        let scenario = response.path.get::<Scenario>()?.to_string();
+        let benchmark = response.key.benchmark.to_string();
+        let profile = response.key.profile;
+        let scenario = response.key.scenario.to_string();
         let graph_series = graph_series(response.series.into_iter(), request.kind);
 
         benchmarks
@@ -188,9 +188,9 @@ fn create_summary(
                 let baseline_responses = interpolated_responses
                     .iter()
                     .filter(|sr| {
-                        let p = sr.path.get::<Profile>().unwrap();
-                        let s = sr.path.get::<Scenario>().unwrap();
-                        *p == profile && *s == Scenario::Empty
+                        let p = sr.key.profile;
+                        let s = sr.key.scenario;
+                        p == profile && s == Scenario::Empty
                     })
                     .map(|sr| sr.series.iter().cloned())
                     .collect();
@@ -205,9 +205,9 @@ fn create_summary(
         let summary_case_responses = interpolated_responses
             .iter()
             .filter(|sr| {
-                let p = sr.path.get::<Profile>().unwrap();
-                let s = sr.path.get::<Scenario>().unwrap();
-                *p == profile && *s == scenario
+                let p = sr.key.profile;
+                let s = sr.key.scenario;
+                p == profile && s == scenario
             })
             .map(|sr| sr.series.iter().cloned())
             .collect();

--- a/site/src/request_handlers/graph.rs
+++ b/site/src/request_handlers/graph.rs
@@ -58,7 +58,7 @@ async fn create_graph(
     let artifact_ids = artifact_ids_for_range(&ctxt, request.start, request.end);
     let mut series_iterator = ctxt
         .compile_statistic_series(
-            CompileBenchmarkQuery::new()
+            CompileBenchmarkQuery::default()
                 .benchmark(Selector::One(request.benchmark))
                 .profile(Selector::One(request.profile.parse()?))
                 .scenario(Selector::One(request.scenario.parse()?))
@@ -101,7 +101,7 @@ async fn create_graphs(
 
     let interpolated_responses: Vec<_> = ctxt
         .compile_statistic_series(
-            CompileBenchmarkQuery::new()
+            CompileBenchmarkQuery::default()
                 .benchmark(benchmark_selector)
                 .profile(profile_selector)
                 .scenario(scenario_selector)

--- a/site/src/request_handlers/self_profile.rs
+++ b/site/src/request_handlers/self_profile.rs
@@ -337,7 +337,7 @@ fn sort_self_profile(
     let mut indices: Vec<_> = (0..qd.len()).collect();
 
     match sort_idx.abs() {
-        1 => indices.sort_by_key(|&i| qd[i].label.clone()),
+        1 => indices.sort_by_key(|&i| qd[i].label),
         2 => indices.sort_by_key(|&i| qd[i].self_time),
         3 => indices.sort_by_key(|&i| qd[i].number_of_cache_misses),
         4 => indices.sort_by_key(|&i| qd[i].number_of_cache_hits),
@@ -480,8 +480,8 @@ pub async fn handle_self_profile_raw(
 ) -> ServerResult<self_profile_raw::Response> {
     log::info!("handle_self_profile_raw({:?})", body);
     let mut it = body.benchmark.rsplitn(2, '-');
-    let profile = it.next().ok_or(format!("no benchmark type"))?;
-    let bench_name = it.next().ok_or(format!("no benchmark name"))?;
+    let profile = it.next().ok_or("no benchmark type".to_string())?;
+    let bench_name = it.next().ok_or("no benchmark name".to_string())?;
 
     let scenario = body
         .scenario
@@ -568,8 +568,8 @@ pub async fn handle_self_profile(
 ) -> ServerResult<self_profile::Response> {
     log::info!("handle_self_profile({:?})", body);
     let mut it = body.benchmark.rsplitn(2, '-');
-    let profile = it.next().ok_or(format!("no benchmark type"))?;
-    let bench_name = it.next().ok_or(format!("no benchmark name"))?;
+    let profile = it.next().ok_or("no benchmark type".to_string())?;
+    let bench_name = it.next().ok_or("no benchmark name".to_string())?;
     let scenario = body
         .scenario
         .parse::<database::Scenario>()
@@ -580,7 +580,7 @@ pub async fn handle_self_profile(
         .sort_idx
         .parse::<i32>()
         .ok()
-        .ok_or(format!("sort_idx needs to be i32"))?;
+        .ok_or("sort_idx needs to be i32".to_string())?;
 
     let query = selector::Query::new()
         .set(Tag::Benchmark, selector::Selector::One(bench_name))

--- a/site/src/request_handlers/self_profile.rs
+++ b/site/src/request_handlers/self_profile.rs
@@ -583,7 +583,7 @@ pub async fn handle_self_profile(
         .ok()
         .ok_or("sort_idx needs to be i32".to_string())?;
 
-    let query = selector::CompileBenchmarkQuery::new()
+    let query = selector::CompileBenchmarkQuery::default()
         .benchmark(selector::Selector::One(bench_name.to_string()))
         .profile(selector::Selector::One(profile.parse().unwrap()))
         .scenario(selector::Selector::One(scenario))

--- a/site/src/request_handlers/self_profile.rs
+++ b/site/src/request_handlers/self_profile.rs
@@ -10,9 +10,10 @@ use hyper::StatusCode;
 
 use crate::api::self_profile::{ArtifactSize, ArtifactSizeDelta};
 use crate::api::{self_profile, self_profile_processed, self_profile_raw, ServerResult};
+use crate::comparison::Metric;
 use crate::db::ArtifactId;
 use crate::load::SiteCtxt;
-use crate::selector::{self, Tag};
+use crate::selector::{self};
 use crate::self_profile::{
     extract_profiling_data, fetch_raw_self_profile_data, get_self_profile_raw_data,
 };
@@ -582,17 +583,11 @@ pub async fn handle_self_profile(
         .ok()
         .ok_or("sort_idx needs to be i32".to_string())?;
 
-    let query = selector::Query::new()
-        .set(Tag::Benchmark, selector::Selector::One(bench_name))
-        .set(Tag::Profile, selector::Selector::One(profile))
-        .set(
-            Tag::Scenario,
-            selector::Selector::One(body.scenario.clone()),
-        )
-        .set(
-            Tag::Metric,
-            selector::Selector::One("cpu-clock".to_string()),
-        );
+    let query = selector::CompileBenchmarkQuery::new()
+        .benchmark(selector::Selector::One(bench_name.to_string()))
+        .profile(selector::Selector::One(profile.parse().unwrap()))
+        .scenario(selector::Selector::One(scenario))
+        .metric(selector::Selector::One(Metric::CpuClock));
 
     // Helper for finding an `ArtifactId` based on a commit sha
     let find_aid = |commit: &str| {
@@ -607,7 +602,9 @@ pub async fn handle_self_profile(
     }
     let commits = Arc::new(commits);
 
-    let mut cpu_responses = ctxt.statistic_series(query, commits.clone()).await?;
+    let mut cpu_responses = ctxt
+        .compile_statistic_series(query, commits.clone())
+        .await?;
     assert_eq!(cpu_responses.len(), 1, "all selectors are exact");
     let mut cpu_response = cpu_responses.remove(0).series;
 

--- a/site/src/selector.rs
+++ b/site/src/selector.rs
@@ -26,7 +26,7 @@ use crate::interpolate::Interpolate;
 use crate::load::SiteCtxt;
 
 use collector::Bound;
-use database::{Benchmark, Commit, Index, Lookup, Metric, QueryLabel};
+use database::{Benchmark, Commit, Index, Lookup, Metric};
 
 use std::fmt;
 use std::ops::RangeInclusive;
@@ -116,7 +116,6 @@ pub enum Tag {
     Profile,
     Scenario,
     Metric,
-    QueryLabel,
 }
 
 pub trait GetValue {
@@ -159,21 +158,11 @@ impl GetValue for Metric {
     }
 }
 
-impl GetValue for QueryLabel {
-    fn value(component: &PathComponent) -> Option<&Self> {
-        match component {
-            PathComponent::QueryLabel(v) => Some(v),
-            _ => None,
-        }
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub enum PathComponent {
     Benchmark(Benchmark),
     Profile(Profile),
     Scenario(Scenario),
-    QueryLabel(QueryLabel),
     Metric(Metric),
 }
 
@@ -184,7 +173,6 @@ impl PathComponent {
             PathComponent::Profile(_) => Tag::Profile,
             PathComponent::Scenario(_) => Tag::Scenario,
             PathComponent::Metric(_) => Tag::Metric,
-            PathComponent::QueryLabel(_) => Tag::QueryLabel,
         }
     }
 }

--- a/site/src/selector.rs
+++ b/site/src/selector.rs
@@ -50,7 +50,7 @@ pub fn artifact_id_for_bound(data: &Index, bound: Bound, is_left: bool) -> Optio
             .rfind(|commit| bound.right_match(commit))
             .cloned()
     };
-    commit.map(|c| ArtifactId::Commit(c)).or_else(|| {
+    commit.map(ArtifactId::Commit).or_else(|| {
         data.artifacts()
             .find(|aid| match &bound {
                 Bound::Commit(c) => *c == **aid,
@@ -345,10 +345,10 @@ impl Query {
         T: FromStr,
         <T as FromStr>::Err: fmt::Display,
     {
-        Ok(self.extract(tag)?.raw.try_map(|p| {
+        self.extract(tag)?.raw.try_map(|p| {
             p.parse::<T>()
                 .map_err(|e| format!("failed to parse query tag {:?}: {}", tag, e))
-        })?)
+        })
     }
 
     fn assert_empty(&self) -> Result<(), String> {

--- a/site/src/selector.rs
+++ b/site/src/selector.rs
@@ -190,15 +190,6 @@ pub struct CompileBenchmarkQuery {
 }
 
 impl CompileBenchmarkQuery {
-    pub fn new() -> Self {
-        Self {
-            benchmark: Selector::All,
-            scenario: Selector::All,
-            profile: Selector::All,
-            metric: Selector::All,
-        }
-    }
-
     pub fn benchmark(mut self, selector: Selector<String>) -> Self {
         self.benchmark = selector;
         self
@@ -225,6 +216,17 @@ impl CompileBenchmarkQuery {
             profile: Selector::All,
             scenario: Selector::All,
             metric: Selector::One(metric.as_str().into()),
+        }
+    }
+}
+
+impl Default for CompileBenchmarkQuery {
+    fn default() -> Self {
+        Self {
+            benchmark: Selector::All,
+            scenario: Selector::All,
+            profile: Selector::All,
+            metric: Selector::All,
         }
     }
 }

--- a/site/src/self_profile/codegen_schedule.rs
+++ b/site/src/self_profile/codegen_schedule.rs
@@ -12,10 +12,10 @@ pub struct Opt {
 }
 
 fn is_interesting(name: &str) -> bool {
-    match name {
-        "codegen_module" | "codegen_module_optimize" | "codegen_module_perform_lto" => true,
-        _ => false,
-    }
+    matches!(
+        name,
+        "codegen_module" | "codegen_module_optimize" | "codegen_module_perform_lto"
+    )
 }
 
 fn by_thread(self_profile_data: Vec<u8>) -> anyhow::Result<(u64, HashMap<u32, Vec<Event>>)> {

--- a/site/src/self_profile/crox.rs
+++ b/site/src/self_profile/crox.rs
@@ -101,7 +101,7 @@ fn generate_thread_to_collapsed_thread_mapping(
                 // need to lookup the thread_id due to new and collapsed threads
                 let mapped_thread_id = *thread_to_collapsed_thread
                     .get(next_thread_id)
-                    .unwrap_or(&next_thread_id);
+                    .unwrap_or(next_thread_id);
 
                 thread_to_collapsed_thread.insert(thread_id, mapped_thread_id);
             } else {
@@ -120,7 +120,7 @@ fn get_args(full_event: &analyzeme::Event) -> Option<HashMap<String, String>> {
                 .additional_data
                 .iter()
                 .enumerate()
-                .map(|(i, arg)| (format!("arg{}", i).to_string(), arg.to_string()))
+                .map(|(i, arg)| (format!("arg{}", i), arg.to_string()))
                 .collect(),
         )
     } else {
@@ -180,7 +180,7 @@ pub fn generate(self_profile_data: Vec<u8>, opt: Opt) -> anyhow::Result<Vec<u8>>
         .map(|index| index + 14);
     if let Some(index) = index_of_crate_name {
         let (_, last) = data.metadata().cmd.split_at(index);
-        let (crate_name, _) = last.split_at(last.find(" ").unwrap_or(last.len()));
+        let (crate_name, _) = last.split_at(last.find(' ').unwrap_or(last.len()));
 
         let process_name = json!({
             "name": "process_name",


### PR DESCRIPTION
Various simplifications, removing of unused code and fixing clippy issues. Best reviewed commit by commit.

Based on https://github.com/rust-lang/rustc-perf/pull/1606.