### PR TITLE
Generalize site `pstat` querying for runtime benchmarks

### DIFF
--- a/collector/src/runtime/mod.rs
+++ b/collector/src/runtime/mod.rs
@@ -26,10 +26,6 @@ pub async fn bench_runtime(
     filter: BenchmarkFilter,
     iterations: u32,
 ) -> anyhow::Result<()> {
-    for benchmark in suite.benchmark_names() {
-        conn.record_runtime_benchmark(benchmark).await;
-    }
-
     let total_benchmark_count = suite.total_benchmark_count();
     let filtered = suite.filtered_benchmark_count(&filter);
     println!(

--- a/database/src/bin/import-sqlite.rs
+++ b/database/src/bin/import-sqlite.rs
@@ -1,4 +1,4 @@
-use database::{CompileBenchmark, Lookup, Pool};
+use database::{CompileBenchmark, Pool};
 use hashbrown::HashMap;
 use std::collections::HashSet;
 
@@ -45,7 +45,8 @@ async fn main() {
         let sqlite_aid = sqlite_conn.artifact_id(&aid).await;
         let postgres_aid = postgres_conn.artifact_id(&aid).await;
 
-        for &(benchmark, profile, scenario, metric) in sqlite_idx.all_statistic_descriptions() {
+        for (&(benchmark, profile, scenario, metric), id) in sqlite_idx.all_statistic_descriptions()
+        {
             if benchmarks.insert(benchmark) {
                 postgres_conn
                     .record_compile_benchmark(
@@ -55,15 +56,6 @@ async fn main() {
                     )
                     .await;
             }
-
-            let id = database::DbLabel::StatisticDescription {
-                benchmark,
-                profile,
-                scenario,
-                metric,
-            }
-            .lookup(&sqlite_idx)
-            .unwrap();
 
             let stat = sqlite_conn
                 .get_pstats(&[id], &[Some(sqlite_aid)])

--- a/database/src/bin/import-sqlite.rs
+++ b/database/src/bin/import-sqlite.rs
@@ -45,7 +45,8 @@ async fn main() {
         let sqlite_aid = sqlite_conn.artifact_id(&aid).await;
         let postgres_aid = postgres_conn.artifact_id(&aid).await;
 
-        for (&(benchmark, profile, scenario, metric), id) in sqlite_idx.all_statistic_descriptions()
+        for (&(benchmark, profile, scenario, metric), id) in
+            sqlite_idx.compile_statistic_descriptions()
         {
             if benchmarks.insert(benchmark) {
                 postgres_conn

--- a/database/src/bin/import-sqlite.rs
+++ b/database/src/bin/import-sqlite.rs
@@ -79,5 +79,20 @@ async fn main() {
                     .await;
             }
         }
+
+        for (&(benchmark, metric), id) in sqlite_idx.runtime_statistic_descriptions() {
+            let stat = sqlite_conn
+                .get_runtime_pstats(&[id], &[Some(sqlite_aid)])
+                .await
+                .pop()
+                .unwrap()
+                .pop()
+                .unwrap();
+            if let Some(stat) = stat {
+                postgres_conn
+                    .record_runtime_statistic(cid, postgres_aid, &benchmark, metric.as_str(), stat)
+                    .await;
+            }
+        }
     }
 }

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -563,6 +563,8 @@ impl Lookup for ArtifactId {
     }
 }
 
+pub type StatisticalDescriptionId = u32;
+
 impl Index {
     pub async fn load(conn: &mut dyn pool::Connection) -> Index {
         conn.load_index().await
@@ -613,8 +615,16 @@ impl Index {
     // for it as keeping indices around would be annoying.
     pub fn all_statistic_descriptions(
         &self,
-    ) -> impl Iterator<Item = &'_ (Benchmark, Profile, Scenario, Metric)> + '_ {
-        self.pstat_series.map.keys()
+    ) -> impl Iterator<
+        Item = (
+            &(Benchmark, Profile, Scenario, Metric),
+            StatisticalDescriptionId,
+        ),
+    > + '_ {
+        self.pstat_series
+            .map
+            .iter()
+            .map(|(test_case, &row_id)| (test_case, row_id))
     }
 
     pub fn artifact_id_for_commit(&self, commit: &str) -> Option<ArtifactId> {

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -406,8 +406,6 @@ pub struct Index {
     commits: Indexed<Commit>,
     /// Id lookup of published release artifacts
     artifacts: Indexed<Box<str>>,
-    /// Id lookup of the errors for a crate
-    errors: Indexed<Benchmark>,
     /// Id lookup of compile stat description ids
     /// For legacy reasons called `pstat_series` in the database, and so the name is kept here.
     pstat_series: Indexed<(Benchmark, Profile, Scenario, Metric)>,
@@ -605,10 +603,6 @@ impl Index {
             .into_iter()
             .map(|s| s.to_string())
             .collect()
-    }
-
-    pub fn all_errors(&self) -> impl Iterator<Item = Benchmark> + '_ {
-        self.errors.map.keys().copied()
     }
 
     // FIXME: in theory this won't scale indefinitely as there's potentially

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -408,7 +408,7 @@ pub struct Index {
     artifacts: Indexed<Box<str>>,
     /// Id lookup of the errors for a crate
     errors: Indexed<Benchmark>,
-    /// Id lookup of stat description ids
+    /// Id lookup of compile stat description ids
     /// For legacy reasons called `pstat_series` in the database, and so the name is kept here.
     pstat_series: Indexed<(Benchmark, Profile, Scenario, Metric)>,
 }
@@ -613,7 +613,7 @@ impl Index {
     // millions of queries and labels and iterating all of them is eventually
     // going to be impractical. But for now it performs quite well, so we'll go
     // for it as keeping indices around would be annoying.
-    pub fn all_statistic_descriptions(
+    pub fn compile_statistic_descriptions(
         &self,
     ) -> impl Iterator<
         Item = (

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -524,9 +524,6 @@ mod index_serde {
 
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum DbLabel {
-    Errors {
-        benchmark: Benchmark,
-    },
     StatisticDescription {
         benchmark: Benchmark,
         profile: Profile,
@@ -544,7 +541,6 @@ impl Lookup for DbLabel {
     type Id = u32;
     fn lookup(&self, index: &Index) -> Option<Self::Id> {
         match self {
-            DbLabel::Errors { benchmark } => index.errors.get(benchmark),
             DbLabel::StatisticDescription {
                 benchmark,
                 profile,

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -411,6 +411,8 @@ pub struct Index {
     /// Id lookup of compile stat description ids
     /// For legacy reasons called `pstat_series` in the database, and so the name is kept here.
     pstat_series: Indexed<(Benchmark, Profile, Scenario, Metric)>,
+    /// Id lookup of runtime stat description ids
+    runtime_pstat_series: Indexed<(Benchmark, Metric)>,
 }
 
 /// An index lookup
@@ -622,6 +624,15 @@ impl Index {
         ),
     > + '_ {
         self.pstat_series
+            .map
+            .iter()
+            .map(|(test_case, &row_id)| (test_case, row_id))
+    }
+
+    pub fn runtime_statistic_descriptions(
+        &self,
+    ) -> impl Iterator<Item = (&(Benchmark, Metric), StatisticalDescriptionId)> + '_ {
+        self.runtime_pstat_series
             .map
             .iter()
             .map(|(test_case, &row_id)| (test_case, row_id))

--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -26,8 +26,6 @@ pub trait Connection: Send + Sync {
     );
     async fn get_compile_benchmarks(&self) -> Vec<CompileBenchmark>;
 
-    async fn record_runtime_benchmark(&self, name: &str);
-
     async fn artifact_by_name(&self, artifact: &str) -> Option<ArtifactId>;
 
     /// This records the duration of a collection run, i.e., collecting all of
@@ -110,6 +108,11 @@ pub trait Connection: Send + Sync {
     async fn get_pstats(
         &self,
         pstat_series_row_ids: &[u32],
+        artifact_row_id: &[Option<ArtifactIdNumber>],
+    ) -> Vec<Vec<Option<f64>>>;
+    async fn get_runtime_pstats(
+        &self,
+        runtime_pstat_series_row_ids: &[u32],
         artifact_row_id: &[Option<ArtifactIdNumber>],
     ) -> Vec<Vec<Option<f64>>>;
     async fn get_error(&self, artifact_row_id: ArtifactIdNumber) -> HashMap<String, String>;

--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -556,6 +556,25 @@ where
                     )
                 })
                 .collect(),
+            runtime_pstat_series: self
+                .conn()
+                .query(
+                    "select id, benchmark, metric from runtime_pstat_series;",
+                    &[],
+                )
+                .await
+                .unwrap()
+                .into_iter()
+                .map(|row| {
+                    (
+                        row.get::<_, i32>(0) as u32,
+                        (
+                            row.get::<_, String>(1).as_str().into(),
+                            row.get::<_, String>(2).as_str().into(),
+                        ),
+                    )
+                })
+                .collect(),
         }
     }
     async fn get_compile_benchmarks(&self) -> Vec<CompileBenchmark> {

--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -570,19 +570,6 @@ where
                     )
                 })
                 .collect(),
-            errors: self
-                .conn()
-                .query("select id, crate from error_series", &[])
-                .await
-                .unwrap()
-                .into_iter()
-                .map(|row| {
-                    (
-                        row.get::<_, i32>(0) as u32,
-                        row.get::<_, String>(1).as_str().into(),
-                    )
-                })
-                .collect(),
             pstat_series: self
                 .conn()
                 .query(

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -324,12 +324,9 @@ static MIGRATIONS: &[Migration] = &[
     Migration::new("alter table pull_request_build add column commit_date timestamp"),
     Migration::new(
         r#"
-        create table runtime_benchmark(
-            name text primary key not null
-        );
         create table runtime_pstat_series(
             id integer primary key not null,
-            benchmark text not null references runtime_benchmark(name) on delete cascade on update cascade,
+            benchmark text not null,
             metric text not null,
             UNIQUE(benchmark, metric)
         );
@@ -411,16 +408,6 @@ impl Connection for SqliteConnection {
             conn: self,
             finished: false,
         })
-    }
-
-    async fn record_duration(&self, artifact: ArtifactIdNumber, duration: Duration) {
-        self.raw_ref()
-            .prepare_cached(
-                "insert or ignore into artifact_collection_duration (aid, date_recorded, duration) VALUES (?, strftime('%s','now'), ?)",
-            )
-            .unwrap()
-            .execute(params![artifact.0, duration.as_secs() as i64])
-            .unwrap();
     }
 
     async fn load_index(&mut self) -> Index {
@@ -542,6 +529,7 @@ impl Connection for SqliteConnection {
                 .unwrap();
         }
     }
+
     async fn get_compile_benchmarks(&self) -> Vec<CompileBenchmark> {
         let conn = self.raw_ref();
         let mut query = conn
@@ -561,14 +549,309 @@ impl Connection for SqliteConnection {
         }
         benchmarks
     }
-    async fn record_runtime_benchmark(&self, name: &str) {
+    async fn artifact_by_name(&self, artifact: &str) -> Option<ArtifactId> {
+        let (date, ty) = self
+            .raw_ref()
+            .prepare("select date, type from artifact where name = ?")
+            .unwrap()
+            .query_row(params![&artifact], |r| {
+                let date = r.get::<_, Option<i64>>(0)?;
+                let ty = r.get::<_, String>(1)?;
+                Ok((date, ty))
+            })
+            .optional()
+            .unwrap()?;
+
+        match ty.as_str() {
+            "master" => Some(ArtifactId::Commit(Commit {
+                sha: artifact.to_owned(),
+                date: Date(
+                    Utc.timestamp_opt(date.expect("master has date"), 0)
+                        .unwrap(),
+                ),
+                r#type: CommitType::Master,
+            })),
+            "try" => Some(ArtifactId::Commit(Commit {
+                sha: artifact.to_owned(),
+                date: date
+                    .map(|d| Date(Utc.timestamp_opt(d, 0).unwrap()))
+                    .unwrap_or_else(|| Date::ymd_hms(2000, 1, 1, 0, 0, 0)),
+                r#type: CommitType::Try,
+            })),
+            "release" => Some(ArtifactId::Tag(artifact.to_owned())),
+            _ => panic!("unknown artifact type: {:?}", ty),
+        }
+    }
+
+    async fn record_duration(&self, artifact: ArtifactIdNumber, duration: Duration) {
+        self.raw_ref()
+            .prepare_cached(
+                "insert or ignore into artifact_collection_duration (aid, date_recorded, duration) VALUES (?, strftime('%s','now'), ?)",
+            )
+            .unwrap()
+            .execute(params![artifact.0, duration.as_secs() as i64])
+            .unwrap();
+    }
+    async fn collection_id(&self, version: &str) -> CollectionId {
+        let raw = self.raw_ref();
+        raw.execute(
+            "insert into collection (perf_commit) values (?)",
+            params![version],
+        )
+        .unwrap();
+        CollectionId(
+            raw.query_row(
+                "select id from collection where rowid = last_insert_rowid()",
+                params![],
+                |r| r.get(0),
+            )
+            .unwrap(),
+        )
+    }
+    async fn artifact_id(&self, artifact: &crate::ArtifactId) -> ArtifactIdNumber {
+        let (name, date, ty) = match artifact {
+            crate::ArtifactId::Commit(commit) => (
+                commit.sha.to_string(),
+                Some(commit.date.0),
+                if commit.is_try() { "try" } else { "master" },
+            ),
+            crate::ArtifactId::Tag(a) => (a.clone(), None, "release"),
+        };
+
         self.raw_ref()
             .execute(
-                "insert into runtime_benchmark (name) VALUES (?)
-                ON CONFLICT (name) do nothing",
-                params![name],
+                "insert or ignore into artifact (name, date, type) VALUES (?, ?, ?)",
+                params![&name, &date.map(|d| d.timestamp()), &ty,],
             )
             .unwrap();
+        ArtifactIdNumber(
+            self.raw_ref()
+                .query_row(
+                    "select id from artifact where name = $1",
+                    params![&name],
+                    |r| r.get::<_, i32>(0),
+                )
+                .unwrap() as u32,
+        )
+    }
+    async fn record_statistic(
+        &self,
+        collection: CollectionId,
+        artifact: ArtifactIdNumber,
+        benchmark: &str,
+        profile: Profile,
+        scenario: crate::Scenario,
+        metric: &str,
+        value: f64,
+    ) {
+        let profile = profile.to_string();
+        let scenario = scenario.to_string();
+        self.raw_ref().execute("insert or ignore into pstat_series (crate, profile, cache, statistic) VALUES (?, ?, ?, ?)", params![
+            &benchmark,
+            &profile,
+            &scenario,
+            &metric,
+        ]).unwrap();
+        let sid: i32 = self.raw_ref().query_row("select id from pstat_series where crate = ? and profile = ? and cache = ? and statistic = ?", params![
+            &benchmark,
+            &profile,
+            &scenario,
+            &metric,
+        ], |r| r.get(0)).unwrap();
+        self.raw_ref()
+            .execute(
+                "insert into pstat (series, aid, cid, value) VALUES (?, ?, ?, ?)",
+                params![&sid, &artifact.0, &collection.0, &value],
+            )
+            .unwrap();
+    }
+    async fn record_runtime_statistic(
+        &self,
+        collection: CollectionId,
+        artifact: ArtifactIdNumber,
+        benchmark: &str,
+        metric: &str,
+        value: f64,
+    ) {
+        self.raw_ref()
+            .execute(
+                "insert or ignore into runtime_pstat_series (benchmark, metric) VALUES (?, ?)",
+                params![&benchmark, &metric,],
+            )
+            .unwrap();
+        let sid: i32 = self
+            .raw_ref()
+            .query_row(
+                "select id from runtime_pstat_series where benchmark = ? and metric = ?",
+                params![&benchmark, &metric,],
+                |r| r.get(0),
+            )
+            .unwrap();
+        self.raw_ref()
+            .execute(
+                "insert into runtime_pstat (series, aid, cid, value) VALUES (?, ?, ?, ?)",
+                params![&sid, &artifact.0, &collection.0, &value],
+            )
+            .unwrap();
+    }
+    async fn record_raw_self_profile(
+        &self,
+        _collection: CollectionId,
+        _artifact: ArtifactIdNumber,
+        _benchmark: &str,
+        _profile: Profile,
+        _scenario: crate::Scenario,
+    ) {
+        // FIXME: this is left for the future, if we ever need to support it. It
+        // shouldn't be too hard, but we may also want to just intern the raw
+        // self profile files into sqlite database or something like that, not
+        // yet clear.
+        unimplemented!("recording raw self profile files is not implemented for sqlite")
+    }
+    async fn record_self_profile_query(
+        &self,
+        collection: CollectionId,
+        artifact: ArtifactIdNumber,
+        benchmark: &str,
+        profile: Profile,
+        scenario: crate::Scenario,
+        query: &str,
+        qd: QueryDatum,
+    ) {
+        let profile = profile.to_string();
+        let scenario = scenario.to_string();
+        self.raw_ref().execute("insert or ignore into self_profile_query_series (crate, profile, cache, query) VALUES (?, ?, ?, ?)", params![
+            &benchmark,
+            &profile,
+            &scenario,
+            &query,
+        ]).unwrap();
+        let sid: i32 = self.raw_ref().query_row("select id from self_profile_query_series where crate = ? and profile = ? and cache = ? and query = ?", params![
+            &benchmark,
+            &profile,
+            &scenario,
+            &query,
+        ], |r| r.get(0)).unwrap();
+        self.raw_ref()
+            .prepare_cached(
+                "insert into self_profile_query(
+                    series,
+                    aid,
+                    cid,
+                    self_time,
+                    blocked_time,
+                    incremental_load_time,
+                    number_of_cache_hits,
+                    invocation_count
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            )
+            .unwrap()
+            .execute(params![
+                &sid,
+                &artifact.0,
+                &collection.0,
+                &i64::try_from(qd.self_time.as_nanos()).unwrap(),
+                &i64::try_from(qd.blocked_time.as_nanos()).unwrap(),
+                &i64::try_from(qd.incremental_load_time.as_nanos()).unwrap(),
+                qd.number_of_cache_hits,
+                qd.invocation_count,
+            ])
+            .unwrap();
+    }
+
+    async fn record_error(&self, artifact: ArtifactIdNumber, krate: &str, error: &str) {
+        self.raw_ref()
+            .execute(
+                "insert or ignore into error_series (crate) VALUES (?)",
+                params![&krate,],
+            )
+            .unwrap();
+        let sid: i32 = self
+            .raw_ref()
+            .query_row(
+                "select id from error_series where crate = ?",
+                params![&krate,],
+                |r| r.get(0),
+            )
+            .unwrap();
+        self.raw_ref()
+            .execute(
+                "insert into error (series, aid, error) VALUES (?, ?, ?)",
+                params![&sid, &artifact.0, &error],
+            )
+            .unwrap();
+    }
+    async fn record_rustc_crate(
+        &self,
+        collection: CollectionId,
+        artifact: ArtifactIdNumber,
+        krate: &str,
+        value: Duration,
+    ) {
+        self.raw_ref()
+            .execute(
+                "insert into rustc_compilation (aid, cid, crate, duration) VALUES (?, ?, ?, ?)",
+                params![
+                    &artifact.0,
+                    &collection.0,
+                    &krate,
+                    &(value.as_nanos() as i64)
+                ],
+            )
+            .unwrap();
+    }
+
+    async fn get_bootstrap(&self, aids: &[ArtifactIdNumber]) -> Vec<Option<Duration>> {
+        aids.iter()
+            .map(|aid| {
+                self.raw_ref()
+                    .prepare(
+                        "
+                        select min(total)
+                        from (
+                            select sum(duration) as total
+                            from rustc_compilation
+                            where aid = ?
+                            group by cid
+                        )
+                    ",
+                    )
+                    .unwrap()
+                    .query_row(params![&aid.0], |row| {
+                        Ok(Duration::from_nanos(row.get::<_, i64>(0)? as u64))
+                    })
+                    .optional()
+                    .unwrap()
+            })
+            .collect()
+    }
+
+    async fn get_bootstrap_by_crate(
+        &self,
+        aids: &[ArtifactIdNumber],
+    ) -> HashMap<String, Vec<Option<Duration>>> {
+        let mut results = HashMap::new();
+
+        for (idx, aid) in aids.iter().copied().enumerate() {
+            let rows: Vec<(String, i64)> = self
+                .raw_ref()
+                .prepare("select crate, min(duration) from rustc_compilation where aid = ? group by crate")
+                .unwrap()
+                .query_map(params![&aid.0], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+                })
+                .unwrap()
+                .map(|r| r.unwrap())
+                .collect();
+            for (krate, min_duration) in rows {
+                let v = results
+                    .entry(krate)
+                    .or_insert_with(|| vec![None; aids.len()]);
+                v[idx] = Some(Duration::from_nanos(min_duration as u64));
+            }
+        }
+
+        results
     }
 
     async fn get_pstats(
@@ -581,6 +864,38 @@ impl Connection for SqliteConnection {
             .prepare_cached("select min(value) from pstat where series = ? and aid = ?;")
             .unwrap();
         series
+            .iter()
+            .map(|sid| {
+                let elements = artifact_row_ids
+                    .iter()
+                    .map(|aid| {
+                        aid.and_then(|aid| {
+                            query
+                                .query_row(params![&sid, &aid.0], |row| row.get(0))
+                                .unwrap_or_else(|e| {
+                                    panic!("{:?}: series={:?}, aid={:?}", e, sid, aid);
+                                })
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                if elements.is_empty() {
+                    vec![None; artifact_row_ids.len()]
+                } else {
+                    elements
+                }
+            })
+            .collect()
+    }
+    async fn get_runtime_pstats(
+        &self,
+        runtime_pstat_series_row_ids: &[u32],
+        artifact_row_ids: &[Option<ArtifactIdNumber>],
+    ) -> Vec<Vec<Option<f64>>> {
+        let conn = self.raw_ref();
+        let mut query = conn
+            .prepare_cached("select min(value) from runtime_pstat where series = ? and aid = ?;")
+            .unwrap();
+        runtime_pstat_series_row_ids
             .iter()
             .map(|sid| {
                 let elements = artifact_row_ids
@@ -704,203 +1019,6 @@ impl Connection for SqliteConnection {
             .optional()
             .unwrap()
     }
-    async fn collection_id(&self, version: &str) -> CollectionId {
-        let raw = self.raw_ref();
-        raw.execute(
-            "insert into collection (perf_commit) values (?)",
-            params![version],
-        )
-        .unwrap();
-        CollectionId(
-            raw.query_row(
-                "select id from collection where rowid = last_insert_rowid()",
-                params![],
-                |r| r.get(0),
-            )
-            .unwrap(),
-        )
-    }
-
-    async fn record_statistic(
-        &self,
-        collection: CollectionId,
-        artifact: ArtifactIdNumber,
-        benchmark: &str,
-        profile: Profile,
-        scenario: crate::Scenario,
-        metric: &str,
-        value: f64,
-    ) {
-        let profile = profile.to_string();
-        let scenario = scenario.to_string();
-        self.raw_ref().execute("insert or ignore into pstat_series (crate, profile, cache, statistic) VALUES (?, ?, ?, ?)", params![
-            &benchmark,
-            &profile,
-            &scenario,
-            &metric,
-        ]).unwrap();
-        let sid: i32 = self.raw_ref().query_row("select id from pstat_series where crate = ? and profile = ? and cache = ? and statistic = ?", params![
-            &benchmark,
-            &profile,
-            &scenario,
-            &metric,
-        ], |r| r.get(0)).unwrap();
-        self.raw_ref()
-            .execute(
-                "insert into pstat (series, aid, cid, value) VALUES (?, ?, ?, ?)",
-                params![&sid, &artifact.0, &collection.0, &value],
-            )
-            .unwrap();
-    }
-    async fn record_runtime_statistic(
-        &self,
-        collection: CollectionId,
-        artifact: ArtifactIdNumber,
-        benchmark: &str,
-        metric: &str,
-        value: f64,
-    ) {
-        self.raw_ref()
-            .execute(
-                "insert or ignore into runtime_pstat_series (benchmark, metric) VALUES (?, ?)",
-                params![&benchmark, &metric,],
-            )
-            .unwrap();
-        let sid: i32 = self
-            .raw_ref()
-            .query_row(
-                "select id from runtime_pstat_series where benchmark = ? and metric = ?",
-                params![&benchmark, &metric,],
-                |r| r.get(0),
-            )
-            .unwrap();
-        self.raw_ref()
-            .execute(
-                "insert into runtime_pstat (series, aid, cid, value) VALUES (?, ?, ?, ?)",
-                params![&sid, &artifact.0, &collection.0, &value],
-            )
-            .unwrap();
-    }
-
-    async fn record_rustc_crate(
-        &self,
-        collection: CollectionId,
-        artifact: ArtifactIdNumber,
-        krate: &str,
-        value: Duration,
-    ) {
-        self.raw_ref()
-            .execute(
-                "insert into rustc_compilation (aid, cid, crate, duration) VALUES (?, ?, ?, ?)",
-                params![
-                    &artifact.0,
-                    &collection.0,
-                    &krate,
-                    &(value.as_nanos() as i64)
-                ],
-            )
-            .unwrap();
-    }
-
-    async fn artifact_id(&self, artifact: &crate::ArtifactId) -> ArtifactIdNumber {
-        let (name, date, ty) = match artifact {
-            crate::ArtifactId::Commit(commit) => (
-                commit.sha.to_string(),
-                Some(commit.date.0),
-                if commit.is_try() { "try" } else { "master" },
-            ),
-            crate::ArtifactId::Tag(a) => (a.clone(), None, "release"),
-        };
-
-        self.raw_ref()
-            .execute(
-                "insert or ignore into artifact (name, date, type) VALUES (?, ?, ?)",
-                params![&name, &date.map(|d| d.timestamp()), &ty,],
-            )
-            .unwrap();
-        ArtifactIdNumber(
-            self.raw_ref()
-                .query_row(
-                    "select id from artifact where name = $1",
-                    params![&name],
-                    |r| r.get::<_, i32>(0),
-                )
-                .unwrap() as u32,
-        )
-    }
-
-    async fn record_self_profile_query(
-        &self,
-        collection: CollectionId,
-        artifact: ArtifactIdNumber,
-        benchmark: &str,
-        profile: Profile,
-        scenario: crate::Scenario,
-        query: &str,
-        qd: QueryDatum,
-    ) {
-        let profile = profile.to_string();
-        let scenario = scenario.to_string();
-        self.raw_ref().execute("insert or ignore into self_profile_query_series (crate, profile, cache, query) VALUES (?, ?, ?, ?)", params![
-            &benchmark,
-            &profile,
-            &scenario,
-            &query,
-        ]).unwrap();
-        let sid: i32 = self.raw_ref().query_row("select id from self_profile_query_series where crate = ? and profile = ? and cache = ? and query = ?", params![
-            &benchmark,
-            &profile,
-            &scenario,
-            &query,
-        ], |r| r.get(0)).unwrap();
-        self.raw_ref()
-            .prepare_cached(
-                "insert into self_profile_query(
-                    series,
-                    aid,
-                    cid,
-                    self_time,
-                    blocked_time,
-                    incremental_load_time,
-                    number_of_cache_hits,
-                    invocation_count
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-            )
-            .unwrap()
-            .execute(params![
-                &sid,
-                &artifact.0,
-                &collection.0,
-                &i64::try_from(qd.self_time.as_nanos()).unwrap(),
-                &i64::try_from(qd.blocked_time.as_nanos()).unwrap(),
-                &i64::try_from(qd.incremental_load_time.as_nanos()).unwrap(),
-                qd.number_of_cache_hits,
-                qd.invocation_count,
-            ])
-            .unwrap();
-    }
-    async fn record_error(&self, artifact: ArtifactIdNumber, krate: &str, error: &str) {
-        self.raw_ref()
-            .execute(
-                "insert or ignore into error_series (crate) VALUES (?)",
-                params![&krate,],
-            )
-            .unwrap();
-        let sid: i32 = self
-            .raw_ref()
-            .query_row(
-                "select id from error_series where crate = ?",
-                params![&krate,],
-                |r| r.get(0),
-            )
-            .unwrap();
-        self.raw_ref()
-            .execute(
-                "insert into error (series, aid, error) VALUES (?, ?, ?)",
-                params![&sid, &artifact.0, &error],
-            )
-            .unwrap();
-    }
     async fn collector_start(&self, aid: ArtifactIdNumber, steps: &[String]) {
         // Clean out any leftover unterminated steps.
         self.raw_ref()
@@ -927,6 +1045,7 @@ impl Connection for SqliteConnection {
             .unwrap()
             == 1
     }
+
     async fn collector_end_step(&self, aid: ArtifactIdNumber, step: &str) {
         let did_modify = self
             .raw_ref()
@@ -1021,6 +1140,7 @@ impl Connection for SqliteConnection {
             .map(|r| r.unwrap())
             .collect()
     }
+
     async fn last_end_time(&self) -> Option<DateTime<Utc>> {
         self.raw_ref()
             .query_row(
@@ -1034,6 +1154,7 @@ impl Connection for SqliteConnection {
             .optional()
             .unwrap()
     }
+
     async fn parent_of(&self, sha: &str) -> Option<String> {
         let mut shas = self
             .raw_ref()
@@ -1057,20 +1178,7 @@ impl Connection for SqliteConnection {
             .optional()
             .unwrap()
     }
-    async fn record_raw_self_profile(
-        &self,
-        _collection: CollectionId,
-        _artifact: ArtifactIdNumber,
-        _benchmark: &str,
-        _profile: Profile,
-        _scenario: crate::Scenario,
-    ) {
-        // FIXME: this is left for the future, if we ever need to support it. It
-        // shouldn't be too hard, but we may also want to just intern the raw
-        // self profile files into sqlite database or something like that, not
-        // yet clear.
-        unimplemented!("recording raw self profile files is not implemented for sqlite")
-    }
+
     async fn list_self_profile(
         &self,
         aid: ArtifactId,
@@ -1102,92 +1210,5 @@ impl Connection for SqliteConnection {
             .unwrap()
             .collect::<Result<_, _>>()
             .unwrap()
-    }
-
-    async fn get_bootstrap(&self, aids: &[ArtifactIdNumber]) -> Vec<Option<Duration>> {
-        aids.iter()
-            .map(|aid| {
-                self.raw_ref()
-                    .prepare(
-                        "
-                        select min(total)
-                        from (
-                            select sum(duration) as total
-                            from rustc_compilation
-                            where aid = ?
-                            group by cid
-                        )
-                    ",
-                    )
-                    .unwrap()
-                    .query_row(params![&aid.0], |row| {
-                        Ok(Duration::from_nanos(row.get::<_, i64>(0)? as u64))
-                    })
-                    .optional()
-                    .unwrap()
-            })
-            .collect()
-    }
-
-    async fn get_bootstrap_by_crate(
-        &self,
-        aids: &[ArtifactIdNumber],
-    ) -> HashMap<String, Vec<Option<Duration>>> {
-        let mut results = HashMap::new();
-
-        for (idx, aid) in aids.iter().copied().enumerate() {
-            let rows: Vec<(String, i64)> = self
-                .raw_ref()
-                .prepare("select crate, min(duration) from rustc_compilation where aid = ? group by crate")
-                .unwrap()
-                .query_map(params![&aid.0], |row| {
-                    Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
-                })
-                .unwrap()
-                .map(|r| r.unwrap())
-                .collect();
-            for (krate, min_duration) in rows {
-                let v = results
-                    .entry(krate)
-                    .or_insert_with(|| vec![None; aids.len()]);
-                v[idx] = Some(Duration::from_nanos(min_duration as u64));
-            }
-        }
-
-        results
-    }
-
-    async fn artifact_by_name(&self, artifact: &str) -> Option<ArtifactId> {
-        let (date, ty) = self
-            .raw_ref()
-            .prepare("select date, type from artifact where name = ?")
-            .unwrap()
-            .query_row(params![&artifact], |r| {
-                let date = r.get::<_, Option<i64>>(0)?;
-                let ty = r.get::<_, String>(1)?;
-                Ok((date, ty))
-            })
-            .optional()
-            .unwrap()?;
-
-        match ty.as_str() {
-            "master" => Some(ArtifactId::Commit(Commit {
-                sha: artifact.to_owned(),
-                date: Date(
-                    Utc.timestamp_opt(date.expect("master has date"), 0)
-                        .unwrap(),
-                ),
-                r#type: CommitType::Master,
-            })),
-            "try" => Some(ArtifactId::Commit(Commit {
-                sha: artifact.to_owned(),
-                date: date
-                    .map(|d| Date(Utc.timestamp_opt(d, 0).unwrap()))
-                    .unwrap_or_else(|| Date::ymd_hms(2000, 1, 1, 0, 0, 0)),
-                r#type: CommitType::Try,
-            })),
-            "release" => Some(ArtifactId::Tag(artifact.to_owned())),
-            _ => panic!("unknown artifact type: {:?}", ty),
-        }
     }
 }

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -859,8 +859,9 @@ impl Connection for SqliteConnection {
         series: &[u32],
         artifact_row_ids: &[Option<ArtifactIdNumber>],
     ) -> Vec<Vec<Option<f64>>> {
-        let conn = self.raw_ref();
-        let mut query = conn
+        let mut conn = self.raw_ref();
+        let tx = conn.transaction().unwrap();
+        let mut query = tx
             .prepare_cached("select min(value) from pstat where series = ? and aid = ?;")
             .unwrap();
         series

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -449,19 +449,6 @@ impl Connection for SqliteConnection {
             .unwrap()
             .map(|r| r.unwrap())
             .collect();
-        let errors = self
-            .raw()
-            .prepare("select id, crate from error_series")
-            .unwrap()
-            .query_map(params![], |row| {
-                Ok((
-                    row.get::<_, i32>(0)? as u32,
-                    row.get::<_, String>(1)?.as_str().into(),
-                ))
-            })
-            .unwrap()
-            .map(|r| r.unwrap())
-            .collect();
         let pstat_series = self
             .raw()
             .prepare("select id, crate, profile, cache, statistic from pstat_series;")
@@ -499,7 +486,6 @@ impl Connection for SqliteConnection {
         Index {
             commits,
             artifacts,
-            errors,
             pstat_series,
             runtime_pstat_series,
         }

--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -167,6 +167,7 @@ pub mod comparison {
         pub a: ArtifactDescription,
         pub b: ArtifactDescription,
         pub compile_comparisons: Vec<CompileBenchmarkComparison>,
+        pub runtime_comparisons: Vec<RuntimeBenchmarkComparison>,
 
         pub new_errors: Vec<(String, String)>,
 
@@ -188,12 +189,22 @@ pub mod comparison {
         pub bootstrap_total: u64,
     }
 
-    /// A serializable wrapper for `comparison::ArtifactData`.
+    /// A serializable wrapper for a comparison between two compile-time test results.
     #[derive(Debug, Clone, Serialize)]
     pub struct CompileBenchmarkComparison {
         pub benchmark: String,
         pub profile: String,
         pub scenario: String,
+        pub is_relevant: bool,
+        pub significance_threshold: f64,
+        pub significance_factor: f64,
+        pub statistics: (f64, f64),
+    }
+
+    /// A serializable wrapper for a comparison between two runtime test results.
+    #[derive(Debug, Clone, Serialize)]
+    pub struct RuntimeBenchmarkComparison {
+        pub benchmark: String,
         pub is_relevant: bool,
         pub significance_threshold: f64,
         pub significance_factor: f64,

--- a/site/src/request_handlers/dashboard.rs
+++ b/site/src/request_handlers/dashboard.rs
@@ -98,7 +98,7 @@ pub async fn handle_dashboard(ctxt: Arc<SiteCtxt>) -> ServerResult<dashboard::Re
             let mut cases = dashboard::Cases::default();
             for scenario in summary_scenarios.iter() {
                 let responses = ctxt
-                    .compile_statistic_series(
+                    .statistic_series(
                         query
                             .clone()
                             .profile(selector::Selector::One(profile))

--- a/site/src/request_handlers/graph.rs
+++ b/site/src/request_handlers/graph.rs
@@ -57,7 +57,7 @@ async fn create_graph(
 ) -> ServerResult<graph::Response> {
     let artifact_ids = artifact_ids_for_range(&ctxt, request.start, request.end);
     let mut series_iterator = ctxt
-        .compile_statistic_series(
+        .statistic_series(
             CompileBenchmarkQuery::default()
                 .benchmark(Selector::One(request.benchmark))
                 .profile(Selector::One(request.profile.parse()?))
@@ -100,7 +100,7 @@ async fn create_graphs(
         create_selector(&request.scenario).try_map(|v| v.parse::<Scenario>())?;
 
     let interpolated_responses: Vec<_> = ctxt
-        .compile_statistic_series(
+        .statistic_series(
             CompileBenchmarkQuery::default()
                 .benchmark(benchmark_selector)
                 .profile(profile_selector)

--- a/site/src/request_handlers/graph.rs
+++ b/site/src/request_handlers/graph.rs
@@ -7,7 +7,7 @@ use crate::api::{graph, graphs, ServerResult};
 use crate::db::{self, ArtifactId, Profile, Scenario};
 use crate::interpolate::IsInterpolated;
 use crate::load::SiteCtxt;
-use crate::selector::{CompileBenchmarkQuery, Selector, SeriesResponse};
+use crate::selector::{CompileBenchmarkQuery, CompileTestCase, Selector, SeriesResponse};
 
 pub async fn handle_graph(
     request: graph::Request,
@@ -119,9 +119,9 @@ async fn create_graphs(
     }
 
     for response in interpolated_responses {
-        let benchmark = response.key.benchmark.to_string();
-        let profile = response.key.profile;
-        let scenario = response.key.scenario.to_string();
+        let benchmark = response.test_case.benchmark.to_string();
+        let profile = response.test_case.profile;
+        let scenario = response.test_case.scenario.to_string();
         let graph_series = graph_series(response.series.into_iter(), request.kind);
 
         benchmarks
@@ -172,7 +172,10 @@ fn master_artifact_ids_for_range(ctxt: &SiteCtxt, start: Bound, end: Bound) -> V
 /// test cases per profile type
 fn create_summary(
     ctxt: &SiteCtxt,
-    interpolated_responses: &[SeriesResponse<Vec<((ArtifactId, Option<f64>), IsInterpolated)>>],
+    interpolated_responses: &[SeriesResponse<
+        CompileTestCase,
+        Vec<((ArtifactId, Option<f64>), IsInterpolated)>,
+    >],
     graph_kind: GraphKind,
 ) -> ServerResult<HashMap<Profile, HashMap<String, graphs::Series>>> {
     let mut baselines = HashMap::new();
@@ -188,8 +191,8 @@ fn create_summary(
                 let baseline_responses = interpolated_responses
                     .iter()
                     .filter(|sr| {
-                        let p = sr.key.profile;
-                        let s = sr.key.scenario;
+                        let p = sr.test_case.profile;
+                        let s = sr.test_case.scenario;
                         p == profile && s == Scenario::Empty
                     })
                     .map(|sr| sr.series.iter().cloned())
@@ -205,8 +208,8 @@ fn create_summary(
         let summary_case_responses = interpolated_responses
             .iter()
             .filter(|sr| {
-                let p = sr.key.profile;
-                let s = sr.key.scenario;
+                let p = sr.test_case.profile;
+                let s = sr.test_case.scenario;
                 p == profile && s == scenario
             })
             .map(|sr| sr.series.iter().cloned())

--- a/site/src/request_handlers/self_profile.rs
+++ b/site/src/request_handlers/self_profile.rs
@@ -602,9 +602,7 @@ pub async fn handle_self_profile(
     }
     let commits = Arc::new(commits);
 
-    let mut cpu_responses = ctxt
-        .compile_statistic_series(query, commits.clone())
-        .await?;
+    let mut cpu_responses = ctxt.statistic_series(query, commits.clone()).await?;
     assert_eq!(cpu_responses.len(), 1, "all selectors are exact");
     let mut cpu_response = cpu_responses.remove(0).series;
 

--- a/site/src/selector.rs
+++ b/site/src/selector.rs
@@ -274,7 +274,7 @@ impl StatisticSeries {
         let index = ctxt.index.load();
         let mut statistic_descriptions = index
             .all_statistic_descriptions()
-            .filter(|&&(b, p, s, m)| {
+            .filter(|(&(b, p, s, m), _)| {
                 query.benchmark.matches(b)
                     && query.profile.matches(p)
                     && query.scenario.matches(s)
@@ -284,18 +284,7 @@ impl StatisticSeries {
 
         statistic_descriptions.sort_unstable();
 
-        let sids = statistic_descriptions
-            .iter()
-            .map(|&&(b, p, s, m)| {
-                let query = crate::db::DbLabel::StatisticDescription {
-                    benchmark: b,
-                    profile: p,
-                    scenario: s,
-                    metric: m,
-                };
-                query.lookup(&index).unwrap()
-            })
-            .collect::<Vec<_>>();
+        let sids: Vec<_> = statistic_descriptions.iter().map(|(_, sid)| *sid).collect();
         let aids = artifact_ids
             .iter()
             .map(|aid| aid.lookup(&index))
@@ -312,7 +301,7 @@ impl StatisticSeries {
             .into_iter()
             .zip(&statistic_descriptions)
             .filter(|(points, _)| points.iter().any(|value| value.is_some()))
-            .map(|(points, &&(benchmark, profile, scenario, metric))| {
+            .map(|(points, (&(benchmark, profile, scenario, metric), _))| {
                 SeriesResponse {
                     series: StatisticSeries {
                         artifact_ids: ArtifactIdIter::new(artifact_ids.clone()),

--- a/site/src/selector.rs
+++ b/site/src/selector.rs
@@ -374,12 +374,10 @@ impl StatisticSeries {
             .map(|aid| aid.lookup(&index))
             .collect::<Vec<_>>();
 
-        let mut conn = ctxt.conn().await;
-        let mut tx = conn.transaction().await;
+        let conn = ctxt.conn().await;
 
         let start = std::time::Instant::now();
-        let res = tx
-            .conn()
+        let res = conn
             .get_pstats(&sids, &aids)
             .await
             .into_iter()

--- a/site/src/selector.rs
+++ b/site/src/selector.rs
@@ -181,7 +181,7 @@ impl<TestCase, T> SeriesResponse<TestCase, T> {
 }
 
 #[async_trait]
-pub trait BenchmarkQuery: Debug {
+pub trait BenchmarkQuery: Debug + Clone {
     type TestCase: TestCase;
 
     async fn execute(
@@ -283,7 +283,7 @@ impl BenchmarkQuery for CompileBenchmarkQuery {
 
         let aids = artifact_ids
             .iter()
-            .map(|aid| aid.lookup(&index))
+            .map(|aid| aid.lookup(index))
             .collect::<Vec<_>>();
 
         Ok(conn
@@ -332,16 +332,6 @@ pub struct RuntimeBenchmarkQuery {
 }
 
 impl RuntimeBenchmarkQuery {
-    pub fn benchmark(mut self, selector: Selector<String>) -> Self {
-        self.benchmark = selector;
-        self
-    }
-
-    pub fn metric(mut self, selector: Selector<Metric>) -> Self {
-        self.metric = selector.map(|v| v.as_str().into());
-        self
-    }
-
     pub fn all_for_metric(metric: Metric) -> Self {
         Self {
             benchmark: Selector::All,
@@ -381,7 +371,7 @@ impl BenchmarkQuery for RuntimeBenchmarkQuery {
 
         let aids = artifact_ids
             .iter()
-            .map(|aid| aid.lookup(&index))
+            .map(|aid| aid.lookup(index))
             .collect::<Vec<_>>();
 
         Ok(conn


### PR DESCRIPTION
This PR generalizes the `site` benchmark data querying code to also make runtime benchmark data available. The generalization is now based on test cases - for compile benchmarks we have each benchmark parametrized by `(benchmark, profile, scenario)`, for runtime benchmarks it's currently only `(benchmark, )`.

To make it work on CI, this PR also implements support for runtime benchmarks for the Postgres DB backend.

Best reviewed commit by commit.