### PR TITLE
Move comparison table links to a separate section

### DIFF
--- a/site/frontend/src/components/cachegrind-cmd.vue
+++ b/site/frontend/src/components/cachegrind-cmd.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import {CompileTestCase, Profile} from "../pages/compare/compile/common";
+import {computed} from "vue";
+
+const props = defineProps<{
+  commit: string;
+  testCase: CompileTestCase;
+  baseline_commit?: string;
+}>();
+
+const firstCommit = computed(() => {
+  if (props.baseline_commit !== undefined) {
+    return props.baseline_commit;
+  } else {
+    return props.commit;
+  }
+});
+
+function normalizeProfile(profile: Profile): string {
+  if (profile === "opt") {
+    return "Opt";
+  } else if (profile === "debug") {
+    return "Debug";
+  } else if (profile === "check") {
+    return "Check";
+  } else if (profile === "doc") {
+    return "Doc";
+  }
+  return "<invalid profile>";
+}
+function normalizeScenario(scenario: string): string {
+  if (scenario === "full") {
+    return "Full";
+  } else if (scenario === "incr-full") {
+    return "IncrFull";
+  } else if (scenario === "incr-unchanged") {
+    return "IncrUnchanged";
+  } else if (scenario.startsWith("incr-patched")) {
+    return "IncrPatched";
+  }
+  return "<invalid scenario>";
+}
+</script>
+
+<template>
+  <pre><code>cargo run --bin collector profile_local cachegrind \
+    +{{ firstCommit }} \<template v-if="props.baseline_commit !== undefined">
+    --rustc2 +{{ props.commit }} \</template>
+    --include {{ testCase.benchmark }} \
+    --profiles {{ normalizeProfile(testCase.profile) }} \
+    --scenarios {{ normalizeScenario(testCase.scenario) }}</code></pre>
+</template>
+
+<style scoped lang="scss">
+pre {
+  background-color: #eeeeee;
+}
+code {
+  user-select: all;
+}
+</style>

--- a/site/frontend/src/components/cachegrind-cmd.vue
+++ b/site/frontend/src/components/cachegrind-cmd.vue
@@ -43,7 +43,7 @@ function normalizeScenario(scenario: string): string {
 </script>
 
 <template>
-  <pre><code>cargo run --bin collector profile_local cachegrind \
+  <pre><code>cargo run --bin collector --release profile_local cachegrind \
     +{{ firstCommit }} \<template v-if="props.baseline_commit !== undefined">
     --rustc2 +{{ props.commit }} \</template>
     --include {{ testCase.benchmark }} \

--- a/site/frontend/src/components/cachegrind-cmd.vue
+++ b/site/frontend/src/components/cachegrind-cmd.vue
@@ -5,12 +5,12 @@ import {computed} from "vue";
 const props = defineProps<{
   commit: string;
   testCase: CompileTestCase;
-  baseline_commit?: string;
+  baselineCommit?: string;
 }>();
 
 const firstCommit = computed(() => {
-  if (props.baseline_commit !== undefined) {
-    return props.baseline_commit;
+  if (props.baselineCommit !== undefined) {
+    return props.baselineCommit;
   } else {
     return props.commit;
   }
@@ -44,7 +44,7 @@ function normalizeScenario(scenario: string): string {
 
 <template>
   <pre><code>cargo run --bin collector --release profile_local cachegrind \
-    +{{ firstCommit }} \<template v-if="props.baseline_commit !== undefined">
+    +{{ firstCommit }} \<template v-if="props.baselineCommit !== undefined">
     --rustc2 +{{ props.commit }} \</template>
     --include {{ testCase.benchmark }} \
     --profiles {{ normalizeProfile(testCase.profile) }} \

--- a/site/frontend/src/pages/compare/compile/table/benchmark-detail.vue
+++ b/site/frontend/src/pages/compare/compile/table/benchmark-detail.vue
@@ -237,6 +237,14 @@ onMounted(() => renderGraph());
           <ul>
             <li>
               <a
+                :href="detailedQueryLink(props.artifact, props.baseArtifact)"
+                target="_blank"
+              >
+                Detailed results
+              </a>
+            </li>
+            <li>
+              <a
                 :href="graphLink(props.artifact, props.metric, props.testCase)"
                 target="_blank"
               >
@@ -244,21 +252,13 @@ onMounted(() => renderGraph());
               </a>
             </li>
             <li>
-              <a
-                :href="detailedQueryLink(props.artifact, props.baseArtifact)"
-                target="_blank"
-              >
-                Self profile (diff)
-              </a>
-            </li>
-            <li>
               <a :href="detailedQueryLink(props.baseArtifact)" target="_blank">
-                Self profile (before)
+                Rustc self-profile: baseline commit
               </a>
             </li>
             <li>
               <a :href="detailedQueryLink(props.artifact)" target="_blank">
-                Self profile (after)
+                Rustc self-profile: benchmarked commit
               </a>
             </li>
             <li>

--- a/site/frontend/src/pages/detailed-query.ts
+++ b/site/frontend/src/pages/detailed-query.ts
@@ -131,6 +131,7 @@ function populate_data(data, state: Selector) {
                    state.scenario
                  )})
                 results for ${state.commit.substring(0, 10)} (new commit)`;
+  // TODO: use the Cachegrind Vue components once this page is refactored to Vue
   let profile = (b) =>
     b.endsWith("-opt")
       ? "Opt"


### PR DESCRIPTION
I wanted to do this for a long time :grin: This PR moves all the "hidden" links that were previously more or less randomly scattered across the various columns of the comparison table to an explicit list of links in the new benchmark detail section.

Before there were these links:
- Benchmark name column: link to source code
- Profile column: link to 30 day graph
- Change column: link to self profile diff
- Raw value (before): link to self profile of commit A
- Raw value (after): link to self profile of commit B

The new link section contains all links except for the 30 day graph, which is now displayed directly in the benchmark detail. I can add an explicit link to the graph there too, if it's considered useful.

This PR changes the "distance" to go to each link from one click to two click (open row, click on link). For source code, I don't think it's that important, since it's not used much I think. For the 30 day graph, it's now actually better, since the graph is displayed directly on the page. For the self-profile links, this is a "regression", so to speak, but I still consider it to be a better trade-off to make the links more discoverable.

![image](https://github.com/rust-lang/rustc-perf/assets/4539057/384f05bc-5c7d-4503-be9a-af37a8ddc0fe)

After removing the links from the columns, I made the whole row clickable, and gave it a slight background tint on hover and when it is toggled. This is bikesheddable of course :)