### PR TITLE
Generalize configuration of benchmarks

### DIFF
--- a/collector/src/runtime/mod.rs
+++ b/collector/src/runtime/mod.rs
@@ -23,7 +23,7 @@ pub const DEFAULT_RUNTIME_ITERATIONS: u32 = 5;
 /// to a Cargo crate. All binaries built by that crate are expected to be runtime benchmark
 /// groups that use `benchlib`.
 pub async fn bench_runtime(
-    mut conn: Box<dyn Connection>,
+    conn: &mut dyn Connection,
     suite: BenchmarkSuite,
     collector: &CollectorCtx,
     filter: BenchmarkFilter,
@@ -41,7 +41,7 @@ pub async fn bench_runtime(
 
     let mut benchmark_index = 0;
     for group in suite.groups {
-        if !collector.start_runtime_step(conn.as_mut(), &group).await {
+        if !collector.start_runtime_step(conn, &group).await {
             eprintln!("skipping {} -- already benchmarked", group.name);
             continue;
         }


### PR DESCRIPTION
We will soon want to execute both compile and runtime benchmarks on multiple places. The current configuration of benchmarks was quite ad hoc. This PR introduces specialized config structs for both compile and runtime benchmarks (and also for configuration which is shared amongst them). It is a bit verbose, but also explicit.

All the call sites in `collector` are transitioned to using the `run_benchmarks` function, but so far runtime benchmarks only run for `bench_runtime_local` and `bench_published`.