### PR TITLE
Refactor runtime benchmarks in `bench_published`

### DIFF
--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -308,33 +308,25 @@ pub struct CollectorCtx {
 
 impl CollectorCtx {
     pub async fn start_compile_step(
-        &mut self,
-        conn: &mut dyn Connection,
+        &self,
+        conn: &dyn Connection,
         benchmark_name: &BenchmarkName,
     ) -> bool {
         conn.collector_start_step(self.artifact_row_id, &benchmark_name.0)
             .await
     }
 
-    pub async fn end_compile_step(
-        &mut self,
-        conn: &mut dyn Connection,
-        benchmark_name: &BenchmarkName,
-    ) {
+    pub async fn end_compile_step(&self, conn: &dyn Connection, benchmark_name: &BenchmarkName) {
         conn.collector_end_step(self.artifact_row_id, &benchmark_name.0)
             .await
     }
 
-    pub async fn start_runtime_step(
-        &mut self,
-        conn: &mut dyn Connection,
-        group: &BenchmarkGroup,
-    ) -> bool {
+    pub async fn start_runtime_step(&self, conn: &dyn Connection, group: &BenchmarkGroup) -> bool {
         conn.collector_start_step(self.artifact_row_id, &runtime_group_step_name(group))
             .await
     }
 
-    pub async fn end_runtime_step(&mut self, conn: &mut dyn Connection, group: &BenchmarkGroup) {
+    pub async fn end_runtime_step(&self, conn: &dyn Connection, group: &BenchmarkGroup) {
         conn.collector_end_step(self.artifact_row_id, &runtime_group_step_name(group))
             .await
     }

--- a/collector/src/runtime/mod.rs
+++ b/collector/src/runtime/mod.rs
@@ -46,6 +46,7 @@ pub async fn bench_runtime(
             continue;
         }
 
+        let mut tx = conn.transaction().await;
         for message in execute_runtime_benchmark_binary(&group.binary, &filter, iterations)? {
             let message = message.map_err(|err| {
                 anyhow::anyhow!(
@@ -63,7 +64,7 @@ pub async fn bench_runtime(
 
                     print_stats(&result);
                     record_stats(
-                        conn.as_ref(),
+                        tx.conn(),
                         collector.artifact_row_id,
                         &rustc_perf_version,
                         result,
@@ -73,7 +74,10 @@ pub async fn bench_runtime(
             }
         }
 
-        collector.end_runtime_step(conn.as_mut(), &group).await;
+        collector.end_runtime_step(tx.conn(), &group).await;
+        tx.commit()
+            .await
+            .expect("Cannot commit runtime benchmark group results");
     }
 
     Ok(())

--- a/collector/src/runtime/mod.rs
+++ b/collector/src/runtime/mod.rs
@@ -25,7 +25,7 @@ pub const DEFAULT_RUNTIME_ITERATIONS: u32 = 5;
 pub async fn bench_runtime(
     mut conn: Box<dyn Connection>,
     suite: BenchmarkSuite,
-    mut collector: CollectorCtx,
+    collector: &CollectorCtx,
     filter: BenchmarkFilter,
     iterations: u32,
 ) -> anyhow::Result<()> {


### PR DESCRIPTION
Add a transaction when storing runtime benchmark metrics and generalize the code a bit to make it easier to run both compile and runtime benchmarks at once.