### PR TITLE
Add a command to profile a runtime benchmark

### DIFF
--- a/collector/README.md
+++ b/collector/README.md
@@ -475,6 +475,15 @@ profilers whose results are not affected by system noise (e.g. `callgrind` or `e
 `RUST_LOG=debug` can be specified to enable verbose logging, which is useful
 for debugging `collector` itself.
 
+## Profiling runtime benchmarks
+It is also possible to profile runtime benchmarks using the following command:
+
+```
+./target/release/collector profile_runtime <PROFILER> <RUSTC> <BENCHMARK_NAME>
+```
+
+Currently, a `<PROFILER>` can be `cachegrind`, which will run the runtime benchmark under
+`Cachegrind`.
 
 ## How `rustc` wrapping works
 When a crate is benchmarked or profiled, the real `rustc` is replaced with the `rustc-fake` binary,

--- a/collector/benchlib/src/cli.rs
+++ b/collector/benchlib/src/cli.rs
@@ -4,6 +4,8 @@ use clap::{CommandFactory, FromArgMatches};
 pub enum Args {
     /// Benchmark all benchmarks in this benchmark group and print the results as JSON.
     Run(BenchmarkArgs),
+    /// Profile a single benchmark execution.
+    Profile(ProfileArgs),
     /// List benchmarks that are defined in the current group as a JSON array.
     List,
 }
@@ -21,6 +23,12 @@ pub struct BenchmarkArgs {
     /// Include only benchmarks matching a prefix in this comma-separated list
     #[arg(long)]
     pub include: Option<String>,
+}
+
+#[derive(clap::Parser, Debug)]
+pub struct ProfileArgs {
+    /// Name of the benchmark that should be profiled.
+    pub benchmark: String,
 }
 
 #[test]

--- a/collector/benchlib/src/lib.rs
+++ b/collector/benchlib/src/lib.rs
@@ -18,6 +18,7 @@ mod cli;
 pub mod comm;
 pub mod measure;
 pub mod process;
+mod profile;
 mod utils;
 
 #[cfg(feature = "compression")]

--- a/collector/benchlib/src/profile.rs
+++ b/collector/benchlib/src/profile.rs
@@ -1,0 +1,4 @@
+pub fn profile_function<F: Fn() -> Bench, R, Bench: FnOnce() -> R>(benchmark_constructor: &F) {
+    let func = benchmark_constructor();
+    func();
+}

--- a/collector/src/runtime/benchmark.rs
+++ b/collector/src/runtime/benchmark.rs
@@ -59,6 +59,15 @@ impl BenchmarkSuite {
             .iter()
             .flat_map(|suite| suite.benchmark_names.iter().map(|n| n.as_ref()))
     }
+
+    pub fn get_group_by_benchmark(&self, benchmark: &str) -> Option<&BenchmarkGroup> {
+        self.groups.iter().find(|group| {
+            group
+                .benchmark_names
+                .iter()
+                .any(|b| b.as_str() == benchmark)
+        })
+    }
 }
 
 pub struct BenchmarkFilter {

--- a/collector/src/runtime/mod.rs
+++ b/collector/src/runtime/mod.rs
@@ -19,6 +19,7 @@ use crate::{run_command_with_output, CollectorCtx};
 mod benchmark;
 mod profile;
 
+pub use benchmark::RuntimeCompilationOpts;
 pub use profile::{profile_runtime, RuntimeProfiler};
 
 pub const DEFAULT_RUNTIME_ITERATIONS: u32 = 5;

--- a/collector/src/runtime/mod.rs
+++ b/collector/src/runtime/mod.rs
@@ -14,9 +14,12 @@ pub use benchmark::{
 use database::{ArtifactIdNumber, CollectionId, Connection};
 
 use crate::utils::git::get_rustc_perf_commit;
-use crate::{run_command, run_command_with_output, CollectorCtx};
+use crate::{run_command_with_output, CollectorCtx};
 
 mod benchmark;
+mod profile;
+
+pub use profile::{profile_runtime, RuntimeProfiler};
 
 pub const DEFAULT_RUNTIME_ITERATIONS: u32 = 5;
 
@@ -103,16 +106,6 @@ pub async fn bench_runtime(
             .expect("Cannot commit runtime benchmark group results");
     }
 
-    Ok(())
-}
-
-pub fn profile_runtime(suite: BenchmarkSuite, benchmark: &str) -> anyhow::Result<()> {
-    let Some(group) = suite.get_group_by_benchmark(benchmark) else {
-        return Err(anyhow::anyhow!("Benchmark `{benchmark}` not found"));
-    };
-    let mut cmd = prepare_command(&group.binary);
-    cmd.arg("profile").arg(benchmark);
-    run_command(&mut cmd)?;
     Ok(())
 }
 

--- a/collector/src/runtime/mod.rs
+++ b/collector/src/runtime/mod.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsStr;
 use std::io::{BufRead, BufReader, Cursor};
 use std::path::Path;
 use std::process::{Command, Stdio};
@@ -13,7 +14,7 @@ pub use benchmark::{
 use database::{ArtifactIdNumber, CollectionId, Connection};
 
 use crate::utils::git::get_rustc_perf_commit;
-use crate::{run_command_with_output, CollectorCtx};
+use crate::{run_command, run_command_with_output, CollectorCtx};
 
 mod benchmark;
 
@@ -105,6 +106,30 @@ pub async fn bench_runtime(
     Ok(())
 }
 
+pub fn profile_runtime(suite: BenchmarkSuite, benchmark: &str) -> anyhow::Result<()> {
+    let Some(group) = suite.get_group_by_benchmark(benchmark) else {
+        return Err(anyhow::anyhow!("Benchmark `{benchmark}` not found"));
+    };
+    let mut cmd = prepare_command(&group.binary);
+    cmd.arg("profile").arg(benchmark);
+    run_command(&mut cmd)?;
+    Ok(())
+}
+
+/// Prepares a command for execution, adding some shared flags.
+fn prepare_command<S: AsRef<OsStr>>(binary: S) -> Command {
+    // Turn off ASLR
+    let mut command = Command::new("setarch");
+    command.arg(std::env::consts::ARCH).arg("-R").arg(binary);
+
+    // We want to see a backtrace if the program panics
+    command.env("RUST_BACKTRACE", "1");
+
+    command.stdout(Stdio::piped());
+    command.stderr(Stdio::piped());
+    command
+}
+
 /// Records the results (stats) of a benchmark into the database.
 async fn record_stats(
     conn: &dyn Connection,
@@ -191,17 +216,10 @@ fn execute_runtime_benchmark_binary(
     filter: &BenchmarkFilter,
     iterations: u32,
 ) -> anyhow::Result<impl Iterator<Item = anyhow::Result<BenchmarkMessage>>> {
-    // Turn off ASLR
-    let mut command = Command::new("setarch");
-    command.arg(std::env::consts::ARCH);
-    command.arg("-R");
-    command.arg(binary);
+    let mut command = prepare_command(binary);
     command.arg("run");
     command.arg("--iterations");
     command.arg(&iterations.to_string());
-
-    // We want to see a backtrace if the benchmark panics
-    command.env("RUST_BACKTRACE", "1");
 
     if let Some(ref exclude) = filter.exclude {
         command.args(["--exclude", exclude]);
@@ -209,9 +227,6 @@ fn execute_runtime_benchmark_binary(
     if let Some(ref include) = filter.include {
         command.args(["--include", include]);
     }
-
-    command.stdout(Stdio::piped());
-    command.stderr(Stdio::piped());
 
     let output = run_command_with_output(&mut command)?;
     if !output.status.success() {

--- a/collector/src/runtime/profile.rs
+++ b/collector/src/runtime/profile.rs
@@ -1,0 +1,49 @@
+use std::fs::create_dir_all;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use anyhow::Context;
+
+use crate::command_output;
+use crate::runtime::BenchmarkSuite;
+
+#[derive(Clone, Debug, clap::ValueEnum)]
+pub enum RuntimeProfiler {
+    Cachegrind,
+}
+
+pub fn profile_runtime(
+    profiler: RuntimeProfiler,
+    suite: BenchmarkSuite,
+    benchmark: &str,
+) -> anyhow::Result<()> {
+    let Some(group) = suite.get_group_by_benchmark(benchmark) else {
+        return Err(anyhow::anyhow!("Benchmark `{benchmark}` not found"));
+    };
+
+    let result_dir = Path::new("results");
+    create_dir_all(result_dir)?;
+
+    let (mut cmd, out_file) = match profiler {
+        RuntimeProfiler::Cachegrind => {
+            let out_file = result_dir.join(format!("cgout-{benchmark}"));
+            let mut cmd = Command::new("valgrind");
+            cmd.arg("--tool=cachegrind")
+                .arg("--branch-sim=no")
+                .arg("--cache-sim=no")
+                .arg(format!("--cachegrind-out-file={}", out_file.display()));
+            (cmd, out_file)
+        }
+    };
+    cmd.stdin(Stdio::null());
+
+    cmd.arg(&group.binary).arg("profile").arg(benchmark);
+    command_output(&mut cmd).context("Cannot run profiler")?;
+
+    println!(
+        "Profiling complete, result can be found in `{}`",
+        out_file.display()
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
This PR adds a CLI command for profiling a single runtime benchmark. Currently, running a single benchmark function under `cachegrind` is supported. Later, I want to make the cachegrind profiling more precise with cachegrind client requests that would only profile the part of the benchmark group where the benchmark function actually runs (so without initialization, CLI parsing,e tc.). I also want to add cachegrind diff functionality in a followup PR to compare instructions executed by a runtime benchmark compiled by two different compiler versions.

I named the command just `profile_runtime` instead of `profile_local_runtime`. Profiling of "remote" artifacts doesn't really make sense, so I think that `profile_local` should also be renamed to `profile_compile` or something like that.