### PR TITLE
Notify website to refresh itself if published artifact has an error

### DIFF
--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -843,14 +843,16 @@ fn main_result() -> anyhow::Result<i32> {
             match next {
                 NextArtifact::Release(tag) => {
                     let toolchain = create_toolchain_from_published_version(&tag, &target_triple)?;
-                    bench_published_artifact(
+                    let res = bench_published_artifact(
                         &toolchain,
                         rt.block_on(pool.connection()),
                         &mut rt,
                         &benchmark_dirs,
-                    )?;
+                    );
 
                     client.post(format!("{}/perf/onpush", site_url)).send()?;
+
+                    res?;
                 }
                 NextArtifact::Commit {
                     commit,


### PR DESCRIPTION
Before, it would just crash the collector and the website wouldn't be refreshed. This mirrors the behaviour of `BenchNext` with a non-published artifact.

Ideally, when the collector fails to benchmark a published release, we should also notify someone somehow, e.g. by sending an e-mail or something like that, so that we know when a stable release fails to perform the benchmarks. I'm not sure if there's any pre-existing mechanism for that (log analysis?).