### PR TITLE
Runtime benchmarks changes

### DIFF
--- a/collector/benchlib/src/benchmark.rs
+++ b/collector/benchlib/src/benchmark.rs
@@ -80,6 +80,13 @@ impl BenchmarkGroup {
 
         for (name, benchmark_fn) in items {
             let mut stats: Vec<BenchmarkStats> = Vec::with_capacity(args.iterations as usize);
+            // Warm-up
+            for _ in 0..3 {
+                let benchmark_stats = benchmark_fn()?;
+                black_box(benchmark_stats);
+            }
+
+            // Actual measurement
             for i in 0..args.iterations {
                 let benchmark_stats = benchmark_fn()?;
                 log::info!("Benchmark (run {i}) `{name}` completed: {benchmark_stats:?}");

--- a/collector/benchlib/src/benchmark.rs
+++ b/collector/benchlib/src/benchmark.rs
@@ -120,7 +120,7 @@ pub fn passes_filter(name: &str, exclude: Option<&str>, include: Option<&str>) -
     }
 }
 
-/// Copied from `iai`, so that we don't have to use unstable features.
+/// Copied from `iai`, so that it works on Rustc older than 1.66.
 pub fn black_box<T>(dummy: T) -> T {
     unsafe {
         let ret = std::ptr::read_volatile(&dummy);

--- a/collector/runtime-benchmarks/bufreader/Cargo.lock
+++ b/collector/runtime-benchmarks/bufreader/Cargo.lock
@@ -87,7 +87,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bufreader"
+name = "bufreader-bench"
 version = "0.1.0"
 dependencies = [
  "benchlib",

--- a/collector/runtime-benchmarks/bufreader/Cargo.toml
+++ b/collector/runtime-benchmarks/bufreader/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "bufreader"
+name = "bufreader-bench"
 version = "0.1.0"
 edition = "2021"
 

--- a/collector/runtime-benchmarks/hashmap/Cargo.lock
+++ b/collector/runtime-benchmarks/hashmap/Cargo.lock
@@ -4,11 +4,11 @@ version = 3
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
- "getrandom",
+ "cfg-if",
  "once_cell",
  "version_check",
 ]
@@ -207,21 +207,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
 name = "hashbrown"
-version = "0.12.3"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
  "ahash",
 ]
@@ -460,12 +449,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"

--- a/collector/runtime-benchmarks/hashmap/Cargo.toml
+++ b/collector/runtime-benchmarks/hashmap/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 benchlib = { path = "../../benchlib" }
-hashbrown = "0.12.3"
+hashbrown = { version = "0.13.2" }
 fxhash = "0.2.1"
 
 [workspace]

--- a/collector/runtime-benchmarks/hashmap/src/main.rs
+++ b/collector/runtime-benchmarks/hashmap/src/main.rs
@@ -1,19 +1,85 @@
 use benchlib;
-use benchlib::benchmark::run_benchmark_group;
+use benchlib::benchmark::{black_box, run_benchmark_group};
 
 fn main() {
     run_benchmark_group(|group| {
-        // Measures how long does it take to insert 10 thousand numbers into a `hashbrown` hashmap.
-        group.register_benchmark("hashmap_insert_10k", || {
+        // Measures how long does it take to insert 1 million numbers into a hashmap.
+        group.register_benchmark("hashmap_insert_1m", || {
+            let count = 1_000_000;
             let mut map = hashbrown::HashMap::with_capacity_and_hasher(
-                10000,
+                // Over allocate the hashmap to avoid reallocations when inserting
+                count * 2,
                 fxhash::FxBuildHasher::default(),
             );
             move || {
-                for index in 0..10000 {
+                for index in 0..count {
                     map.insert(index, index);
                 }
             }
+        });
+
+        // Measures how long it takes to remove 1 million elements from a hashmap.
+        group.register_benchmark("hashmap_remove_1m", || {
+            let mut map = hashbrown::HashMap::with_capacity_and_hasher(
+                1_000_000,
+                fxhash::FxBuildHasher::default(),
+            );
+            for index in 0..map.capacity() {
+                map.insert(index, index);
+            }
+
+            move || {
+                for index in 0..map.capacity() {
+                    map.remove(&index);
+                }
+            }
+        });
+
+        // Measures how long it takes to find 1 million elements that are in a hashmap.
+        group.register_benchmark("hashmap_find_1m", || {
+            let mut map = hashbrown::HashMap::with_capacity_and_hasher(
+                1_000_000,
+                fxhash::FxBuildHasher::default(),
+            );
+            for index in 0..map.capacity() {
+                map.insert(index, index);
+            }
+
+            move || {
+                for index in 0..map.capacity() {
+                    black_box(map.get(&index));
+                }
+            }
+        });
+
+        // Measures how long it takes to find 1 million elements that are not in a hashmap.
+        group.register_benchmark("hashmap_find_misses_1m", || {
+            let mut map = hashbrown::HashMap::with_capacity_and_hasher(
+                1_000_000,
+                fxhash::FxBuildHasher::default(),
+            );
+            for index in 0..map.capacity() {
+                map.insert(index, index);
+            }
+
+            move || {
+                for index in map.capacity()..(map.capacity() * 2) {
+                    black_box(map.get(&index));
+                }
+            }
+        });
+
+        // Measures how long it takes to iterate through values of a hashmap with 1 million elements.
+        group.register_benchmark("hashmap_iterate_1m", || {
+            let mut map = hashbrown::HashMap::with_capacity_and_hasher(
+                1_000_000,
+                fxhash::FxBuildHasher::default(),
+            );
+            for index in 0..map.capacity() {
+                map.insert(index, index as u64);
+            }
+
+            move || map.values().sum::<u64>()
         });
     });
 }

--- a/collector/runtime-benchmarks/nbody/src/main.rs
+++ b/collector/runtime-benchmarks/nbody/src/main.rs
@@ -1,12 +1,11 @@
-//! Calculates the N-body simulation.
-//! Code taken from https://github.com/prestontw/rust-nbody
-
 use benchlib::benchmark::run_benchmark_group;
 
 mod nbody;
 
 fn main() {
     run_benchmark_group(|group| {
+        // Calculates the N-body simulation.
+        // Code taken from https://github.com/prestontw/rust-nbody
         group.register_benchmark("nbody_5k", || {
             let mut nbody = nbody::init(5000);
             || {

--- a/collector/runtime-benchmarks/nbody/src/main.rs
+++ b/collector/runtime-benchmarks/nbody/src/main.rs
@@ -7,13 +7,13 @@ mod nbody;
 
 fn main() {
     run_benchmark_group(|group| {
-        group.register_benchmark("nbody_10k", || {
-            let mut nbody_10k = nbody::init(10000);
+        group.register_benchmark("nbody_5k", || {
+            let mut nbody = nbody::init(5000);
             || {
                 for _ in 0..10 {
-                    nbody_10k = nbody::compute_forces(nbody_10k);
+                    nbody = nbody::compute_forces(nbody);
                 }
-                nbody_10k
+                nbody
             }
         });
     });

--- a/collector/src/runtime/mod.rs
+++ b/collector/src/runtime/mod.rs
@@ -221,9 +221,11 @@ fn print_stats(result: &BenchmarkResult) {
                     .map(|v| (v as f64 - mean).powf(2.0)),
             )
             .sqrt();
+            let min = result.stats.iter().map(&f).min().unwrap_or(0);
 
             println!(
-                "{name:>18}: {:>16} (+/- {:>11})",
+                "{name:>18}: min:{:>16}    mean: {:>16}    stddev: {:>11}",
+                min.separate_with_commas(),
                 (mean as u64).separate_with_commas(),
                 (stddev as u64).separate_with_commas()
             );


### PR DESCRIPTION
Performs some small changes to runtime benchmarks and the benchmark harness.

I will also send a series of PRs adding various new runtime benchmarks. I'm not claiming that we should use these for the "final" benchmark suite, I just want to add more diverse code here, so that we can find out issues on CI (too long/short benchmarks, slow compilation of runtime benchmarks, too much noise etc.).