### PR TITLE
Ignore duplicate values in `artifact_collection_duration` in Postgre

### DIFF
--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -445,6 +445,7 @@ impl PostgresConnection {
                         date_recorded,
                         duration
                     ) VALUES ($1, CURRENT_TIMESTAMP, $2)
+                    ON CONFLICT DO NOTHING
                 ").await.unwrap(),
                 in_progress_steps: conn.prepare("
                 select step,


### PR DESCRIPTION
Since https://github.com/rust-lang/rustc-perf/pull/1637, we record artifact duration collection unconditionally, even if some benchmarks were skipped (and thus computed sometime before). SQLite was able to handle this, but Postgre errors out on a duplicate key.

This PR changes the behaviour of Postgre to also ignore the duplicate records. This situation actually shouldn't even happen on the server (unless we manually backfill runtime benchmarks for an already benchmarked artifact, which we will probably want to do for a few artifacts), but it would be nice if it was handled gracefully anyway.