### PR TITLE
Type-check Vue components, not just TypeScript files

### DIFF
--- a/site/frontend/package-lock.json
+++ b/site/frontend/package-lock.json
@@ -23,7 +23,8 @@
         "@types/highcharts": "^7.0.0",
         "@types/msgpack-lite": "^0.1.8",
         "prettier": "2.8.8",
-        "typescript": "^5.0.2"
+        "typescript": "^5.0.2",
+        "vue-tsc": "^1.8.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1774,6 +1775,33 @@
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
+    "node_modules/@volar/language-core": {
+      "version": "1.7.10",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-1.7.10.tgz",
+      "integrity": "sha512-18Gmth5M0UI3hDDqhZngjMnb6WCslcfglkOdepRIhGxRYe7xR7DRRzciisYDMZsvOQxDYme+uaohg0dKUxLV2Q==",
+      "dev": true,
+      "dependencies": {
+        "@volar/source-map": "1.7.10"
+      }
+    },
+    "node_modules/@volar/source-map": {
+      "version": "1.7.10",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-1.7.10.tgz",
+      "integrity": "sha512-FBpLEOKJpRxeh2nYbw1mTI5sZOPXYU8LlsCz6xuBY3yNtAizDTTIZtBHe1V8BaMpoSMgRysZe4gVxMEi3rDGVA==",
+      "dev": true,
+      "dependencies": {
+        "muggle-string": "^0.3.1"
+      }
+    },
+    "node_modules/@volar/typescript": {
+      "version": "1.7.10",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-1.7.10.tgz",
+      "integrity": "sha512-yqIov4wndLU3GE1iE25bU5W6T+P+exPePcE1dFPPBKzQIBki1KvmdQN5jBlJp3Wo+wp7UIxa/RsdNkXT+iFBjg==",
+      "dev": true,
+      "dependencies": {
+        "@volar/language-core": "1.7.10"
+      }
+    },
     "node_modules/@vue/compiler-core": {
       "version": "3.2.47",
       "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.47.tgz",
@@ -1819,6 +1847,67 @@
         "@vue/compiler-dom": "3.2.47",
         "@vue/shared": "3.2.47"
       }
+    },
+    "node_modules/@vue/language-core": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-1.8.3.tgz",
+      "integrity": "sha512-AzhvMYoQkK/tg8CpAAttO19kx1zjS3+weYIr2AhlH/M5HebVzfftQoq4jZNFifjq+hyLKi8j9FiDMS8oqA89+A==",
+      "dev": true,
+      "dependencies": {
+        "@volar/language-core": "1.7.10",
+        "@volar/source-map": "1.7.10",
+        "@vue/compiler-dom": "^3.3.0",
+        "@vue/reactivity": "^3.3.0",
+        "@vue/shared": "^3.3.0",
+        "minimatch": "^9.0.0",
+        "muggle-string": "^0.3.1",
+        "vue-template-compiler": "^2.7.14"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vue/language-core/node_modules/@vue/compiler-core": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.4.tgz",
+      "integrity": "sha512-cquyDNvZ6jTbf/+x+AgM2Arrp6G4Dzbb0R64jiG804HRMfRiFXWI6kqUVqZ6ZR0bQhIoQjB4+2bhNtVwndW15g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.21.3",
+        "@vue/shared": "3.3.4",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.0.2"
+      }
+    },
+    "node_modules/@vue/language-core/node_modules/@vue/compiler-dom": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.4.tgz",
+      "integrity": "sha512-wyM+OjOVpuUukIq6p5+nwHYtj9cFroz9cwkfmP9O1nzH68BenTTv0u7/ndggT8cIQlnBeOo6sUT/gvHcIkLA5w==",
+      "dev": true,
+      "dependencies": {
+        "@vue/compiler-core": "3.3.4",
+        "@vue/shared": "3.3.4"
+      }
+    },
+    "node_modules/@vue/language-core/node_modules/@vue/reactivity": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.4.tgz",
+      "integrity": "sha512-kLTDLwd0B1jG08NBF3R5rqULtv/f8x3rOFByTDz4J53ttIQEDmALqKqXY0J+XQeN0aV2FBxY8nJDf88yvOPAqQ==",
+      "dev": true,
+      "dependencies": {
+        "@vue/shared": "3.3.4"
+      }
+    },
+    "node_modules/@vue/language-core/node_modules/@vue/shared": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
+      "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==",
+      "dev": true
     },
     "node_modules/@vue/reactivity": {
       "version": "3.2.47",
@@ -1876,6 +1965,16 @@
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.47.tgz",
       "integrity": "sha512-BHGyyGN3Q97EZx0taMQ+OLNuZcW3d37ZEVmEAyeoA9ERdGvm9Irc/0Fua8SNyOtV1w6BS4q25wbMzJujO9HIfQ=="
     },
