### PR TITLE
Store artifact sizes into the DB

### DIFF
--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -921,8 +921,8 @@ fn main_result() -> anyhow::Result<i32> {
             sysroot.preserve(); // don't delete it
 
             // Print the directory containing the toolchain.
-            sysroot.rustc.pop();
-            let s = format!("{:?}", sysroot.rustc);
+            sysroot.components.rustc.pop();
+            let s = format!("{:?}", sysroot.components.rustc);
             println!("{}", &s[1..s.len() - 1]);
 
             Ok(0)

--- a/collector/src/compile/execute/mod.rs
+++ b/collector/src/compile/execute/mod.rs
@@ -144,12 +144,12 @@ impl<'a> CargoProcess<'a> {
     }
 
     fn base_command(&self, cwd: &Path, subcommand: &str) -> Command {
-        let mut cmd = Command::new(Path::new(&self.toolchain.cargo));
+        let mut cmd = Command::new(Path::new(&self.toolchain.components.cargo));
         cmd
             // Not all cargo invocations (e.g. `cargo clean`) need all of these
             // env vars set, but it doesn't hurt to have them.
             .env("RUSTC", &*FAKE_RUSTC)
-            .env("RUSTC_REAL", &self.toolchain.rustc)
+            .env("RUSTC_REAL", &self.toolchain.components.rustc)
             // We separately pass -Cincremental to the leaf crate --
             // CARGO_INCREMENTAL is cached separately for both the leaf crate
             // and any in-tree dependencies, and we don't want that; it wastes
@@ -164,7 +164,7 @@ impl<'a> CargoProcess<'a> {
             .arg("--manifest-path")
             .arg(&self.manifest_path);
 
-        if let Some(r) = &self.toolchain.rustdoc {
+        if let Some(r) = &self.toolchain.components.rustdoc {
             cmd.env("RUSTDOC", &*FAKE_RUSTDOC).env("RUSTDOC_REAL", r);
         }
         cmd

--- a/collector/src/compile/execute/rustc.rs
+++ b/collector/src/compile/execute/rustc.rs
@@ -95,11 +95,11 @@ fn record(
     .arg("rust.deny-warnings=false")
     .arg("--set")
     .arg(&format!("build.rustc={}", fake_rustc.to_str().unwrap()))
-    .env("RUSTC_PERF_REAL_RUSTC", &toolchain.rustc)
+    .env("RUSTC_PERF_REAL_RUSTC", &toolchain.components.rustc)
     .arg("--set")
     .arg(&format!(
         "build.cargo={}",
-        toolchain.cargo.to_str().unwrap()
+        toolchain.components.cargo.to_str().unwrap()
     ))
     .status()
     .context("configuring")?;
@@ -114,7 +114,7 @@ fn record(
                     .context("x.py script canonicalize")?,
             )
             .current_dir(checkout)
-            .env("RUSTC_PERF_REAL_RUSTC", &toolchain.rustc)
+            .env("RUSTC_PERF_REAL_RUSTC", &toolchain.components.rustc)
             .arg("build")
             .arg("--stage")
             .arg("0")

--- a/collector/src/runtime/benchmark.rs
+++ b/collector/src/runtime/benchmark.rs
@@ -240,9 +240,9 @@ fn start_cargo_build(
     benchmark_dir: &Path,
     target_dir: Option<&Path>,
 ) -> anyhow::Result<Child> {
-    let mut command = Command::new(&toolchain.cargo);
+    let mut command = Command::new(&toolchain.components.cargo);
     command
-        .env("RUSTC", &toolchain.rustc)
+        .env("RUSTC", &toolchain.components.rustc)
         .arg("build")
         .arg("--release")
         .arg("--message-format")

--- a/database/schema.md
+++ b/database/schema.md
@@ -283,26 +283,13 @@ bors_sha    pr  parent_sha  complete  requested    include  exclude  runs  commi
 1w0p83...   42  fq24xq...   true      <timestamp>                    3     <timestamp>
 ```
 
-### error_series
-
-Records a compile-time benchmark that caused an error.
-
-This table exists to avoid duplicating benchmarks many times in the `error` table.
-
-```
-sqlite> select * from error_series limit 1;
-id          crate
-----------  -----------
-1           hello-world
-```
-
 ### error
 
-Records a compilation error for an artifact and an entry in `error_series`.
+Records a compilation or runtime error for an artifact and a benchmark.
 
 ```
 sqlite> select * from error limit 1;
-series      aid  error
-----------  ---  -----
-1           42   Failed to compile...
+aid         benchmark   error
+----------  ---         -----
+1           syn-1.0.89  Failed to compile...
 ```

--- a/database/schema.md
+++ b/database/schema.md
@@ -61,6 +61,22 @@ id          name        date        type
 1           LOCAL_TEST              release
 ```
 
+### artifact size
+
+Records the size of individual components (like `librustc_driver.so` or `libLLVM.so`) of a single
+artifact.
+
+This description includes:
+* component: normalized name of the component (hashes are removed)
+* size: size of the component in bytes
+
+```
+sqlite> select * from artifact_size limit 1;
+aid         component   size
+----------  ----------  ----------
+1           libLLVM.so  177892352
+```
+
 ### collection
 
 A "collection" of benchmarks tied only differing by the statistic collected.

--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -86,6 +86,11 @@ pub trait Connection: Send + Sync {
         krate: &str,
         value: Duration,
     );
+
+    /// Records the size of an artifact component (like `librustc_driver.so` or `libLLVM.so`) in
+    /// bytes.
+    async fn record_artifact_size(&self, artifact: ArtifactIdNumber, component: &str, size: u64);
+
     /// Returns vector of bootstrap build times for the given artifacts. The kth
     /// element is the minimum build time for the kth artifact in `aids`, across
     /// all collections for the artifact, or none if there is no bootstrap data


### PR DESCRIPTION
This PR adds a new DB table that records the size of individual components (like `librustc_driver.so`, `libLLVM.so`, ...) into the database. I decided to explicitly list the components that we want to record, instead of just taking the whole `bin`/`lib` directory and somehow removing hashes from the filenames.