### PR TITLE
Fix width of tabs in compare page

### DIFF
--- a/site/frontend/src/pages/compare/tabs.vue
+++ b/site/frontend/src/pages/compare/tabs.vue
@@ -187,7 +187,7 @@ const activeTab: Ref<Tab> = ref(props.initialTab);
   display: flex;
   flex-direction: column;
   position: relative;
-  width: 200px;
+  min-width: 200px;
   min-height: 60px;
   padding: 5px;
   text-align: center;


### PR DESCRIPTION
Fixes this: https://perf.rust-lang.org/compare.html?start=ff8fe76c0e36b65c038a080a8a8341024104d117&end=3c3d525b34cf1491d7ff1e217aa1d892d51f0102&stat=instructions:u. Who knew width could also be a problem...