+    "node_modules/@vue/typescript": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@vue/typescript/-/typescript-1.8.3.tgz",
+      "integrity": "sha512-6bdgSnIFpRYHlt70pHmnmNksPU00bfXgqAISeaNz3W6d2cH0OTfH8h/IhligQ82sJIhsuyfftQJ5518ZuKIhtA==",
+      "dev": true,
+      "dependencies": {
+        "@volar/typescript": "1.7.10",
+        "@vue/language-core": "1.8.3"
+      }
+    },
     "node_modules/abortcontroller-polyfill": {
       "version": "1.7.5",
       "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.5.tgz",
@@ -1918,6 +2017,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
     "node_modules/base-x": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
@@ -1944,6 +2049,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
     },
     "node_modules/braces": {
       "version": "3.0.2",
@@ -2176,6 +2290,12 @@
       "version": "2.6.21",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
       "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w=="
+    },
+    "node_modules/de-indent": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
+      "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
+      "dev": true
     },
     "node_modules/detect-libc": {
       "version": "1.0.3",
@@ -2425,6 +2545,15 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "bin": {
+        "he": "bin/he"
       }
     },
     "node_modules/highcharts": {
@@ -2833,6 +2962,18 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
       "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ=="
     },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.25.9",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
@@ -2856,6 +2997,21 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.2.tgz",
+      "integrity": "sha512-PZOT9g5v2ojiTL7r1xF6plNHLtOeTpSlDI007As2NlA2aYBMfVom17yqa6QzhmDP8QOhn7LjHTg7DFCVSSa6yg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/msgpack-lite": {
@@ -2911,6 +3067,12 @@
         "node-gyp-build-optional-packages-optional": "optional.js",
         "node-gyp-build-optional-packages-test": "build-test.js"
       }
+    },
+    "node_modules/muggle-string": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.3.1.tgz",
+      "integrity": "sha512-ckmWDJjphvd/FvZawgygcUeQCxzvohjFO5RxTjj4eq8kw359gFF3E1brjfI+viLMxss5JrHTDRHZvu2/tuy0Qg==",
+      "dev": true
     },
     "node_modules/nanoid": {
       "version": "3.3.6",
@@ -3555,6 +3717,48 @@
         "@vue/shared": "3.2.47"
       }
     },
+    "node_modules/vue-template-compiler": {
+      "version": "2.7.14",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.14.tgz",
+      "integrity": "sha512-zyA5Y3ArvVG0NacJDkkzJuPQDF8RFeRlzV2vLeSnhSpieO6LK2OVbdLPi5MPPs09Ii+gMO8nY4S3iKQxBxDmWQ==",
+      "dev": true,
+      "dependencies": {
+        "de-indent": "^1.0.2",
+        "he": "^1.2.0"
+      }
+    },
+    "node_modules/vue-tsc": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-1.8.3.tgz",
+      "integrity": "sha512-Ua4DHuYxjudlhCW2nRZtaXbhIDVncRGIbDjZhHpF8Z8vklct/G/35/kAPuGNSOmq0JcvhPAe28Oa7LWaUerZVA==",
+      "dev": true,
+      "dependencies": {
+        "@vue/language-core": "1.8.3",
+        "@vue/typescript": "1.8.3",
+        "semver": "^7.3.8"
+      },
+      "bin": {
+        "vue-tsc": "bin/vue-tsc.js"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      }
+    },
+    "node_modules/vue-tsc/node_modules/semver": {
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/weak-lru-cache": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/weak-lru-cache/-/weak-lru-cache-1.2.2.tgz",
@@ -3564,6 +3768,12 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-0.4.2.tgz",
       "integrity": "sha512-/eyHVRJQCirEkSZ1agRSCwriMhwlyUcFkXD5TPVSLP+IPzjsqMVzZwdoczLp1SoQU0R3dxz1RpIK+4YNQbCVOA=="
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/yaml": {
       "version": "1.10.2",

--- a/site/frontend/package.json
+++ b/site/frontend/package.json
@@ -6,7 +6,7 @@
     "watch": "parcel watch --no-hmr",
     "build": "parcel build",
     "fmt": "prettier --write src",
-    "check": "tsc -p tsconfig.json --noEmit && prettier --check src"
+    "check": "vue-tsc -p tsconfig.json --noEmit && prettier --check src"
   },
   "author": "",
   "license": "MIT",
