### PR TITLE
Fix spelling of perf. run estimation PR comment

### DIFF
--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -296,7 +296,7 @@ pub async fn enqueue_shas(
             let suffix = if other_artifact_count == 1 { "" } else { "s" };
             let queue_msg = format!(
                 r#"There {verb} currently {other_artifact_count} other artifact{suffix} in the [queue](https://perf.rust-lang.org/status.html).
-It will probably take at least ~{:.2} hours until the benchmark run finishes."#,
+It will probably take at least ~{:.1} hours until the benchmark run finishes."#,
                 (expected_duration / 3600.0)
             );
 

--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -287,9 +287,15 @@ pub async fn enqueue_shas(
 
             // At this point, the queue should also contain the commit that we're mentioning below.
             let other_artifact_count = artifacts_in_queue.saturating_sub(1);
+
+            let verb = if other_artifact_count == 1 {
+                "is"
+            } else {
+                "are"
+            };
             let suffix = if other_artifact_count == 1 { "" } else { "s" };
             let queue_msg = format!(
-                r#"There are currently {other_artifact_count} other artifact{suffix} in the [queue](https://perf.rust-lang.org/status.html).
+                r#"There {verb} currently {other_artifact_count} other artifact{suffix} in the [queue](https://perf.rust-lang.org/status.html).
 It will probably take at least ~{:.2} hours until the benchmark run finishes."#,
                 (expected_duration / 3600.0)
             );


### PR DESCRIPTION
Slight improvement of https://github.com/rust-lang/rustc-perf/pull/1654.