### PR TITLE
Run tests and lint code on Linux CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,28 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.70.0
+          override: true
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: linux
+
+      - name: Run unit tests
+        run: cargo test --all
+
+      - name: Lint check
+        run: cargo clippy --all -- -D warnings
+
       - name: Formatting check
         run: cargo fmt --all -- --check
 
       - uses: docker/setup-buildx-action@v2
-      - name: Build and push
+      - name: Build Docker image
         uses: docker/build-push-action@v4
         with:
           context: .


### PR DESCRIPTION
The `test_and_deploy` didn't actually test anything, it was just building the Docker image. So we didn't run any unit tests on Linux. Now it will run unit tests and also lint the code to make sure that clippy is happy.

I pinned the toolchain version in CI to avoid `beta` breaking CI if clippy gets something new. Before there was no specific version of cargo installed, I wonder how did it even get access to `cargo fmt` (?). Maybe the GH runners contain `cargo` by default now.