### PR TITLE
Correctly remove query parameters in compare page

### DIFF
--- a/site/frontend/src/utils/navigation.ts
+++ b/site/frontend/src/utils/navigation.ts
@@ -10,6 +10,8 @@ export function createUrlWithAppendedParams(params: Dict<any>): URL {
       const stringified = value.toString();
       if (stringified !== "") {
         url.searchParams.set(key, stringified);
+      } else {
+        url.searchParams.delete(key);
       }
     }
   }


### PR DESCRIPTION
If you set an empty value in the start/end inputs, the start/end URL parameters weren't removed previously. Therefore it was not possible to go back from a set start/end to an unset start/end.