### PR TITLE
handle 0 metrics to avoid NaNs during sorting

### DIFF
--- a/site/frontend/src/pages/compare/data.ts
+++ b/site/frontend/src/pages/compare/data.ts
@@ -90,7 +90,22 @@ export function computeTestCasesWithNonRelevant(
     .map((c: CompileBenchmarkComparison): TestCase => {
       const datumA = c.statistics[0];
       const datumB = c.statistics[1];
-      const percent = 100 * ((datumB - datumA) / datumA);
+
+      // In the vast majority of cases, we can do the proportional change calculation. However, some
+      // metrics can be zero. If the initial value is 0, we can't compute the new value as a
+      // percentage change of the old one. If both values are 0, we can say the change is also 0%.
+      // If the new value is not 0, the percentage is not really meaningful, but we can say it's 100%.
+      let percent;
+      if (datumA === 0) {
+        if (datumB === 0) {
+          percent = 0;
+        } else {
+          percent = 100;
+        }
+      } else {
+        percent = 100 * ((datumB - datumA) / datumA);
+      }
+
       return {
         benchmark: c.benchmark,
         profile: c.profile,


### PR DESCRIPTION
Sorting benchmarks expects the initial value to be non-zero like time, this is not always the case with the size and self-profile stats.
That can make the %age change, that we use for sorting, not meaningful when the initial value is 0.

This causes sorting [to be incorrect](https://perf.rust-lang.org/compare.html?start=68c8fdaac071432c0a5c149ece5c094449fbe8e0&end=01c64cbb288ae7a44bb43912291d2b7b6e47da7d&stat=size%3Acgu_instructions&tab=compile).

![image](https://github.com/rust-lang/rustc-perf/assets/247183/1aa60085-a15f-4991-a2c0-629fa6f70cd5)

If both values are 0 we can say the change is 0%, but if the new value is not zero then a percentage doesn't really make sense. Here I say it's 100%, to have an arbitrary value, that if it shows up, will entice people to turn on "Display raw data". I expect this be very rare if it ever happens.

![image](https://github.com/rust-lang/rustc-perf/assets/247183/61e9c68e-703e-48a8-9639-6cec7f5f24c5)
