### PR TITLE
Add artifact size UI to compare page

### DIFF
--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -91,6 +91,9 @@ pub trait Connection: Send + Sync {
     /// bytes.
     async fn record_artifact_size(&self, artifact: ArtifactIdNumber, component: &str, size: u64);
 
+    /// Returns the sizes of individual components of a single artifact.
+    async fn get_artifact_size(&self, aid: ArtifactIdNumber) -> HashMap<String, u64>;
+
     /// Returns vector of bootstrap build times for the given artifacts. The kth
     /// element is the minimum build time for the kth artifact in `aids`, across
     /// all collections for the artifact, or none if there is no bootstrap data

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -812,6 +812,18 @@ impl Connection for SqliteConnection {
             .unwrap();
     }
 
+    async fn get_artifact_size(&self, aid: ArtifactIdNumber) -> HashMap<String, u64> {
+        self.raw_ref()
+            .prepare("select component, size from artifact_size where aid = ?")
+            .unwrap()
+            .query_map(params![&aid.0], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, u64>(1)?))
+            })
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect()
+    }
+
     async fn get_bootstrap(&self, aids: &[ArtifactIdNumber]) -> Vec<Option<Duration>> {
         aids.iter()
             .map(|aid| {

--- a/site/frontend/src/pages/compare/artifact-size/artifact-size-table.vue
+++ b/site/frontend/src/pages/compare/artifact-size/artifact-size-table.vue
@@ -1,0 +1,152 @@
+<script setup lang="ts">
+import {ArtifactDescription} from "../types";
+import {diffClass, formatSize} from "../shared";
+
+const props = defineProps<{
+  a: ArtifactDescription;
+  b: ArtifactDescription;
+}>();
+
+// Sort binaries first, libraries later. Then within each category, sort in descending order by size
+// of the original (a) artifact component.
+const components = Object.entries(props.a.component_sizes)
+  .sort((a, b) => {
+    const aLib = a[0].startsWith("lib");
+    const bLib = b[0].startsWith("lib");
+    if (aLib && !bLib) {
+      return 1;
+    } else if (!aLib && bLib) {
+      return -1;
+    } else {
+      return b[1] - a[1];
+    }
+  })
+  .map((item) => item[0]);
+
+function formatName(component: string): string {
+  if (component.startsWith("lib")) {
+    return `${component}.so`;
+  }
+  return component;
+}
+
+function formatValue(value: number | undefined): string {
+  if (value === undefined) {
+    return "-";
+  }
+  return formatSize(value);
+}
+
+function formatChange(a: number | undefined, b: number | undefined): string {
+  if (a === undefined || b === undefined) {
+    return "-";
+  }
+  const diff = b - a;
+  const formatted = formatSize(Math.abs(diff));
+  if (diff < 0) {
+    return `-${formatted}`;
+  }
+  return formatted;
+}
+
+function formatPercentChange(
+  a: number | undefined,
+  b: number | undefined
+): string {
+  if (a === undefined || b === undefined) {
+    return "-";
+  }
+  return `${(((b - a) / a) * 100).toFixed(3)}%`;
+}
+
+function getClass(a: number | undefined, b: number | undefined): string {
+  if (a === undefined || b === undefined || a == b) {
+    return "";
+  }
+  return diffClass(b - a);
+}
+</script>
+
+<template>
+  <div class="category-title">Artifact component sizes</div>
+  <table>
+    <thead>
+      <tr>
+        <th>Component</th>
+        <th>Before</th>
+        <th>After</th>
+        <th>Change</th>
+        <th>% Change</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr v-for="component in components">
+        <td class="component">{{ formatName(component) }}</td>
+        <td>
+          <div class="aligned">
+            {{ formatValue(a.component_sizes[component]) }}
+          </div>
+        </td>
+        <td>
+          <div class="aligned">
+            {{ formatValue(b.component_sizes[component]) }}
+          </div>
+        </td>
+        <td
+          :class="
+            getClass(a.component_sizes[component], b.component_sizes[component])
+          "
+        >
+          <div class="aligned">
+            {{
+              formatChange(
+                a.component_sizes[component],
+                b.component_sizes[component]
+              )
+            }}
+          </div>
+        </td>
+        <td
+          :class="
+            getClass(a.component_sizes[component], b.component_sizes[component])
+          "
+        >
+          <div class="aligned">
+            {{
+              formatPercentChange(
+                a.component_sizes[component],
+                b.component_sizes[component]
+              )
+            }}
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</template>
+
+<style scoped lang="scss">
+table {
+  table-layout: fixed;
+  width: 100%;
+  margin-top: 10px;
+
+  td,
+  th {
+    text-align: center;
+    padding: 0.3em;
+  }
+
+  .component {
+    word-break: break-word;
+  }
+
+  .aligned {
+    text-align: right;
+
+    @media (min-width: 600px) {
+      width: 120px;
+    }
+  }
+}
+</style>

--- a/site/frontend/src/pages/compare/artifact-size/artifact-size-table.vue
+++ b/site/frontend/src/pages/compare/artifact-size/artifact-size-table.vue
@@ -65,6 +65,29 @@ function getClass(a: number | undefined, b: number | undefined): string {
   }
   return diffClass(b - a);
 }
+
+function generateTitle(component: string): string {
+  if (component === "rustc") {
+    return `Main binary of the Rust compiler. It is a small shim that links to librustc_driver.so,
+ which contains most of the compiler logic.`;
+  } else if (component === "rustdoc") {
+    return `Tool that generates documentation of Rust crates. Links to librustc_driver.so, which provides
+ most of the compiler logic.`;
+  } else if (component === "cargo") {
+    return "Build tool that compiles crates and their dependencies.";
+  } else if (component === "librustc_driver") {
+    return `Shared library which contains the core implementation of the compiler. It is used by several
+ other tools and binaries.`;
+  } else if (component === "libLLVM") {
+    return `LLVM codegen backend that is used by librustc_driver.so to emit optimized assembly.`;
+  } else if (component === "libstd") {
+    return `The Rust standard library.`;
+  } else if (component === "libtest") {
+    return `Library that contains implementation of the default test harness used by Rust programs.`;
+  } else {
+    return ""; // Unknown component
+  }
+}
 </script>
 
 <template>
@@ -81,7 +104,9 @@ function getClass(a: number | undefined, b: number | undefined): string {
     </thead>
     <tbody>
       <tr v-for="component in components">
-        <td class="component">{{ formatName(component) }}</td>
+        <td class="component" :title="generateTitle(component)">
+          {{ formatName(component) }}
+        </td>
         <td>
           <div class="aligned">
             {{ formatValue(a.component_sizes[component]) }}

--- a/site/frontend/src/pages/compare/artifact-size/artifact-size-table.vue
+++ b/site/frontend/src/pages/compare/artifact-size/artifact-size-table.vue
@@ -44,6 +44,16 @@ function formatValue(value: number | undefined): string {
   return formatSize(value);
 }
 
+function formatChangeTitle(
+  a: number | undefined,
+  b: number | undefined
+): string {
+  if (!isValidValue(a) || !isValidValue(b)) {
+    return "";
+  }
+  return (b - a).toLocaleString();
+}
+
 function formatChange(a: number | undefined, b: number | undefined): string {
   if (!isValidValue(a) || !isValidValue(b)) {
     return "-";
@@ -108,12 +118,18 @@ function generateTitle(component: string): string {
             {{ isLibrary(component) ? "Library" : "Binary" }}
           </td>
           <td>
-            <div class="aligned">
+            <div
+              class="aligned"
+              :title="a.component_sizes[component].toLocaleString()"
+            >
               {{ formatValue(a.component_sizes[component]) }}
             </div>
           </td>
           <td>
-            <div class="aligned">
+            <div
+              class="aligned"
+              :title="b.component_sizes[component].toLocaleString()"
+            >
               {{ formatValue(b.component_sizes[component]) }}
             </div>
           </td>
@@ -125,7 +141,15 @@ function generateTitle(component: string): string {
               )
             "
           >
-            <div class="aligned">
+            <div
+              class="aligned"
+              :title="
+                formatChangeTitle(
+                  a.component_sizes[component],
+                  b.component_sizes[component]
+                )
+              "
+            >
               {{
                 formatChange(
                   a.component_sizes[component],

--- a/site/frontend/src/pages/compare/artifact-size/artifact-size-table.vue
+++ b/site/frontend/src/pages/compare/artifact-size/artifact-size-table.vue
@@ -64,22 +64,19 @@ function getClass(a: number | undefined, b: number | undefined): string {
 
 function generateTitle(component: string): string {
   if (component === "rustc") {
-    return `Main binary of the Rust compiler. It is a small shim that links to librustc_driver.so,
- which contains most of the compiler logic.`;
+    return `Executable of the Rust compiler. A small wrapper that links to librustc_driver.so, which provides most of the compiler logic.`;
   } else if (component === "rustdoc") {
-    return `Tool that generates documentation of Rust crates. Links to librustc_driver.so, which provides
- most of the compiler logic.`;
+    return `Executable of rustdoc. Links to librustc_driver.so, which provides most of the compiler logic.`;
   } else if (component === "cargo") {
-    return "Build tool that compiles crates and their dependencies.";
+    return "Executable of cargo.";
   } else if (component === "librustc_driver") {
-    return `Shared library which contains the core implementation of the compiler. It is used by several
- other tools and binaries.`;
+    return `Shared library containing the core implementation of the compiler. It is used by several other tools and binaries.`;
   } else if (component === "libLLVM") {
-    return `LLVM codegen backend that is used by librustc_driver.so to emit optimized assembly.`;
+    return `Shared library of the LLVM codegen backend. It is used by librustc_driver.so.`;
   } else if (component === "libstd") {
-    return `The Rust standard library.`;
+    return `Shared library containing the Rust standard library. It is used by librustc_driver.so.`;
   } else if (component === "libtest") {
-    return `Library that contains implementation of the default test harness used by Rust programs.`;
+    return `Shared library containing the Rust test harness.`;
   } else {
     return ""; // Unknown component
   }
@@ -102,6 +99,7 @@ function generateTitle(component: string): string {
       <tr v-for="component in components">
         <td class="component" :title="generateTitle(component)">
           {{ formatName(component) }}
+          <Tooltip>{{ generateTitle(component) }}</Tooltip>
         </td>
         <td>
           <div class="aligned">

--- a/site/frontend/src/pages/compare/artifact-size/artifact-size-table.vue
+++ b/site/frontend/src/pages/compare/artifact-size/artifact-size-table.vue
@@ -1,6 +1,12 @@
 <script setup lang="ts">
 import {ArtifactDescription} from "../types";
-import {diffClass, formatSize} from "../shared";
+import {
+  diffClass,
+  formatPercentChange,
+  formatSize,
+  isValidValue,
+} from "../shared";
+import Tooltip from "../tooltip.vue";
 
 const props = defineProps<{
   a: ArtifactDescription;
@@ -31,14 +37,14 @@ function formatName(component: string): string {
 }
 
 function formatValue(value: number | undefined): string {
-  if (value === undefined) {
+  if (!isValidValue(value)) {
     return "-";
   }
   return formatSize(value);
 }
 
 function formatChange(a: number | undefined, b: number | undefined): string {
-  if (a === undefined || b === undefined) {
+  if (!isValidValue(a) || !isValidValue(b)) {
     return "-";
   }
   const diff = b - a;
@@ -49,18 +55,8 @@ function formatChange(a: number | undefined, b: number | undefined): string {
   return formatted;
 }
 
-function formatPercentChange(
-  a: number | undefined,
-  b: number | undefined
-): string {
-  if (a === undefined || b === undefined) {
-    return "-";
-  }
-  return `${(((b - a) / a) * 100).toFixed(3)}%`;
-}
-
 function getClass(a: number | undefined, b: number | undefined): string {
-  if (a === undefined || b === undefined || a == b) {
+  if (!isValidValue(a) || !isValidValue(b) || a == b) {
     return "";
   }
   return diffClass(b - a);

--- a/site/frontend/src/pages/compare/artifact-size/artifact-size-table.vue
+++ b/site/frontend/src/pages/compare/artifact-size/artifact-size-table.vue
@@ -13,24 +13,25 @@ const props = defineProps<{
   b: ArtifactDescription;
 }>();
 
-// Sort binaries first, libraries later. Then within each category, sort in descending order by size
-// of the original (a) artifact component.
-const components = Object.entries(props.a.component_sizes)
-  .sort((a, b) => {
-    const aLib = a[0].startsWith("lib");
-    const bLib = b[0].startsWith("lib");
-    if (aLib && !bLib) {
-      return 1;
-    } else if (!aLib && bLib) {
-      return -1;
-    } else {
-      return b[1] - a[1];
-    }
-  })
-  .map((item) => item[0]);
+// Sort binaries first, libraries later. Then within each category, sort alphabetically.
+const components = Object.keys(props.a.component_sizes).sort((a, b) => {
+  const aLib = a.startsWith("lib");
+  const bLib = b.startsWith("lib");
+  if (aLib && !bLib) {
+    return 1;
+  } else if (!aLib && bLib) {
+    return -1;
+  } else {
+    return a.localeCompare(b);
+  }
+});
+
+function isLibrary(component: string): boolean {
+  return component.startsWith("lib");
+}
 
 function formatName(component: string): string {
-  if (component.startsWith("lib")) {
+  if (isLibrary(component)) {
     return `${component}.so`;
   }
   return component;
@@ -85,69 +86,84 @@ function generateTitle(component: string): string {
 
 <template>
   <div class="category-title">Artifact component sizes</div>
-  <table>
-    <thead>
-      <tr>
-        <th>Component</th>
-        <th>Before</th>
-        <th>After</th>
-        <th>Change</th>
-        <th>% Change</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr v-for="component in components">
-        <td class="component" :title="generateTitle(component)">
-          {{ formatName(component) }}
-          <Tooltip>{{ generateTitle(component) }}</Tooltip>
-        </td>
-        <td>
-          <div class="aligned">
-            {{ formatValue(a.component_sizes[component]) }}
-          </div>
-        </td>
-        <td>
-          <div class="aligned">
-            {{ formatValue(b.component_sizes[component]) }}
-          </div>
-        </td>
-        <td
-          :class="
-            getClass(a.component_sizes[component], b.component_sizes[component])
-          "
-        >
-          <div class="aligned">
-            {{
-              formatChange(
+  <div class="wrapper">
+    <table>
+      <thead>
+        <tr>
+          <th>Component</th>
+          <th>Kind</th>
+          <th class="aligned-header">Before</th>
+          <th class="aligned-header">After</th>
+          <th class="aligned-header">Change</th>
+          <th class="aligned-header">% Change</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="component in components">
+          <td class="component">
+            {{ formatName(component) }}
+            <Tooltip>{{ generateTitle(component) }}</Tooltip>
+          </td>
+          <td>
+            {{ isLibrary(component) ? "Library" : "Binary" }}
+          </td>
+          <td>
+            <div class="aligned">
+              {{ formatValue(a.component_sizes[component]) }}
+            </div>
+          </td>
+          <td>
+            <div class="aligned">
+              {{ formatValue(b.component_sizes[component]) }}
+            </div>
+          </td>
+          <td
+            :class="
+              getClass(
                 a.component_sizes[component],
                 b.component_sizes[component]
               )
-            }}
-          </div>
-        </td>
-        <td
-          :class="
-            getClass(a.component_sizes[component], b.component_sizes[component])
-          "
-        >
-          <div class="aligned">
-            {{
-              formatPercentChange(
+            "
+          >
+            <div class="aligned">
+              {{
+                formatChange(
+                  a.component_sizes[component],
+                  b.component_sizes[component]
+                )
+              }}
+            </div>
+          </td>
+          <td
+            :class="
+              getClass(
                 a.component_sizes[component],
                 b.component_sizes[component]
               )
-            }}
-          </div>
-        </td>
-      </tr>
-    </tbody>
-  </table>
+            "
+          >
+            <div class="aligned">
+              {{
+                formatPercentChange(
+                  a.component_sizes[component],
+                  b.component_sizes[component]
+                )
+              }}
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
 </template>
 
 <style scoped lang="scss">
+.wrapper {
+  display: flex;
+  justify-content: center;
+}
 table {
   table-layout: fixed;
-  width: 100%;
   margin-top: 10px;
 
   td,
@@ -166,6 +182,9 @@ table {
     @media (min-width: 600px) {
       width: 120px;
     }
+  }
+  .aligned-header {
+    text-align: right;
   }
 }
 </style>

--- a/site/frontend/src/pages/compare/page.vue
+++ b/site/frontend/src/pages/compare/page.vue
@@ -28,6 +28,7 @@ import {
   computeRuntimeComparisonsWithNonRelevant,
   defaultRuntimeFilter,
 } from "./runtime/common";
+import ArtifactSizeTable from "./artifact-size/artifact-size-table.vue";
 
 function loadSelectorFromUrl(urlParams: Dict<string>): CompareSelector {
   const start = urlParams["start"] ?? "";
@@ -46,6 +47,7 @@ function loadTabFromUrl(urlParams: Dict<string>): Tab | null {
     compile: Tab.CompileTime,
     runtime: Tab.Runtime,
     bootstrap: Tab.Bootstrap,
+    ["artifact-size"]: Tab.ArtifactSize,
   };
   return tabs[tab] ?? null;
 }
@@ -121,10 +123,19 @@ const activeTab = computed((): Tab => {
   if (tab.value === Tab.Runtime && !runtimeDataAvailable.value) {
     return Tab.CompileTime;
   }
+  if (tab.value === Tab.ArtifactSize && !artifactSizeAvailable.value) {
+    return Tab.CompileTime;
+  }
   return tab.value;
 });
 
 const runtimeDataAvailable = computed(() => runtimeSummary.value !== null);
+const artifactSizeAvailable = computed(
+  () =>
+    data.value != null &&
+    (Object.keys(data.value.a.component_sizes).length > 0 ||
+      Object.keys(data.value.b.component_sizes).length > 0)
+);
 
 function changeTab(newTab: Tab) {
   tab.value = newTab;
@@ -171,6 +182,9 @@ loadCompareData(selector, loading);
         />
       </template>
       <BootstrapTable v-if="activeTab === Tab.Bootstrap" :data="data" />
+      <template v-if="artifactSizeAvailable && activeTab === Tab.ArtifactSize">
+        <ArtifactSizeTable :a="data.a" :b="data.b" />
+      </template>
     </div>
   </div>
   <br />

--- a/site/frontend/src/pages/compare/page.vue
+++ b/site/frontend/src/pages/compare/page.vue
@@ -163,7 +163,6 @@ loadCompareData(selector, loading);
           :benchmark-info="info"
         />
       </template>
-      <BootstrapTable v-if="activeTab === Tab.Bootstrap" :data="data" />
       <template v-if="runtimeDataAvailable && activeTab === Tab.Runtime">
         <RuntimeBenchmarksPage
           :data="data"
@@ -171,6 +170,7 @@ loadCompareData(selector, loading);
           :benchmark-info="info"
         />
       </template>
+      <BootstrapTable v-if="activeTab === Tab.Bootstrap" :data="data" />
     </div>
   </div>
   <br />

--- a/site/frontend/src/pages/compare/shared.ts
+++ b/site/frontend/src/pages/compare/shared.ts
@@ -7,6 +7,7 @@ export function formatDate(dateString: string): string {
     date.getUTCDate()
   )} `;
 }
+
 export function signIfPositive(pct: number): string {
   if (pct >= 0) {
     return "+";
@@ -33,4 +34,19 @@ export function diffClass(diff: number): string {
     return "positive";
   }
   return "negative";
+}
+
+const KiB = 1024;
+const MiB = KiB * 1024;
+const GiB = MiB * 1024;
+
+export function formatSize(size: number): string {
+  if (size >= GiB) {
+    return `${(size / GiB).toFixed(2)} GiB`;
+  } else if (size >= MiB) {
+    return `${(size / MiB).toFixed(2)} MiB`;
+  } else if (size >= KiB) {
+    return `${(size / KiB).toFixed(2)} KiB`;
+  }
+  return `${size} B`;
 }

--- a/site/frontend/src/pages/compare/shared.ts
+++ b/site/frontend/src/pages/compare/shared.ts
@@ -50,3 +50,20 @@ export function formatSize(size: number): string {
   }
   return `${size} B`;
 }
+
+// Formats a percentual change between two values
+export function formatPercentChange(
+  before: number | undefined,
+  after: number | undefined,
+  invalidPlaceholder: string = "-"
+): string {
+  if (!isValidValue(before) || !isValidValue(after)) {
+    return invalidPlaceholder;
+  }
+  return `${(((after - before) / before) * 100).toFixed(3)}%`;
+}
+
+// Checks if the value is not undefined and not zero
+export function isValidValue(size: number | undefined): boolean {
+  return size !== undefined && size !== 0;
+}

--- a/site/frontend/src/pages/compare/tabs.vue
+++ b/site/frontend/src/pages/compare/tabs.vue
@@ -1,7 +1,12 @@
 <script setup lang="tsx">
 import {computed, h, ref, Ref} from "vue";
 import {CompareResponse, Tab} from "./types";
-import {diffClass, formatSize, percentClass} from "./shared";
+import {
+  diffClass,
+  formatPercentChange,
+  formatSize,
+  percentClass,
+} from "./shared";
 import {SummaryGroup} from "./data";
 import SummaryPercentValue from "./summary/percent-value.vue";
 import SummaryRange from "./summary/range.vue";
@@ -156,7 +161,7 @@ const activeTab: Ref<Tab> = ref(props.initialTab);
         >
           {{ totalSizeB < totalSizeA ? "-" : ""
           }}{{ formatSize(Math.abs(totalSizeB - totalSizeA)) }} ({{
-            (((totalSizeB - totalSizeA) / totalSizeA) * 100).toFixed(3)
+            formatPercentChange(totalSizeA, totalSizeB)
           }}%)
         </div>
       </div>

--- a/site/frontend/src/pages/compare/tabs.vue
+++ b/site/frontend/src/pages/compare/tabs.vue
@@ -1,7 +1,7 @@
 <script setup lang="tsx">
 import {computed, h, ref, Ref} from "vue";
 import {CompareResponse, Tab} from "./types";
-import {diffClass, percentClass} from "./shared";
+import {diffClass, formatSize, percentClass} from "./shared";
 import {SummaryGroup} from "./data";
 import SummaryPercentValue from "./summary/percent-value.vue";
 import SummaryRange from "./summary/range.vue";
@@ -63,11 +63,29 @@ function SummaryTable({summary}: {summary: SummaryGroup}) {
   return <div>No relevant results</div>;
 }
 
+function formatArtifactSize(size: number): string {
+  if (size === 0) {
+    return "???";
+  }
+  return formatSize(size);
+}
+
 const bootstrapA = props.data.a.bootstrap_total;
 const bootstrapB = props.data.b.bootstrap_total;
 const bootstrapValid = bootstrapA > 0.0 && bootstrapB > 0.0;
 
 const runtimeAvailable = computed(() => props.runtimeSummary !== null);
+
+const totalSizeA = Object.values(props.data.a.component_sizes).reduce(
+  (a, b) => a + b,
+  0
+);
+const totalSizeB = Object.values(props.data.b.component_sizes).reduce(
+  (a, b) => a + b,
+  0
+);
+const sizesAvailable = totalSizeA > 0 || totalSizeB > 0;
+const bothSizesAvailable = totalSizeA > 0 && totalSizeB > 0;
 
 const activeTab: Ref<Tab> = ref(props.initialTab);
 </script>
@@ -115,6 +133,30 @@ const activeTab: Ref<Tab> = ref(props.initialTab);
         >
           {{ ((bootstrapB - bootstrapA) / 10e8).toFixed(1) }}s ({{
             (((bootstrapB - bootstrapA) / bootstrapA) * 100).toFixed(3)
+          }}%)
+        </div>
+      </div>
+    </div>
+    <div
+      class="tab"
+      title="Artifact size: sizes of individual components of the two artifacts."
+      v-if="sizesAvailable"
+      :class="{selected: activeTab === Tab.ArtifactSize}"
+      @click="changeTab(Tab.ArtifactSize)"
+    >
+      <div class="title">Artifact size</div>
+      <div class="summary">
+        <div>
+          {{ formatArtifactSize(totalSizeA) }} ->
+          {{ formatArtifactSize(totalSizeB) }}
+        </div>
+        <div
+          v-if="bothSizesAvailable"
+          :class="diffClass(totalSizeB - totalSizeA)"
+        >
+          {{ totalSizeB < totalSizeA ? "-" : ""
+          }}{{ formatSize(Math.abs(totalSizeB - totalSizeA)) }} ({{
+            (((totalSizeB - totalSizeA) / totalSizeA) * 100).toFixed(3)
           }}%)
         </div>
       </div>

--- a/site/frontend/src/pages/compare/types.ts
+++ b/site/frontend/src/pages/compare/types.ts
@@ -52,4 +52,5 @@ export enum Tab {
   CompileTime = "compile",
   Runtime = "runtime",
   Bootstrap = "bootstrap",
+  ArtifactSize = "artifact-size",
 }

--- a/site/frontend/src/pages/compare/types.ts
+++ b/site/frontend/src/pages/compare/types.ts
@@ -22,6 +22,7 @@ export interface ArtifactDescription {
   pr: number | null;
   bootstrap: Dict<number>;
   bootstrap_total: number;
+  component_sizes: Dict<number>;
 }
 
 export interface StatComparison {

--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -187,6 +187,7 @@ pub mod comparison {
         pub pr: Option<u32>,
         pub bootstrap: HashMap<String, u64>,
         pub bootstrap_total: u64,
+        pub component_sizes: HashMap<String, u64>,
     }
 
     #[derive(Debug, Clone, Serialize)]

--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -925,6 +925,7 @@ pub struct ArtifactDescription {
     /// Bootstrap data in the form "$crate" -> nanoseconds
     pub bootstrap: HashMap<String, u64>,
     pub bootstrap_total: u64,
+    pub component_sizes: HashMap<String, u64>,
 }
 
 type StatisticsMap<TestCase> = HashMap<TestCase, f64>;
@@ -939,9 +940,8 @@ impl ArtifactDescription {
         artifact: ArtifactId,
         master_commits: &[collector::MasterCommit],
     ) -> Self {
-        let bootstrap = conn
-            .get_bootstrap_by_crate(&[conn.artifact_id(&artifact).await])
-            .await;
+        let aid = conn.artifact_id(&artifact).await;
+        let bootstrap = conn.get_bootstrap_by_crate(&[aid]).await;
         let bootstrap_total = bootstrap
             .values()
             .filter_map(|v| {
@@ -979,11 +979,14 @@ impl ArtifactDescription {
             None
         };
 
+        let component_sizes = conn.get_artifact_size(aid).await.into_iter().collect();
+
         Self {
             pr,
             artifact,
             bootstrap,
             bootstrap_total,
+            component_sizes,
         }
     }
 }
@@ -1023,6 +1026,7 @@ impl From<ArtifactDescription> for api::comparison::ArtifactDescription {
             pr: data.pr,
             bootstrap: data.bootstrap,
             bootstrap_total: data.bootstrap_total,
+            component_sizes: data.component_sizes,
         }
     }
 }


### PR DESCRIPTION
Adds a tab with a simple table containing artifact component size diff to the compare page.

![image](https://github.com/rust-lang/rustc-perf/assets/4539057/aa61fb30-d5da-4f8e-b832-0df0480c1a35)