### PR TITLE
Perform runtime benchmarks when benchmarking published artifacts

### DIFF
--- a/collector/src/compile/execute/bencher.rs
+++ b/collector/src/compile/execute/bencher.rs
@@ -6,7 +6,7 @@ use crate::compile::execute::{
     rustc, DeserializeStatError, PerfTool, ProcessOutputData, Processor, Retry, SelfProfile,
     SelfProfileFiles, Stats, Upload,
 };
-use crate::toolchain::Compiler;
+use crate::toolchain::Toolchain;
 use crate::utils::git::get_rustc_perf_commit;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
@@ -160,11 +160,11 @@ impl<'a> BenchProcessor<'a> {
             .block_on(async move { while let Some(()) = buf.next().await {} });
     }
 
-    pub fn measure_rustc(&mut self, compiler: Compiler<'_>) -> anyhow::Result<()> {
+    pub fn measure_rustc(&mut self, toolchain: &Toolchain) -> anyhow::Result<()> {
         rustc::measure(
             self.rt,
             self.conn,
-            compiler,
+            toolchain,
             self.artifact,
             self.artifact_row_id,
         )

--- a/collector/src/runtime/benchmark.rs
+++ b/collector/src/runtime/benchmark.rs
@@ -66,7 +66,14 @@ pub struct BenchmarkFilter {
 }
 
 impl BenchmarkFilter {
-    pub fn new(exclude: Option<String>, include: Option<String>) -> BenchmarkFilter {
+    pub fn keep_all() -> Self {
+        Self {
+            exclude: None,
+            include: None,
+        }
+    }
+
+    pub fn new(exclude: Option<String>, include: Option<String>) -> Self {
         Self { exclude, include }
     }
 }
@@ -87,7 +94,7 @@ pub enum CargoIsolationMode {
 /// We assume that each binary defines a benchmark suite using `benchlib`.
 /// We then execute each benchmark suite with the `list-benchmarks` command to find out its
 /// benchmark names.
-pub fn create_runtime_benchmark_suite(
+pub fn prepare_runtime_benchmark_suite(
     toolchain: &Toolchain,
     benchmark_dir: &Path,
     isolation_mode: CargoIsolationMode,
@@ -124,7 +131,7 @@ pub fn create_runtime_benchmark_suite(
 
         let cargo_process = start_cargo_build(toolchain, &benchmark_crate.path, target_dir)
             .with_context(|| {
-                anyhow::anyhow!("Cannot not start compilation of {}", benchmark_crate.name)
+                anyhow::anyhow!("Cannot start compilation of {}", benchmark_crate.name)
             })?;
         let group =
             parse_benchmark_group(cargo_process, &benchmark_crate.name).with_context(|| {

--- a/collector/src/runtime/benchmark.rs
+++ b/collector/src/runtime/benchmark.rs
@@ -6,7 +6,7 @@ use core::option::Option;
 use core::option::Option::Some;
 use core::result::Result::Ok;
 use std::collections::HashMap;
-use std::io::{BufReader, Write};
+use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use tempfile::TempDir;
@@ -114,14 +114,11 @@ pub fn create_runtime_benchmark_suite(
 
     let mut groups = Vec::new();
     for (index, benchmark_crate) in benchmark_crates.into_iter().enumerate() {
-        // Show incremental progress
-        print!(
-            "\r{}\rCompiling `{}` ({}/{group_count})",
-            " ".repeat(80),
-            benchmark_crate.name,
+        println!(
+            "Compiling {:<22} ({}/{group_count})",
+            format!("`{}`", benchmark_crate.name),
             index + 1
         );
-        std::io::stdout().flush().unwrap();
 
         let target_dir = temp_dir.as_ref().map(|d| d.path());
 
@@ -135,7 +132,6 @@ pub fn create_runtime_benchmark_suite(
             })?;
         groups.push(group);
     }
-    println!();
 
     groups.sort_unstable_by(|a, b| a.binary.cmp(&b.binary));
     log::debug!("Found binaries: {:?}", groups);

--- a/collector/src/runtime/benchmark.rs
+++ b/collector/src/runtime/benchmark.rs
@@ -1,4 +1,4 @@
-use crate::toolchain::LocalToolchain;
+use crate::toolchain::Toolchain;
 use anyhow::Context;
 use benchlib::benchmark::passes_filter;
 use cargo_metadata::Message;
@@ -88,7 +88,7 @@ pub enum CargoIsolationMode {
 /// We then execute each benchmark suite with the `list-benchmarks` command to find out its
 /// benchmark names.
 pub fn create_runtime_benchmark_suite(
-    toolchain: &LocalToolchain,
+    toolchain: &Toolchain,
     benchmark_dir: &Path,
     isolation_mode: CargoIsolationMode,
 ) -> anyhow::Result<BenchmarkSuite> {
@@ -233,7 +233,7 @@ fn parse_benchmark_group(
 /// Starts the compilation of a single runtime benchmark crate.
 /// Returns the stdout output stream of Cargo.
 fn start_cargo_build(
-    toolchain: &LocalToolchain,
+    toolchain: &Toolchain,
     benchmark_dir: &Path,
     target_dir: Option<&Path>,
 ) -> anyhow::Result<Child> {

--- a/collector/src/runtime/mod.rs
+++ b/collector/src/runtime/mod.rs
@@ -6,7 +6,7 @@ use thousands::Separable;
 
 use benchlib::comm::messages::{BenchmarkMessage, BenchmarkResult, BenchmarkStats};
 pub use benchmark::{
-    create_runtime_benchmark_suite, runtime_benchmark_dir, BenchmarkFilter, BenchmarkGroup,
+    prepare_runtime_benchmark_suite, runtime_benchmark_dir, BenchmarkFilter, BenchmarkGroup,
     BenchmarkSuite, CargoIsolationMode,
 };
 use database::{ArtifactIdNumber, CollectionId, Connection};
@@ -15,6 +15,8 @@ use crate::utils::git::get_rustc_perf_commit;
 use crate::CollectorCtx;
 
 mod benchmark;
+
+pub const DEFAULT_RUNTIME_ITERATIONS: u32 = 5;
 
 /// Perform a series of runtime benchmarks using the provided `rustc` compiler.
 /// The runtime benchmarks are looked up in `benchmark_dir`, which is expected to be a path

--- a/collector/src/toolchain.rs
+++ b/collector/src/toolchain.rs
@@ -416,6 +416,10 @@ pub fn create_toolchain_from_published_version(
     let rustdoc = which("rustdoc")?;
     let cargo = which("cargo")?;
 
+    debug!("Found rustc: {}", rustc.display());
+    debug!("Found rustdoc: {}", rustdoc.display());
+    debug!("Found cargo: {}", cargo.display());
+
     Ok(Toolchain {
         rustc,
         rustdoc: Some(rustdoc),

--- a/collector/src/toolchain.rs
+++ b/collector/src/toolchain.rs
@@ -9,6 +9,7 @@ use std::{fmt, str};
 use tar::Archive;
 use xz2::bufread::XzDecoder;
 
+/// Sysroot downloaded from CI.
 pub struct Sysroot {
     pub sha: String,
     pub rustc: PathBuf,
@@ -214,42 +215,26 @@ impl SysrootDownload {
     }
 }
 
-#[derive(Debug, Copy, Clone)]
-pub struct Compiler<'a> {
-    pub rustc: &'a Path,
-    pub rustdoc: Option<&'a Path>,
-    pub cargo: &'a Path,
-    pub triple: &'a str,
-    pub is_nightly: bool,
-}
-
-impl<'a> Compiler<'a> {
-    pub fn from_sysroot(sysroot: &'a Sysroot) -> Compiler<'a> {
-        Compiler {
-            rustc: &sysroot.rustc,
-            rustdoc: Some(&sysroot.rustdoc),
-            cargo: &sysroot.cargo,
-            triple: &sysroot.triple,
-            is_nightly: true,
-        }
-    }
-    pub fn from_toolchain(toolchain: &'a LocalToolchain, target_triple: &'a str) -> Compiler<'a> {
-        Compiler {
-            rustc: &toolchain.rustc,
-            rustdoc: toolchain.rustdoc.as_deref(),
-            cargo: &toolchain.cargo,
-            triple: target_triple,
-            is_nightly: true,
-        }
-    }
-}
-
-#[derive(Debug)]
-pub struct LocalToolchain {
+/// Representation of a toolchain that can be used to compile Rust programs.
+#[derive(Debug, Clone)]
+pub struct Toolchain {
     pub rustc: PathBuf,
     pub rustdoc: Option<PathBuf>,
     pub cargo: PathBuf,
     pub id: String,
+    pub triple: String,
+}
+
+impl Toolchain {
+    pub fn from_sysroot(sysroot: &Sysroot, id: String) -> Self {
+        Self {
+            rustc: sysroot.rustc.clone(),
+            rustdoc: Some(sysroot.rustdoc.clone()),
+            cargo: sysroot.cargo.clone(),
+            id,
+            triple: sysroot.triple.clone(),
+        }
+    }
 }
 
 /// Get a toolchain from the input.
@@ -265,7 +250,8 @@ pub fn get_local_toolchain(
     cargo: Option<&Path>,
     id: Option<&str>,
     id_suffix: &str,
-) -> anyhow::Result<LocalToolchain> {
+    target_triple: String,
+) -> anyhow::Result<Toolchain> {
     // `+`-prefixed rustc is an indicator to fetch the rustc of the toolchain
     // specified. This follows the similar pattern used by rustup's binaries
     // (e.g., `rustc +stage1`).
@@ -388,10 +374,11 @@ pub fn get_local_toolchain(
         cargo
     };
 
-    Ok(LocalToolchain {
+    Ok(Toolchain {
         rustc,
         rustdoc,
         cargo,
         id,
+        triple: target_triple,
     })
 }


### PR DESCRIPTION
This PR contains several cleanups that make it easier to run both compile and runtime benchmarks in the same `collector` execution, and finally it enables runtime benchmarks when published artifacts are benchmarked.

It can be tried e.g. with:
```bash
$ cargo run --bin collector bench_published 1.70.0
```