### PR TITLE
Update compare page UI

### DIFF
--- a/site/frontend/package.json
+++ b/site/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
-    "watch": "parcel watch",
+    "watch": "parcel watch --no-hmr",
     "build": "parcel build",
     "fmt": "prettier --write src",
     "check": "tsc -p tsconfig.json --noEmit && prettier --check src"

--- a/site/frontend/src/pages/compare/benchmarks/test-cases-table.vue
+++ b/site/frontend/src/pages/compare/benchmarks/test-cases-table.vue
@@ -117,29 +117,41 @@ function prettifyRawNumber(number: number): string {
             </td>
             <td>{{ testCase.scenario }}</td>
             <td>
-              <a
-                v-bind:href="
-                  detailedQueryPercentLink(commitB, commitA, testCase)
-                "
-              >
-                <span v-bind:class="percentClass(testCase.percent)">
-                  {{ testCase.percent.toFixed(2) }}%
-                </span>
-              </a>
+              <div class="numeric-aligned">
+                <div>
+                  <a
+                    v-bind:href="
+                      detailedQueryPercentLink(commitB, commitA, testCase)
+                    "
+                  >
+                    <span v-bind:class="percentClass(testCase.percent)">
+                      {{ testCase.percent.toFixed(2) }}%
+                    </span>
+                  </a>
+                </div>
+              </div>
             </td>
             <td>
-              {{
-                testCase.significanceThreshold
-                  ? testCase.significanceThreshold.toFixed(2) + "%"
-                  : "-"
-              }}
+              <div class="numeric-aligned">
+                <div>
+                  {{
+                    testCase.significanceThreshold
+                      ? testCase.significanceThreshold.toFixed(2) + "%"
+                      : "-"
+                  }}
+                </div>
+              </div>
             </td>
             <td>
-              {{
-                testCase.significanceFactor
-                  ? testCase.significanceFactor.toFixed(2) + "x"
-                  : "-"
-              }}
+              <div class="numeric-aligned">
+                <div>
+                  {{
+                    testCase.significanceFactor
+                      ? testCase.significanceFactor.toFixed(2) + "x"
+                      : "-"
+                  }}
+                </div>
+              </div>
             </td>
             <td v-if="showRawData" class="numeric">
               <a v-bind:href="detailedQueryRawDataLink(commitA, testCase)">
@@ -189,17 +201,27 @@ function prettifyRawNumber(number: number): string {
 
 .benches th {
   text-align: center;
-  width: 25%;
   min-width: 50px;
 }
 
 .benches td {
   text-align: center;
   width: 25%;
-}
 
-.benches td.numeric {
-  text-align: right;
+  & > .numeric-aligned {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: right;
+
+    & > div {
+      width: 70px;
+    }
+  }
+
+  &.numeric {
+    text-align: right;
+  }
 }
 
 .bench-table {

--- a/site/frontend/src/pages/compare/bootstrap-table.vue
+++ b/site/frontend/src/pages/compare/bootstrap-table.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import {CompareResponse} from "./types";
-import {percentClass} from "./shared";
+import {diffClass, percentClass} from "./shared";
 
 const props = defineProps<{data: CompareResponse}>();
 
@@ -44,16 +44,6 @@ const bootstraps = Object.entries(props.data.a.bootstrap)
       return a.name.localeCompare(b.name);
     }
   });
-
-function diffClass(diff: number): string {
-  let klass = "";
-  if (diff > 1) {
-    klass = "positive";
-  } else if (diff < -1) {
-    klass = "negative";
-  }
-  return klass;
-}
 </script>
 
 <template>

