### PR TITLE
Fix height of tabs in compare page

### DIFF
--- a/site/frontend/src/pages/compare/tabs.vue
+++ b/site/frontend/src/pages/compare/tabs.vue
@@ -141,7 +141,7 @@ const activeTab: Ref<Tab> = ref(props.initialTab);
   flex-direction: column;
   position: relative;
   width: 200px;
-  height: 60px;
+  min-height: 60px;
   padding: 5px;
   text-align: center;
   border: 2px dotted #cccccc;


### PR DESCRIPTION
If regressions were too large, the text did overflow previously. Now the height is set to `min-height`, so the tab header will be expanded as needed.

Fixes this: https://perf.rust-lang.org/compare.html?start=ff8fe76c0e36b65c038a080a8a8341024104d117&end=3c3d525b34cf1491d7ff1e217aa1d892d51f0102&stat=cycles:u