### PR TITLE
Add `--group` flag to runtime benchmark/profiling command

### DIFF
--- a/collector/README.md
+++ b/collector/README.md
@@ -183,6 +183,11 @@ by a selected version of rustc. You can run it using the following command:
 The following options alter the behaviour of the `bench_runtime_local` subcommand.
 - `--no-isolate`: you can use this flag to make repeated local benchmarks faster. It will cause the
   `collector` to reuse compiled artifacts of the runtime benchmark groups.
+- `--group`: Compile only the selected runtime benchmark group (i.e. only compile a crate inside the
+directory `collector/runtime-benchmarks/<group>`). This can be used to speed up local runtime benchmark
+experiments. Even with `--no-isolate`, it can take a few seconds to recompile all runtime benchmarks
+and discover all benchmarks within them. If you only want to run benchmark(s) from a single crate,
+you can use this to speed up the runtime benchmarking or profiling commands.
 
 The `bench_runtime_local` command also shares some options with the `bench_local` command, notably
 `--id`, `--db`, `--cargo`, `--include`, `--exclude` and `--iterations`. 


### PR DESCRIPTION
This flag allows us to choose a specific benchmark group that will be compiled, when running runtime benchmarks or profiling. This serves purely as a latency reduction optimization for local experiments, because now even with `--no-isolate` it takes some time until a runtime benchmark starts executing, because all compiled groups are currently executed first with the `list` parameter. And since some of the groups perform non-trivial work in `main` (e.g. `compression` currently), this can take a few seconds, which is annoying.