### PR TITLE
Add a command and benchmark flags to remove artifact data

### DIFF
--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -413,6 +413,21 @@ struct BenchRustcOption {
     bench_rustc: bool,
 }
 
+#[derive(Clone, Debug, clap::ValueEnum)]
+enum PurgeMode {
+    /// Purge all old data associated with the artifact
+    Old,
+    /// Purge old data of failed benchmarks associated with the artifact
+    Failed,
+}
+
+#[derive(Debug, clap::Args)]
+struct PurgeOption {
+    /// Removes old data for the specified artifact prior to running the benchmarks.
+    #[arg(long = "purge")]
+    purge: Option<PurgeMode>,
+}
+
 // For each subcommand we list the mandatory arguments in the required
 // order, followed by the options in alphabetical order.
 #[derive(Debug, clap::Subcommand)]
@@ -437,6 +452,9 @@ enum Commands {
         /// faster.
         #[arg(long = "no-isolate")]
         no_isolate: bool,
+
+        #[command(flatten)]
+        purge: PurgeOption,
     },
 
     /// Profiles a runtime benchmark.
@@ -493,6 +511,9 @@ enum Commands {
 
         #[command(flatten)]
         self_profile: SelfProfileOption,
+
+        #[command(flatten)]
+        purge: PurgeOption,
     },
 
     /// Benchmarks the next commit or release for perf.rust-lang.org
