### PR TITLE
update `proc-macro2` to build on the latest nightly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1870,9 +1870,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.52"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]


### PR DESCRIPTION
`proc-macro2` had some breakage, so `rustc-perf` currently doesn't build on nightly, like https://github.com/rust-lang/rust/issues/113152.

The latest version fixes that issue and also builds on stable.

