### PR TITLE
Reduce needless sleeps in `collector/collect.sh`

### DIFF
--- a/collector/collect.sh
+++ b/collector/collect.sh
@@ -22,9 +22,12 @@ while : ; do
         # Install measureme tooling
         cargo install --git https://github.com/rust-lang/measureme --branch stable flamegraph crox summarize
 
-        target/release/collector bench_next $SITE_URL --self-profile --bench-rustc --db $DATABASE;
-        echo finished run at `date`;
+        target/release/collector bench_next $SITE_URL --self-profile --bench-rustc --db $DATABASE
+        STATUS=$?
+        echo finished run at `date` with exit code $STATUS
 
-        # Wait a little bit before the next run starts.
-        sleep 120
+        # Wait a bit if the command has failed.
+        if [ $STATUS -ne 0 ]; then
+            sleep 120
+        fi
 done

--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -747,6 +747,12 @@ fn main_result() -> anyhow::Result<i32> {
                 c
             } else {
                 println!("no artifact to benchmark");
+
+                // Sleep for a bit to avoid spamming the perf server too much
+                // This sleep serves to remove a needless sleep in `collector/collect.sh` when
+                // a benchmark was actually executed.
+                std::thread::sleep(Duration::from_secs(60 * 2));
+
                 // no missing artifacts
                 return Ok(0);
             };


### PR DESCRIPTION
Before, the collector would sleep for 2 minutes after every collection, both if something was benchmarked and if nothing was benchmarked because the queue was empty. When the queue is not empty, it's wasteful to sleep for two minutes.

This PR moves the sleep directly to the `BenchNext` command. This means that the sleep will only be performed when nothing was benchmarked and the queue is empty. The `collect.sh` script will now only sleep if collection resulted in a non-zero exit code. This solution is not super nice code-wise, but the command is only used by the `collect.sh` script anyway.