--- a/site/frontend/src/pages/compare/header/filters.vue
+++ b/site/frontend/src/pages/compare/header/filters.vue
@@ -33,7 +33,7 @@ watch(
 
 <template>
   <fieldset class="collapsible-section">
-    <Toggle :defaultOpened="true">
+    <Toggle :defaultOpened="false">
       <template #label>Filters</template>
       <template #content>
         <div>

--- a/site/frontend/src/pages/compare/header/header.vue
+++ b/site/frontend/src/pages/compare/header/header.vue
@@ -61,7 +61,7 @@ const after = computed(() =>
 </script>
 
 <template>
-  <h2>
+  <h2 style="text-align: center">
     Comparing <span id="stat-header">{{ selector.stat }}</span> between
     <span id="before">{{ before }}</span> and
     <span id="after">{{ after }}</span>

--- a/site/frontend/src/pages/compare/header/quick-links.vue
+++ b/site/frontend/src/pages/compare/header/quick-links.vue
@@ -39,7 +39,7 @@ const metrics = [
 
 <template>
   <div class="quick-links">
-    <div>Quick links:</div>
+    <div class="label">Quick links:</div>
     <div
       v-for="metric in metrics"
       :class="{active: props.stat === metric.stat}"
@@ -63,5 +63,13 @@ const metrics = [
 
 .quick-links .active {
   font-weight: bold;
+}
+
+.quick-links .label {
+  display: none;
+
+  @media (min-width: 600px) {
+    display: block;
+  }
 }
 </style>

--- a/site/frontend/src/pages/compare/page.vue
+++ b/site/frontend/src/pages/compare/page.vue
@@ -11,7 +11,7 @@ import {computed, Ref, ref} from "vue";
 import {withLoading} from "../../utils/loading";
 import {postMsgpack} from "../../utils/requests";
 import {COMPARE_DATA_URL} from "../../urls";
-import {CompareResponse, CompareSelector, DataFilter} from "./types";
+import {CompareResponse, CompareSelector, DataFilter, Tab} from "./types";
 import BootstrapTable from "./bootstrap-table.vue";
 import Header from "./header/header.vue";
 import DataSelector, {SelectionParams} from "./header/data-selector.vue";
@@ -23,10 +23,12 @@ import {
   computeSummary,
   computeTestCasesWithNonRelevant,
   filterNonRelevant,
+  SummaryGroup,
 } from "./data";
 import OverallTable from "./summary/overall-table.vue";
 import Aggregations from "./summary/aggregations.vue";
 import Benchmarks from "./benchmarks/benchmarks.vue";
+import Tabs from "./tabs.vue";
 
 function loadSelectorFromUrl(urlParams: Dict<string>): CompareSelector {
   const start = urlParams["start"] ?? "";
@@ -158,6 +160,16 @@ async function loadCompareData(
     return await postMsgpack<CompareResponse>(COMPARE_DATA_URL, params);
   });
   data.value = response;
+  totalSummary.value = computeSummary(
+    filterNonRelevant(
+      defaultFilter,
+      computeTestCasesWithNonRelevant(
+        defaultFilter,
+        data.value,
+        benchmarkMap.value
+      )
+    )
+  );
 }
 
 function updateSelection(params: SelectionParams) {
@@ -222,12 +234,23 @@ const testCases = computed(() =>
 );
 const filteredSummary = computed(() => computeSummary(testCases.value));
 
+// Include all relevant changes in the compile-time tab summary
+// We do not wrap it in computed, because it should be loaded only once, after
+// the data is downloaded.
+const totalSummary: Ref<SummaryGroup | null> = ref(null);
+
 const loading = ref(false);
 
 const quickLinksKey = ref(0);
 const info = await loadBenchmarkInfo();
 const selector = loadSelectorFromUrl(urlParams);
 const filter = ref(loadFilterFromUrl(urlParams, defaultFilter));
+
+const tab: Ref<Tab> = ref(Tab.CompileTime);
+
+function changeTab(newTab: Tab) {
+  tab.value = newTab;
+}
 
 const data: Ref<CompareResponse | null> = ref(null);
 loadCompareData(selector, loading);
@@ -247,23 +270,30 @@ loadCompareData(selector, loading);
       <p>Loading ...</p>
     </div>
     <div v-if="data !== null">
-      <QuickLinks :stat="selector.stat" :key="quickLinksKey" />
-      <Filters
-        :defaultFilter="defaultFilter"
-        :initialFilter="filter"
-        @change="updateFilter"
-        @export="exportData"
-      />
-      <OverallTable :summary="filteredSummary" />
-      <Aggregations :cases="testCases" />
-      <Benchmarks
+      <Tabs
+        @change-tab="changeTab"
         :data="data"
-        :test-cases="testCases"
-        :all-test-cases="allTestCases"
-        :filter="filter"
-        :stat="selector.stat"
-      ></Benchmarks>
-      <BootstrapTable :data="data" />
+        :compile-time-summary="totalSummary"
+      />
+      <template v-if="tab === Tab.CompileTime">
+        <QuickLinks :stat="selector.stat" :key="quickLinksKey" />
+        <Filters
+          :defaultFilter="defaultFilter"
+          :initialFilter="filter"
+          @change="updateFilter"
+          @export="exportData"
+        />
+        <OverallTable :summary="filteredSummary" />
+        <Aggregations :cases="testCases" />
+        <Benchmarks
+          :data="data"
+          :test-cases="testCases"
+          :all-test-cases="allTestCases"
+          :filter="filter"
+          :stat="selector.stat"
+        ></Benchmarks>
+      </template>
+      <BootstrapTable v-if="tab === Tab.Bootstrap" :data="data" />
     </div>
   </div>
   <br />

--- a/site/frontend/src/pages/compare/shared.ts
+++ b/site/frontend/src/pages/compare/shared.ts
@@ -29,11 +29,8 @@ export function percentClass(pct: number): string {
 }
 
 export function diffClass(diff: number): string {
-  let klass = "";
-  if (diff > 1) {
-    klass = "positive";
-  } else if (diff < -1) {
-    klass = "negative";
+  if (diff >= 0) {
+    return "positive";
   }
-  return klass;
+  return "negative";
 }

--- a/site/frontend/src/pages/compare/shared.ts
+++ b/site/frontend/src/pages/compare/shared.ts
@@ -27,3 +27,13 @@ export function percentClass(pct: number): string {
   }
   return klass;
 }
+
+export function diffClass(diff: number): string {
+  let klass = "";
+  if (diff > 1) {
+    klass = "positive";
+  } else if (diff < -1) {
+    klass = "negative";
+  }
+  return klass;
+}

--- a/site/frontend/src/pages/compare/summary/percent-value.vue
+++ b/site/frontend/src/pages/compare/summary/percent-value.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import {computed} from "vue";
-import {signIfPositive} from "../shared";
+import {percentClass, signIfPositive} from "../shared";
 
 const props = withDefaults(
   defineProps<{
@@ -23,5 +23,7 @@ const padSpaces = computed((): string => {
 </script>
 
 <template>
-  <span><span v-html="padSpaces" />{{ formattedValue }}%</span>
+  <span :class="percentClass(props.value)"
+    ><span v-html="padSpaces" />{{ formattedValue }}%</span
+  >
 </template>

--- a/site/frontend/src/pages/compare/summary/summary-table.vue
+++ b/site/frontend/src/pages/compare/summary/summary-table.vue
@@ -39,7 +39,7 @@ const summary = computed(() => props.summary);
       </tr>
     </thead>
     <tbody>
-      <tr class="positive">
+      <tr>
         <td title="Regressions" v-if="withLegend">❌</td>
         <template v-if="summary.regressions.count !== 0">
           <td>
@@ -48,7 +48,7 @@ const summary = computed(() => props.summary);
           <td>
             <SummaryPercentValue :value="summary.regressions.average" />
           </td>
-          <td>
+          <td class="positive">
             <SummaryCount
               :cases="summary.regressions.count"
               :benchmarks="summary.regressions.benchmarks"
@@ -59,7 +59,7 @@ const summary = computed(() => props.summary);
           <td colspan="3" style="text-align: center">No regressions</td>
         </template>
       </tr>
-      <tr class="negative">
+      <tr>
         <td title="Improvements" v-if="withLegend">✅</td>
         <template v-if="summary.improvements.count !== 0">
           <td>
@@ -68,7 +68,7 @@ const summary = computed(() => props.summary);
           <td>
             <SummaryPercentValue :value="summary.improvements.average" />
           </td>
-          <td>
+          <td class="negative">
             <SummaryCount
               :cases="summary.improvements.count"
               :benchmarks="summary.improvements.benchmarks"

--- a/site/frontend/src/pages/compare/tabs.vue
+++ b/site/frontend/src/pages/compare/tabs.vue
@@ -1,0 +1,190 @@
+<script lang="ts"></script>
+
+<script setup lang="ts">
+import {Ref, ref} from "vue";
+import {CompareResponse, Tab} from "./types";
+import {diffClass, percentClass} from "./shared";
+import {SummaryGroup} from "./data";
+import SummaryPercentValue from "./summary/percent-value.vue";
+
+const props = withDefaults(
+  defineProps<{
+    data: CompareResponse;
+    compileTimeSummary: SummaryGroup;
+    initialTab?: Tab;
+  }>(),
+  {
+    initialTab: Tab.CompileTime,
+  }
+);
+const emit = defineEmits<{
+  (e: "changeTab", tab: Tab): void;
+}>();
+
+function changeTab(tab: Tab) {
+  activeTab.value = tab;
+  emit("changeTab", tab);
+}
+
+function formatBootstrap(value: number): string {
+  if (value > 0.0) {
+    return (value / 10e8).toFixed(3);
+  }
+  return "???";
+}
+
+const bootstrapA = props.data.a.bootstrap_total;
+const bootstrapB = props.data.b.bootstrap_total;
+const bootstrapValid = bootstrapA > 0.0 && bootstrapB > 0.0;
+const compileTimeValid = props.compileTimeSummary.all.count > 0;
+
+const activeTab: Ref<Tab> = ref(props.initialTab);
+</script>
+
+<template>
+  <div class="wrapper">
+    <div
+      class="tab"
+      title="Compilation time benchmarks"
+      :class="{selected: activeTab === Tab.CompileTime}"
+      @click="changeTab(Tab.CompileTime)"
+    >
+      <div class="title">Compile-time</div>
+      <div class="summary compile-time">
+        <template v-if="compileTimeValid">
+          <table>
+            <thead>
+              <tr>
+                <th>min</th>
+                <th>max</th>
+                <th>avg</th>
+              </tr>
+            </thead>
+            <thead>
+              <tr>
+                <td>
+                  <SummaryPercentValue
+                    :class="percentClass(compileTimeSummary.all.range[0])"
+                    :value="compileTimeSummary.all.range[0]"
+                  />
+                </td>
+                <td>
+                  <SummaryPercentValue
+                    :class="percentClass(compileTimeSummary.all.range[1])"
+                    :value="compileTimeSummary.all.range[1]"
+                  />
+                </td>
+                <td>
+                  <SummaryPercentValue
+                    :class="percentClass(compileTimeSummary.all.average)"
+                    :value="compileTimeSummary.all.average"
+                  />
+                </td>
+              </tr>
+            </thead>
+          </table>
+        </template>
+        <template v-else>No relevant results</template>
+      </div>
+    </div>
+    <div
+      class="tab"
+      title="Bootstrap duration"
+      :class="{selected: activeTab === Tab.Bootstrap}"
+      @click="changeTab(Tab.Bootstrap)"
+    >
+      <div class="title">Bootstrap</div>
+      <div
+        :class="{[diffClass(bootstrapB - bootstrapA)]: bootstrapValid}"
+        class="summary"
+      >
+        <div>
+          {{ formatBootstrap(bootstrapA) }} ->
+          {{ formatBootstrap(bootstrapB) }}
+        </div>
+        <div v-if="bootstrapValid">
+          {{ ((bootstrapB - bootstrapA) / 10e8).toFixed(1) }}s ({{
+            (((bootstrapB - bootstrapA) / bootstrapA) * 100).toFixed(3)
+          }}%)
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped lang="scss">
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 20px 0;
+
+  @media (min-width: 600px) {
+    justify-content: center;
+    flex-direction: row;
+    align-items: normal;
+  }
+}
+
+.tab {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  width: 200px;
+  height: 60px;
+  padding: 5px;
+  text-align: center;
+  border: 2px dotted #cccccc;
+  border-radius: 5px;
+  cursor: pointer;
+
+  &:hover {
+    @extend .selected;
+  }
+
+  @media (min-width: 600px) {
+    &:not(:first-child) {
+      margin-left: 30px;
+    }
+    &:not(:last-child) {
+      :after {
+        content: "";
+        position: absolute;
+        right: -17px;
+        border-right: 1px solid black;
+        top: 20%;
+        bottom: 20%;
+      }
+    }
+  }
+}
+
+.title {
+  font-weight: bold;
+  margin-bottom: 4px;
+}
+
+.selected {
+  border-style: solid;
+  border-color: black;
+}
+
+.compile-time {
+  table {
+    width: 100%;
+    table-layout: auto;
+  }
+
+  th {
+    font-weight: normal;
+  }
+}
+
+.summary {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  font-size: 0.9em;
+  flex-grow: 1;
+}
+</style>

--- a/site/frontend/src/pages/compare/tabs.vue
+++ b/site/frontend/src/pages/compare/tabs.vue
@@ -6,6 +6,7 @@ import {CompareResponse, Tab} from "./types";
 import {diffClass, percentClass} from "./shared";
 import {SummaryGroup} from "./data";
 import SummaryPercentValue from "./summary/percent-value.vue";
+import SummaryRange from "./summary/range.vue";
 
 const props = withDefaults(
   defineProps<{
@@ -55,24 +56,14 @@ const activeTab: Ref<Tab> = ref(props.initialTab);
           <table>
             <thead>
               <tr>
-                <th>min</th>
-                <th>max</th>
-                <th>avg</th>
+                <th>Range</th>
+                <th>Mean</th>
               </tr>
             </thead>
             <thead>
               <tr>
                 <td>
-                  <SummaryPercentValue
-                    :class="percentClass(compileTimeSummary.all.range[0])"
-                    :value="compileTimeSummary.all.range[0]"
-                  />
-                </td>
-                <td>
-                  <SummaryPercentValue
-                    :class="percentClass(compileTimeSummary.all.range[1])"
-                    :value="compileTimeSummary.all.range[1]"
-                  />
+                  <SummaryRange :range="compileTimeSummary.all.range" />
                 </td>
                 <td>
                   <SummaryPercentValue
@@ -94,15 +85,15 @@ const activeTab: Ref<Tab> = ref(props.initialTab);
       @click="changeTab(Tab.Bootstrap)"
     >
       <div class="title">Bootstrap</div>
-      <div
-        :class="{[diffClass(bootstrapB - bootstrapA)]: bootstrapValid}"
-        class="summary"
-      >
+      <div class="summary">
         <div>
           {{ formatBootstrap(bootstrapA) }} ->
           {{ formatBootstrap(bootstrapB) }}
         </div>
-        <div v-if="bootstrapValid">
+        <div
+          v-if="bootstrapValid"
+          :class="{[diffClass(bootstrapB - bootstrapA)]: bootstrapValid}"
+        >
           {{ ((bootstrapB - bootstrapA) / 10e8).toFixed(1) }}s ({{
             (((bootstrapB - bootstrapA) / bootstrapA) * 100).toFixed(3)
           }}%)
@@ -161,7 +152,8 @@ const activeTab: Ref<Tab> = ref(props.initialTab);
 
 .title {
   font-weight: bold;
-  margin-bottom: 4px;
+  font-size: 1.1em;
+  margin-bottom: 5px;
 }
 
 .selected {

--- a/site/frontend/src/pages/compare/types.ts
+++ b/site/frontend/src/pages/compare/types.ts
@@ -66,3 +66,8 @@ export interface CompareResponse {
   new_errors: Array<[string, string]>;
   compile_benchmark_data: [CompileBenchmarkDescription];
 }
+
+export enum Tab {
+  CompileTime,
+  Bootstrap,
+}

--- a/site/frontend/src/pages/compare/types.ts
+++ b/site/frontend/src/pages/compare/types.ts
@@ -68,6 +68,6 @@ export interface CompareResponse {
 }
 
 export enum Tab {
-  CompileTime,
-  Bootstrap,
+  CompileTime = "compile",
+  Bootstrap = "bootstrap",
 }

--- a/site/frontend/src/utils/navigation.ts
+++ b/site/frontend/src/utils/navigation.ts
@@ -42,3 +42,13 @@ export function getUrlParams(): Dict<string> {
 export function navigateToUrlParams(params: URLSearchParams) {
   window.location.search = params.toString();
 }
+
+/**
+ * Changes the current URL without navigating away from the page and without
+ * creating a history entry.
+ */
+export function changeUrl(params: Dict<string>) {
+  if (history.replaceState) {
+    history.replaceState({}, null, createUrlFromParams(params).toString());
+  }
+}

--- a/site/frontend/static/styles/shared.css
+++ b/site/frontend/static/styles/shared.css
@@ -1,6 +1,6 @@
 body {
     font-family: monospace;
-    margin: 3em auto;
+    margin: 2em auto;
 }
 p {
     margin-top: 1.2em;
@@ -70,10 +70,16 @@ img {
   border: 0;
 }
 .container {
-  padding-right: 4em;
-  padding-left: 4em;
+  padding-right: 1em;
+  padding-left: 1em;
   margin-right: auto;
   margin-left: auto;
+}
+@media (min-width: 600px) {
+    .container {
+        padding-right: 4em;
+        padding-left: 4em;
+    }
 }
 
 #as-of {

--- a/site/frontend/templates/layout.html
+++ b/site/frontend/templates/layout.html
@@ -6,6 +6,7 @@
   <link rel="alternate icon" type="image/png" href="/favicon-32x32.png">
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <link rel="stylesheet" type="text/css" href="styles/shared.css">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   {% block head %}{% endblock %}
 </head>
 <body class="container">

--- a/site/frontend/templates/pages/compare.html
+++ b/site/frontend/templates/pages/compare.html
@@ -1,7 +1,5 @@
 {% extends "layout.html" %}
 {% block head %}
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-
 <style>
     body {
         max-width: 1000px;


### PR DESCRIPTION
This PR modifies the UI of the compare page, with several goals:
1) Prepare the page for the inclusion of runtime benchmarks by introducing tabs, combined with a quick summary. This allows us to see bootstrap results without scrolling down a lot.
2) Remove unnecessary padding and spaces and cramp stuff closer together, so that more of the compare table can be seen outright  .
3) Make it look slightly nicer on mobiles.

The commits are mostly atomic and independent, so we can land only some of the changes, if they are too controversial.
More changes could be made, e.g. to put some things that belong together more closer together (such as the quick links with the "Do another comparison"), and in general the page could definitely use some UX love, but for now I think that this is good enough.

<details>
<summary>Before</summary>

![image](https://github.com/rust-lang/rustc-perf/assets/4539057/ea7c76f8-0d4e-4fd9-ab18-d0fde289ec3c)
</details>

<details>
<summary>After</summary>

![image](https://github.com/rust-lang/rustc-perf/assets/4539057/fa0ad3df-df99-4e0e-935f-168297f01c82)

</details>

<details>
<summary>Video (outdated design)</summary>

https://github.com/rust-lang/rustc-perf/assets/4539057/73d03100-92c4-4fee-901b-c2229ca25d93

</details>