### PR TITLE
Show `dev` profile metadata for benchmarks

### DIFF
--- a/site/frontend/src/pages/compare/compile/common.ts
+++ b/site/frontend/src/pages/compare/compile/common.ts
@@ -67,6 +67,7 @@ export interface CompileBenchmarkMetadata {
   binary: boolean | null;
   iterations: number | null;
   release_profile: CargoProfileMetadata;
+  dev_profile: CargoProfileMetadata;
 }
 
 export interface CompileBenchmarkComparison {

--- a/site/frontend/src/pages/compare/compile/comparisons-table.vue
+++ b/site/frontend/src/pages/compare/compile/comparisons-table.vue
@@ -73,8 +73,7 @@ Category: ${metadata.category}
   if (metadata.iterations !== null) {
     tooltip += `Iterations: ${metadata.iterations}\n`;
   }
-  if (testCase.profile === "opt" && metadata.release_profile !== null) {
-    const {lto, debug, codegen_units} = metadata.release_profile;
+  const addMetadata = ({lto, debug, codegen_units}) => {
     if (lto !== null) {
       tooltip += `LTO: ${lto}\n`;
     }
@@ -84,6 +83,9 @@ Category: ${metadata.category}
     if (codegen_units !== null) {
       tooltip += `Codegen units: ${codegen_units}\n`;
     }
+  };
+  if (testCase.profile === "opt" && metadata.release_profile !== null) {
+    addMetadata(metadata.release_profile);
   }
 
   return tooltip;

--- a/site/frontend/src/pages/compare/compile/comparisons-table.vue
+++ b/site/frontend/src/pages/compare/compile/comparisons-table.vue
@@ -86,6 +86,8 @@ Category: ${metadata.category}
   };
   if (testCase.profile === "opt" && metadata.release_profile !== null) {
     addMetadata(metadata.release_profile);
+  } else if (testCase.profile === "debug" && metadata.dev_profile !== null) {
+    addMetadata(metadata.dev_profile);
   }
 
   return tooltip;

--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -159,6 +159,7 @@ pub mod comparison {
         pub binary: Option<bool>,
         pub iterations: Option<u32>,
         pub release_profile: Option<ProfileMetadata>,
+        pub dev_profile: Option<ProfileMetadata>,
     }
 
     #[derive(Debug, Clone, Serialize)]

--- a/site/src/benchmark_metadata/metadata.rs
+++ b/site/src/benchmark_metadata/metadata.rs
@@ -22,6 +22,7 @@ pub struct ProfileMetadata {
 pub struct CompileBenchmarkMetadata {
     pub perf_config: serde_json::Value,
     pub release_metadata: ProfileMetadata,
+    pub dev_metadata: ProfileMetadata,
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]

--- a/site/src/benchmark_metadata/mod.rs
+++ b/site/src/benchmark_metadata/mod.rs
@@ -13,6 +13,7 @@ pub use metadata::ProfileMetadata;
 pub struct CompileBenchmarkMetadata {
     pub perf_config: BenchmarkConfig,
     pub release_metadata: ProfileMetadata,
+    pub dev_metadata: ProfileMetadata,
 }
 
 /// The metadata of compile-time benchmarks is embedded directly within the binary using
@@ -50,6 +51,7 @@ fn load_compile_benchmark_metadata() -> HashMap<String, CompileBenchmarkMetadata
             let metadata::CompileBenchmarkMetadata {
                 perf_config,
                 release_metadata,
+                dev_metadata,
             } = metadata;
             let perf_config: BenchmarkConfig =
                 serde_json::from_value(perf_config).unwrap_or_else(|error| {
@@ -62,6 +64,7 @@ fn load_compile_benchmark_metadata() -> HashMap<String, CompileBenchmarkMetadata
             let metadata = CompileBenchmarkMetadata {
                 perf_config,
                 release_metadata,
+                dev_metadata,
             };
             (name, metadata)
         })

--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -185,6 +185,7 @@ pub async fn handle_compare(
                 binary: metadata.map(|m| m.perf_config.artifact() == ArtifactType::Binary),
                 iterations: metadata.map(|m| m.perf_config.iterations() as u32),
                 release_profile: metadata.map(|m| m.release_metadata.clone()),
+                dev_profile: metadata.map(|m| m.dev_metadata.clone()),
             }
         })
         .collect();


### PR DESCRIPTION
This PR extends #1626 to also show benchmark metadata from the `dev` profile for `Check` and `Debug` benchmarks. 

Even the dev profile has interesting information for some benchmarks: while `ripgrep` uses debuginfo in release, `exa` uses no debuginfo in debug...