### PR TITLE
Move all rustc-perf crates to edition 2021

### DIFF
--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["The Rust Compiler Team"]
 name = "collector"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 description = "Collects Rust performance data"
 
 [dependencies]

--- a/collector/src/compile/benchmark/mod.rs
+++ b/collector/src/compile/benchmark/mod.rs
@@ -532,6 +532,6 @@ mod tests {
             None,
         )
         .unwrap();
-        assert!(benchmarks.len() > 0);
+        assert!(!benchmarks.is_empty());
     }
 }

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -2,7 +2,7 @@
 name = "database"
 version = "0.1.0"
 authors = ["Mark Rousskov <mark.simulacrum@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 hashbrown = { version = "0.13", features = ["serde"] }

--- a/intern/Cargo.toml
+++ b/intern/Cargo.toml
@@ -2,7 +2,7 @@
 name = "intern"
 version = "0.1.0"
 authors = ["Mark Rousskov <mark.simulacrum@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 bumpalo = "3.2"

--- a/site/Cargo.toml
+++ b/site/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Mark-Simulacrum <mark.simulacrum@gmail.com>", "Nicholas Cameron <ncameron@mozilla.com>", "The rustc-perf contributors"]
 name = "site"
 version = "0.1.0"
-edition = '2018'
+edition = "2021"
 
 [dependencies]
 env_logger = "0.10"


### PR DESCRIPTION
Just a small (long-overdue) maintenance.