@@ -16,7 +16,8 @@
     "@types/highcharts": "^7.0.0",
     "@types/msgpack-lite": "^0.1.8",
     "prettier": "2.8.8",
-    "typescript": "^5.0.2"
+    "typescript": "^5.0.2",
+    "vue-tsc": "^1.8.3"
   },
   "dependencies": {
     "highcharts": "6.0.7",

--- a/site/frontend/src/pages/compare/compile/comparisons-table.vue
+++ b/site/frontend/src/pages/compare/compile/comparisons-table.vue
@@ -159,14 +159,14 @@ function prettifyRawNumber(number: number): string {
             </td>
             <td v-if="showRawData" class="numeric">
               <a v-bind:href="detailedQueryRawDataLink(commitA, comparison)">
-                <abbr :title="comparison.datumA">{{
+                <abbr :title="comparison.datumA.toString()">{{
                   prettifyRawNumber(comparison.datumA)
                 }}</abbr>
               </a>
             </td>
             <td v-if="showRawData" class="numeric">
               <a v-bind:href="detailedQueryRawDataLink(commitB, comparison)">
-                <abbr :title="comparison.datumB">{{
+                <abbr :title="comparison.datumB.toString()">{{
                   prettifyRawNumber(comparison.datumB)
                 }}</abbr>
               </a>

--- a/site/frontend/src/pages/compare/runtime/comparisons-table.vue
+++ b/site/frontend/src/pages/compare/runtime/comparisons-table.vue
@@ -90,12 +90,12 @@ function prettifyRawNumber(number: number): string {
               </div>
             </td>
             <td v-if="showRawData" class="numeric">
-              <abbr :title="comparison.datumA">{{
+              <abbr :title="comparison.datumA.toString()">{{
                 prettifyRawNumber(comparison.datumA)
               }}</abbr>
             </td>
             <td v-if="showRawData" class="numeric">
-              <abbr :title="comparison.datumB">{{
+              <abbr :title="comparison.datumB.toString()">{{
                 prettifyRawNumber(comparison.datumB)
               }}</abbr>
             </td>

--- a/site/frontend/src/pages/compare/summary/percent-value.vue
+++ b/site/frontend/src/pages/compare/summary/percent-value.vue
@@ -15,8 +15,8 @@ const formattedValue = computed((): string => {
 });
 const padSpaces = computed((): string => {
   const value = formattedValue.value;
-  if (value.length < this.padWidth) {
-    return "&nbsp;".repeat(this.padWidth - value.length);
+  if (value.length < props.padWidth) {
+    return "&nbsp;".repeat(props.padWidth - value.length);
   }
   return "";
 });

--- a/site/frontend/src/pages/compare/tabs.vue
+++ b/site/frontend/src/pages/compare/tabs.vue
@@ -51,7 +51,7 @@ function SummaryTable({summary}: {summary: SummaryGroup}) {
             </td>
             <td>
               <SummaryPercentValue
-                className={percentClass(summary.all.average)}
+                class={percentClass(summary.all.average)}
                 value={summary.all.average}
               />
             </td>

--- a/site/frontend/tsconfig.json
+++ b/site/frontend/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "lib": ["es2020", "dom"],
     "target": "es2017",
+    "module": "es2022",
     "moduleResolution": "node",
     "rootDir": "src",
     "esModuleInterop": true,


### PR DESCRIPTION
Before, only TypeScript files were checked, but most of the frontend code is actually in Vue components. This PR fixes that, and also resolves a few issues found by the type-checker in Vue components.