@@ -629,6 +650,7 @@ fn main_result() -> anyhow::Result<i32> {
             iterations,
             db,
             no_isolate,
+            purge,
         } => {
             log_db(&db);
             let toolchain = get_local_toolchain_for_runtime_benchmarks(&local, &target_triple)?;
@@ -642,6 +664,8 @@ fn main_result() -> anyhow::Result<i32> {
 
             let mut conn = rt.block_on(pool.connection());
             let artifact_id = ArtifactId::Tag(toolchain.id.clone());
+            rt.block_on(purge_old_data(conn.as_mut(), &artifact_id, purge.purge));
+
             let runtime_suite = rt.block_on(load_runtime_benchmarks(
                 conn.as_mut(),
                 &runtime_benchmark_dir,
@@ -756,6 +780,7 @@ fn main_result() -> anyhow::Result<i32> {
             bench_rustc,
             iterations,
             self_profile,
+            purge,
         } => {
             log_db(&db);
             let profiles = opts.profiles.0;
@@ -784,7 +809,9 @@ fn main_result() -> anyhow::Result<i32> {
             benchmarks.retain(|b| b.category().is_primary_or_secondary());
 
             let artifact_id = ArtifactId::Tag(toolchain.id.clone());
-            let conn = rt.block_on(pool.connection());
+            let mut conn = rt.block_on(pool.connection());
+            rt.block_on(purge_old_data(conn.as_mut(), &artifact_id, purge.purge));
+
             let shared = SharedBenchmarkConfig {
                 toolchain,
                 artifact_id,
@@ -1130,6 +1157,28 @@ async fn record_runtime_compilation_errors(
 
 fn log_db(db_option: &DbOption) {
     println!("Using database `{}`", db_option.db);
+}
+
+async fn purge_old_data(
+    conn: &mut dyn Connection,
+    artifact_id: &ArtifactId,
+    purge_mode: Option<PurgeMode>,
+) {
+    match purge_mode {
+        Some(PurgeMode::Old) => {
+            // Delete everything associated with the artifact
+            conn.purge_artifact(artifact_id).await;
+        }
+        Some(PurgeMode::Failed) => {
+            // Delete all benchmarks that have an error for the given artifact
+            let artifact_row_id = conn.artifact_id(artifact_id).await;
+            let errors = conn.get_error(artifact_row_id).await;
+            for krate in errors.keys() {
+                conn.collector_remove_step(artifact_row_id, krate).await;
+            }
+        }
+        None => {}
+    }
 }
 
 /// Record a collection entry into the database, specifying which benchmark steps will be executed.

--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -552,6 +552,15 @@ enum Commands {
 
     /// Download a crate into collector/benchmarks.
     Download(DownloadCommand),
+
+    /// Removes all data associated with artifact(s) with the given name.
+    PurgeArtifact {
+        /// Name of the artifact.
+        name: String,
+
+        #[command(flatten)]
+        db: DbOption,
+    },
 }
 
 #[derive(Debug, clap::Parser)]
@@ -1055,6 +1064,14 @@ Make sure to modify `{dir}/perf-config.json` if the category/artifact don't matc
                 cmd.artifact,
                 dir = target_dir.display(),
             );
+            Ok(0)
+        }
+        Commands::PurgeArtifact { name, db } => {
+            let pool = Pool::open(&db.db);
+            let conn = rt.block_on(pool.connection());
+            rt.block_on(conn.purge_artifact(&ArtifactId::Tag(name.clone())));
+
+            println!("Data of artifact {name} were removed");
             Ok(0)
         }
     }

--- a/database/manual-modifications.md
+++ b/database/manual-modifications.md
@@ -1,5 +1,6 @@
-# Useful queries
-This document contains useful queries that should be performed manually in exceptional situations.
+# Useful queries and commands
+This document contains useful queries and commands that should be performed manually in exceptional
+situations.
 
 ## Remove data for a stable artifact from the DB
 This is important for situations where there is some compilation error for a stable benchmark,
@@ -8,9 +9,16 @@ of future incompatibility lints turning into errors.
 
 The benchmark should be fixed first, and then the DB should be altered (see below).
 
-The easiest solution is to simply completely remove the artifact from the DB. There are
-`ON DELETE CASCADE` clauses for `aid` (artifact ID) on tables that reference it, so it should be
-enough to just delete the artifact from the `artifact` table.
+The easiest solution is to simply completely remove the artifact from the DB.
+You can do that either using the following command:
+
+```bash
+$ cargo run --bin collector purge_artifact <artifact-name>
+# $ cargo run --bin collector purge_artifact 1.70.0 # Remove stable artifact 1.70.0
+```
+
+Or using SQL queries. There are `ON DELETE CASCADE` clauses for `aid` (artifact ID) on tables that
+reference it, so it should be enough to just delete the artifact from the `artifact` table.
 The set of queries below show an example of removing the measured data and errors for Rust `1.69`
 and `1.70`:
 ```sql

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -384,6 +384,30 @@ impl From<Commit> for ArtifactId {
     }
 }
 
+struct ArtifactInfo<'a> {
+    name: &'a str,
+    date: Option<DateTime<Utc>>,
+    kind: &'static str,
+}
+
+impl ArtifactId {
+    fn info(&self) -> ArtifactInfo {
+        let (name, date, ty) = match self {
+            Self::Commit(commit) => (
+                commit.sha.as_str(),
+                Some(commit.date.0),
+                if commit.is_try() { "try" } else { "master" },
+            ),
+            Self::Tag(a) => (a.as_str(), None, "release"),
+        };
+        ArtifactInfo {
+            name,
+            date,
+            kind: ty,
+        }
+    }
+}
+
 intern!(pub struct QueryLabel);
 
 #[derive(PartialEq, Eq, Clone, Debug)]

--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -152,6 +152,8 @@ pub trait Connection: Send + Sync {
     async fn collector_start_step(&self, aid: ArtifactIdNumber, step: &str) -> bool;
     async fn collector_end_step(&self, aid: ArtifactIdNumber, step: &str);
 
+    async fn collector_remove_step(&self, aid: ArtifactIdNumber, step: &str);
+
     async fn in_progress_artifacts(&self) -> Vec<ArtifactId>;
 
     async fn in_progress_steps(&self, aid: &ArtifactId) -> Vec<Step>;

--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -179,6 +179,9 @@ pub trait Connection: Send + Sync {
         profile: &str,
         cache: &str,
     ) -> Vec<(ArtifactIdNumber, i32)>;
+
+    /// Removes all data associated with the given artifact.
+    async fn purge_artifact(&self, aid: &ArtifactId);
 }
 
 #[async_trait::async_trait]

--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -1380,4 +1380,14 @@ where
             _ => panic!("unknown artifact type: {:?}", ty),
         }
     }
+
+    async fn purge_artifact(&self, aid: &ArtifactId) {
+        // Once we delete the artifact, all data associated with it should also be deleted
+        // thanks to ON DELETE CASCADE.
+        let info = aid.info();
+        self.conn()
+            .execute("delete from artifact where name = $1", &[&info.name])
+            .await
+            .unwrap();
+    }
 }

--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -1134,6 +1134,16 @@ where
             log::error!("did not end {} for {:?}", step, aid);
         }
     }
+    async fn collector_remove_step(&self, aid: ArtifactIdNumber, step: &str) {
+        self.conn()
+            .execute(
+                "delete from collector_progress \
+                where aid = $1 and step = $2;",
+                &[&(aid.0 as i32), &step],
+            )
+            .await
+            .unwrap();
+    }
     async fn in_progress_artifacts(&self) -> Vec<ArtifactId> {
         let rows = self
             .conn()

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -1074,6 +1074,17 @@ impl Connection for SqliteConnection {
             log::error!("did not end {} for {:?}", step, aid);
         }
     }
+
+    async fn collector_remove_step(&self, aid: ArtifactIdNumber, step: &str) {
+        self.raw_ref()
+            .execute(
+                "delete from collector_progress \
+                where aid = ? and step = ?",
+                params![&aid.0, &step],
+            )
+            .unwrap();
+    }
+
     async fn in_progress_artifacts(&self) -> Vec<ArtifactId> {
         let conn = self.raw_ref();
         let mut aids = conn

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -1231,4 +1231,13 @@ impl Connection for SqliteConnection {
             .collect::<Result<_, _>>()
             .unwrap()
     }
+
+    async fn purge_artifact(&self, aid: &ArtifactId) {
+        // Once we delete the artifact, all data associated with it should also be deleted
+        // thanks to ON DELETE CASCADE.
+        let info = aid.info();
+        self.raw_ref()
+            .execute("delete from artifact where name = ?1", [info.name])
+            .unwrap();
+    }
 }


### PR DESCRIPTION
There are basically three things that we can do during benchmarking if there is already some data in the database for the benchmarked artifact:
1) Skip the benchmark (that's what we do now)
2) Append new data to the old
3) Remove the old data

I don't think that appending makes much sense. If nothing has changed between two benchmark invocations with the same artifact, you just want to fill in the data. If something has changed, then you probably don't want to mix and average results for the old and the new data. And we show a minimum of measured values in the dashboard anyway, so you might as well just remove the old data.

Removing the old data is useful when rerunning benchmarks repeatedly on a local machine, so that you don't have to remove the database over and over again.

This PR adds a new `--purge` flag to `bench_local` and `bench_runtime_local` that removes either any old data for the given artifact, or just data for benchmarks that had an error for the given artifact. The flag is idempotent and can be used even if there is no previous data.

The PR also adds a separate `collector` command `purge_artifact`, which removes all data for a specified artifact. This can be handy e.g. for removing data that should be re-benchmarked on the perf server.

Best reviewed commit by commit.

Fixes: https://github.com/rust-lang/rustc-perf/issues/804