### PR TITLE
Add units to wall-time in compage page tables

### DIFF
--- a/site/frontend/src/pages/compare/compile/comparisons-table.vue
+++ b/site/frontend/src/pages/compare/compile/comparisons-table.vue
@@ -4,6 +4,7 @@ import Tooltip from "../tooltip.vue";
 import {ArtifactDescription} from "../types";
 import {percentClass} from "../shared";
 import {CompileBenchmarkMap, CompileTestCase} from "./common";
+import {computed} from "vue";
 
 const props = defineProps<{
   id: string;
@@ -92,6 +93,16 @@ Category: ${metadata.category}
 
   return tooltip;
 }
+
+const unit = computed(() => {
+  // The DB stored wall-time data in seconds for compile benchmarks, so it is
+  // hardcoded here
+  if (props.stat == "wall-time") {
+    return "s";
+  } else {
+    return null;
+  }
+});
 </script>
 
 <template>
@@ -194,16 +205,16 @@ Category: ${metadata.category}
             </td>
             <td v-if="showRawData" class="numeric">
               <a v-bind:href="detailedQueryRawDataLink(commitA, comparison)">
-                <abbr :title="comparison.datumA.toString()">{{
-                  prettifyRawNumber(comparison.datumA)
-                }}</abbr>
+                <abbr :title="comparison.datumA.toString()"
+                  >{{ prettifyRawNumber(comparison.datumA) }}{{ unit }}</abbr
+                >
               </a>
             </td>
             <td v-if="showRawData" class="numeric">
               <a v-bind:href="detailedQueryRawDataLink(commitB, comparison)">
-                <abbr :title="comparison.datumB.toString()">{{
-                  prettifyRawNumber(comparison.datumB)
-                }}</abbr>
+                <abbr :title="comparison.datumB.toString()"
+                  >{{ prettifyRawNumber(comparison.datumB) }}{{ unit }}</abbr
+                >
               </a>
             </td>
           </tr>

--- a/site/frontend/src/pages/compare/runtime/comparisons-table.vue
+++ b/site/frontend/src/pages/compare/runtime/comparisons-table.vue
@@ -3,16 +3,28 @@ import {TestCaseComparison} from "../data";
 import Tooltip from "../tooltip.vue";
 import {percentClass} from "../shared";
 import {RuntimeTestCase} from "./common";
+import {computed} from "vue";
 
 const props = defineProps<{
   comparisons: TestCaseComparison<RuntimeTestCase>[];
   hasNonRelevant: boolean;
   showRawData: boolean;
+  metric: string;
 }>();
 
 function prettifyRawNumber(number: number): string {
   return number.toLocaleString();
 }
+
+const unit = computed(() => {
+  // The DB stored wall-time data in nanoseconds for runtime benchmarks, so it is
+  // hardcoded here
+  if (props.metric == "wall-time") {
+    return "ns";
+  } else {
+    return null;
+  }
+});
 </script>
 
 <template>
@@ -90,14 +102,14 @@ function prettifyRawNumber(number: number): string {
               </div>
             </td>
             <td v-if="showRawData" class="numeric">
-              <abbr :title="comparison.datumA.toString()">{{
-                prettifyRawNumber(comparison.datumA)
-              }}</abbr>
+              <abbr :title="comparison.datumA.toString()"
+                >{{ prettifyRawNumber(comparison.datumA) }}{{ unit }}</abbr
+              >
             </td>
             <td v-if="showRawData" class="numeric">
-              <abbr :title="comparison.datumB.toString()">{{
-                prettifyRawNumber(comparison.datumB)
-              }}</abbr>
+              <abbr :title="comparison.datumB.toString()"
+                >{{ prettifyRawNumber(comparison.datumB) }}{{ unit }}</abbr
+              >
             </td>
           </tr>
         </template>

--- a/site/frontend/src/pages/compare/runtime/runtime-page.vue
+++ b/site/frontend/src/pages/compare/runtime/runtime-page.vue
@@ -124,6 +124,7 @@ const filteredSummary = computed(() => computeSummary(comparisons.value));
     :comparisons="comparisons"
     :has-non-relevant="allComparisons.length > 0"
     :show-raw-data="filter.showRawData"
+    :metric="selector.stat"
   />
 </template>
 


### PR DESCRIPTION
Adds known units to wall-time raw values in the compage page compile/runtime tables. The units are hardcoded in DB, so they are also hardcoded in the UI.