### PR TITLE
Add benchmark detail to compile benchmark in compare page

### DIFF
--- a/site/frontend/src/pages/compare/compile/benchmarks.vue
+++ b/site/frontend/src/pages/compare/compile/benchmarks.vue
@@ -1,6 +1,6 @@
 <script setup lang="tsx">
 import {computed, h} from "vue";
-import ComparisonsTable from "./comparisons-table.vue";
+import ComparisonsTable from "./table/comparisons-table.vue";
 import {TestCaseComparison} from "../data";
 import {CompareResponse} from "../types";
 import {

--- a/site/frontend/src/pages/compare/compile/table/benchmark-detail.vue
+++ b/site/frontend/src/pages/compare/compile/table/benchmark-detail.vue
@@ -1,10 +1,91 @@
 <script setup lang="ts">
-import {CompileTestCase} from "../common";
+import {
+  CargoProfileMetadata,
+  CompileBenchmarkMap,
+  CompileBenchmarkMetadata,
+  CompileTestCase,
+} from "../common";
+import {computed} from "vue";
+import Tooltip from "../../tooltip.vue";
 
 const props = defineProps<{
   testCase: CompileTestCase;
+  benchmarkMap: CompileBenchmarkMap;
 }>();
+const metadata = computed(
+  (): CompileBenchmarkMetadata =>
+    props.benchmarkMap[props.testCase.benchmark] ?? null
+);
+const cargoProfile = computed((): CargoProfileMetadata => {
+  if (
+    props.testCase.profile === "opt" &&
+    metadata?.value.release_profile !== null
+  ) {
+    return metadata.value.release_profile;
+  } else if (
+    props.testCase.profile === "debug" &&
+    metadata?.value.dev_profile !== null
+  ) {
+    return metadata?.value.dev_profile;
+  }
+});
 </script>
 <template>
-  <div>Benchmark detail</div>
+  <table>
+    <tbody>
+      <tr>
+        <td>Benchmark</td>
+        <td>{{ testCase.benchmark }}</td>
+      </tr>
+      <tr>
+        <td>Profile</td>
+        <td>{{ testCase.profile }}</td>
+      </tr>
+      <tr>
+        <td>Scenario</td>
+        <td>{{ testCase.scenario }}</td>
+      </tr>
+      <tr>
+        <td>Category</td>
+        <td>{{ testCase.category }}</td>
+      </tr>
+      <tr v-if="(metadata?.binary ?? null) !== null">
+        <td>Artifact</td>
+        <td>{{ metadata.binary ? "binary" : "library" }}</td>
+      </tr>
+      <tr v-if="(metadata?.iterations ?? null) !== null">
+        <td>
+          Iterations<Tooltip>
+            How many times is the benchmark executed?
+          </Tooltip>
+        </td>
+        <td>{{ metadata.iterations }}</td>
+      </tr>
+      <tr v-if="(cargoProfile?.lto ?? null) !== null">
+        <td>LTO</td>
+        <td>{{ cargoProfile.lto }}</td>
+      </tr>
+      <tr v-if="(cargoProfile?.debug ?? null) !== null">
+        <td>Debuginfo</td>
+        <td>{{ cargoProfile.debug }}</td>
+      </tr>
+      <tr v-if="(cargoProfile?.codegen_units ?? null) !== null">
+        <td>Codegen units</td>
+        <td>{{ cargoProfile.codegen_units }}</td>
+      </tr>
+    </tbody>
+  </table>
 </template>
+
+<style scoped lang="scss">
+table {
+  td {
+    text-align: left;
+
+    &:first-child {
+      font-weight: bold;
+      padding-right: 10px;
+    }
+  }
+}
+</style>

--- a/site/frontend/src/pages/compare/compile/table/benchmark-detail.vue
+++ b/site/frontend/src/pages/compare/compile/table/benchmark-detail.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+import {CompileTestCase} from "../common";
+
+const props = defineProps<{
+  testCase: CompileTestCase;
+}>();
+</script>
+<template>
+  <div>Benchmark detail</div>
+</template>

--- a/site/frontend/src/pages/compare/compile/table/comparisons-table.vue
+++ b/site/frontend/src/pages/compare/compile/table/comparisons-table.vue
@@ -5,6 +5,8 @@ import {ArtifactDescription} from "../../types";
 import {percentClass} from "../../shared";
 import {CompileBenchmarkMap, CompileTestCase} from "../common";
 import {computed} from "vue";
+import {useExpandedStore} from "./expansion";
+import BenchmarkDetail from "./benchmark-detail.vue";
 
 const props = defineProps<{
   id: string;
@@ -94,6 +96,13 @@ Category: ${metadata.category}
   return tooltip;
 }
 
+const columnCount = computed(() => {
+  const base = 7;
+  if (props.showRawData) {
+    return base + 2;
+  }
+  return base;
+});
 const unit = computed(() => {
   // The DB stored wall-time data in seconds for compile benchmarks, so it is
   // hardcoded here
@@ -103,6 +112,7 @@ const unit = computed(() => {
     return null;
   }
 });
+const {toggleExpanded, isExpanded} = useExpandedStore();
 </script>
 
 <template>
@@ -114,6 +124,7 @@ const unit = computed(() => {
     <table v-else class="benches compare">
       <thead>
         <tr>
+          <th></th>
           <th>Benchmark</th>
           <th>Profile</th>
           <th>Scenario</th>
@@ -147,6 +158,9 @@ const unit = computed(() => {
       <tbody>
         <template v-for="comparison in comparisons">
           <tr>
+            <td @click="toggleExpanded(comparison.testCase)">
+              {{ isExpanded(comparison.testCase) ? "▼" : "▶" }}
+            </td>
             <td :title="generateBenchmarkTooltip(comparison.testCase)">
               <a
                 v-bind:href="benchmarkLink(comparison.testCase.benchmark)"
@@ -216,6 +230,11 @@ const unit = computed(() => {
                   >{{ prettifyRawNumber(comparison.datumB) }}{{ unit }}</abbr
                 >
               </a>
+            </td>
+          </tr>
+          <tr v-if="isExpanded(comparison.testCase)">
+            <td :colspan="columnCount">
+              <BenchmarkDetail :test-case="comparison.testCase" />
             </td>
           </tr>
         </template>

--- a/site/frontend/src/pages/compare/compile/table/comparisons-table.vue
+++ b/site/frontend/src/pages/compare/compile/table/comparisons-table.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import {TestCaseComparison} from "../data";
-import Tooltip from "../tooltip.vue";
-import {ArtifactDescription} from "../types";
-import {percentClass} from "../shared";
-import {CompileBenchmarkMap, CompileTestCase} from "./common";
+import {TestCaseComparison} from "../../data";
+import Tooltip from "../../tooltip.vue";
+import {ArtifactDescription} from "../../types";
+import {percentClass} from "../../shared";
+import {CompileBenchmarkMap, CompileTestCase} from "../common";
 import {computed} from "vue";
 
 const props = defineProps<{

--- a/site/frontend/src/pages/compare/compile/table/comparisons-table.vue
+++ b/site/frontend/src/pages/compare/compile/table/comparisons-table.vue
@@ -90,12 +90,12 @@ const {toggleExpanded, isExpanded} = useExpandedStore();
     <table v-else class="benches compare">
       <thead>
         <tr>
-          <th></th>
+          <th class="toggle"></th>
           <th>Benchmark</th>
           <th>Profile</th>
           <th>Scenario</th>
           <th>% Change</th>
-          <th>
+          <th class="narrow">
             Significance Threshold
             <Tooltip>
               The minimum % change that is considered significant. The higher
@@ -109,7 +109,7 @@ const {toggleExpanded, isExpanded} = useExpandedStore();
               how the significance threshold is calculated.
             </Tooltip>
           </th>
-          <th>
+          <th class="narrow">
             Significance Factor
             <Tooltip>
               How much a particular result is over the significance threshold. A
@@ -124,7 +124,7 @@ const {toggleExpanded, isExpanded} = useExpandedStore();
       <tbody>
         <template v-for="comparison in comparisons">
           <tr>
-            <td @click="toggleExpanded(comparison.testCase)">
+            <td @click="toggleExpanded(comparison.testCase)" class="toggle">
               {{ isExpanded(comparison.testCase) ? "▼" : "▶" }}
             </td>
             <td>
@@ -161,7 +161,7 @@ const {toggleExpanded, isExpanded} = useExpandedStore();
                 </div>
               </div>
             </td>
-            <td>
+            <td class="narrow">
               <div class="numeric-aligned">
                 <div>
                   {{
@@ -172,7 +172,7 @@ const {toggleExpanded, isExpanded} = useExpandedStore();
                 </div>
               </div>
             </td>
-            <td>
+            <td class="narrow">
               <div class="numeric-aligned">
                 <div>
                   {{
@@ -214,8 +214,9 @@ const {toggleExpanded, isExpanded} = useExpandedStore();
 
 <style scoped lang="scss">
 .benches {
+  width: 100%;
+  table-layout: auto;
   font-size: medium;
-  table-layout: fixed;
 
   td,
   th {
@@ -237,15 +238,22 @@ const {toggleExpanded, isExpanded} = useExpandedStore();
   border-right: dotted 1px;
 }
 
-.benches th {
-  text-align: center;
-  min-width: 50px;
+.benches {
+  td,
+  th {
+    text-align: center;
+
+    &.toggle {
+      padding-right: 5px;
+      cursor: pointer;
+    }
+    &.narrow {
+      max-width: 100px;
+    }
+  }
 }
 
 .benches td {
-  text-align: center;
-  width: 25%;
-
   & > .numeric-aligned {
     display: flex;
     flex-direction: column;

--- a/site/frontend/src/pages/compare/compile/table/comparisons-table.vue
+++ b/site/frontend/src/pages/compare/compile/table/comparisons-table.vue
@@ -62,40 +62,6 @@ function prettifyRawNumber(number: number): string {
   return number.toLocaleString();
 }
 
-function generateBenchmarkTooltip(testCase: CompileTestCase): string {
-  const metadata = props.benchmarkMap[testCase.benchmark] ?? null;
-  if (metadata === null) {
-    return "<No metadata found>";
-  }
-  let tooltip = `Benchmark: ${testCase.benchmark}
-Category: ${metadata.category}
-`;
-  if (metadata.binary !== null) {
-    tooltip += `Artifact: ${metadata.binary ? "binary" : "library"}\n`;
-  }
-  if (metadata.iterations !== null) {
-    tooltip += `Iterations: ${metadata.iterations}\n`;
-  }
-  const addMetadata = ({lto, debug, codegen_units}) => {
-    if (lto !== null) {
-      tooltip += `LTO: ${lto}\n`;
-    }
-    if (debug !== null) {
-      tooltip += `Debuginfo: ${debug}\n`;
-    }
-    if (codegen_units !== null) {
-      tooltip += `Codegen units: ${codegen_units}\n`;
-    }
-  };
-  if (testCase.profile === "opt" && metadata.release_profile !== null) {
-    addMetadata(metadata.release_profile);
-  } else if (testCase.profile === "debug" && metadata.dev_profile !== null) {
-    addMetadata(metadata.dev_profile);
-  }
-
-  return tooltip;
-}
-
 const columnCount = computed(() => {
   const base = 7;
   if (props.showRawData) {
@@ -161,7 +127,7 @@ const {toggleExpanded, isExpanded} = useExpandedStore();
             <td @click="toggleExpanded(comparison.testCase)">
               {{ isExpanded(comparison.testCase) ? "▼" : "▶" }}
             </td>
-            <td :title="generateBenchmarkTooltip(comparison.testCase)">
+            <td>
               <a
                 v-bind:href="benchmarkLink(comparison.testCase.benchmark)"
                 class="silent-link"
@@ -234,7 +200,10 @@ const {toggleExpanded, isExpanded} = useExpandedStore();
           </tr>
           <tr v-if="isExpanded(comparison.testCase)">
             <td :colspan="columnCount">
-              <BenchmarkDetail :test-case="comparison.testCase" />
+              <BenchmarkDetail
+                :test-case="comparison.testCase"
+                :benchmark-map="benchmarkMap"
+              />
             </td>
           </tr>
         </template>

--- a/site/frontend/src/pages/compare/compile/table/expansion.ts
+++ b/site/frontend/src/pages/compare/compile/table/expansion.ts
@@ -1,0 +1,25 @@
+import {ref} from "vue";
+import {CompileTestCase} from "../common";
+
+export function useExpandedStore() {
+  const expanded = ref(new Set());
+
+  function isExpanded(testCase: CompileTestCase) {
+    return expanded.value.has(testCaseKey(testCase));
+  }
+
+  function toggleExpanded(testCase: CompileTestCase) {
+    const key = testCaseKey(testCase);
+    if (isExpanded(testCase)) {
+      expanded.value.delete(key);
+    } else {
+      expanded.value.add(key);
+    }
+  }
+
+  return {toggleExpanded, isExpanded};
+}
+
+function testCaseKey(testCase: CompileTestCase): string {
+  return `${testCase.benchmark};${testCase.profile};${testCase.scenario};${testCase.category}`;
+}


### PR DESCRIPTION
This PR adds an expandable section containing benchmark details to each row in the (compile) comparison table. Later I want to add more data here, e.g. a 30 day history chart, information about recent similar changes to better detect noise, etc.

Currently, the details are opened by clicking on an arrow. Once people get used to it, I would also probably suggest just making the whole row clickable, and move the various links that are present in the individual columns (benchmark column => benchmark source code, profile column => 30 day graph link, change column => detailed query link) to the detail section. These links were quite hidden and unintuitive except to a "select few", who already knew about them :)


https://github.com/rust-lang/rustc-perf/assets/4539057/9bf672e6-82ba-4c33-bb62-6bf7bfdddc66