### PR TITLE
Improve PR rollup table formatting

### DIFF
--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -29,9 +29,11 @@ pub async fn unroll_rollup(
     previous_master: &str,
     rollup_pr_number: u32,
 ) -> Result<(), String> {
+    let commit_link = |sha: &str| format!("https://github.com/rust-lang-ci/rust/commit/{sha}");
+
     let format_commit = |s: &str, truncate: bool| {
         let display = truncate.then(|| s.split_at(10).0).unwrap_or(s);
-        format!("[{display}](https://github.com/rust-lang-ci/rust/commit/{s})")
+        format!("[{display}]({})", commit_link(s))
     };
 
     // Sort rolled up commits by their PR number in ascending order, so that they have the
@@ -49,7 +51,11 @@ pub async fn unroll_rollup(
             let commit = c
                 .sha
                 .as_deref()
-                .map(|s| format_commit(s, false))
+                .map(|s| {
+                    // Format the SHA as a code block to make it easy to copy-paste verbatim
+                    let link = commit_link(s);
+                    format!("`{s}` ([link]({link}))")
+                })
                 .unwrap_or_else(|| {
                     let head = format_commit(&c.rolled_up_head, true);
                     format!("❌ conflicts merging '{head}' into previous master ❌")

--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -141,7 +141,7 @@ async fn enqueue_unrolled_try_builds<'a>(
             .merge_branch(
                 "perf-tmp",
                 &rolled_up_head,
-                &format!("Unrolled build for #{original_pr_number}"),
+                &format!("Unrolled build for #{original_pr_number}\n{}", rollup_merge.message),
             )
             .await
             .map_err(|e| {


### PR DESCRIPTION
The context is described in the linked issue. The last commit isn't mentioned in the issue, but it's something that has bothered me :)

Fixes: https://github.com/rust-lang/rustc-perf/issues/1622

This is how it should look like (simulated, as this is not straightforward to test):
![image](https://github.com/rust-lang/rustc-perf/assets/4539057/72394f5e-4bc1-44de-99f7-70c98cf55581)
