### PR TITLE
Add runtime benchmark cachegrind diff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,6 +374,7 @@ dependencies = [
  "num_cpus",
  "rayon",
  "reqwest",
+ "rustc-demangle",
  "semver",
  "serde",
  "serde_json",
@@ -2167,6 +2168,12 @@ dependencies = [
  "indexmap",
  "serde",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc-hash"

--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -34,6 +34,7 @@ flate2 = { version = "1.0.22", features = ["rust_backend"] }
 rayon = "1.5.2"
 cargo_metadata = "0.15.0"
 thousands = "0.2.0"
+rustc-demangle = { version = "0.1", features = ["std"] }
 
 benchlib = { path = "benchlib" }
 

--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -19,8 +19,8 @@ use std::ffi::OsStr;
 use std::fs;
 use std::fs::File;
 use std::future::Future;
+use std::io::BufWriter;
 use std::io::Write;
-use std::io::{BufReader, BufWriter};
 use std::path::{Path, PathBuf};
 use std::process;
 use std::process::{Command, Stdio};
@@ -39,6 +39,7 @@ use collector::runtime::{profile_runtime, RuntimeCompilationOpts};
 use collector::toolchain::{
     create_toolchain_from_published_version, get_local_toolchain, Sysroot, Toolchain,
 };
+use collector::utils::mangling::demangle_file;
 use collector::utils::wait_for_future;
 
 fn n_normal_benchmarks_remaining(n: usize) -> String {
@@ -192,20 +193,6 @@ fn generate_cachegrind_diffs(
         }
     }
     annotated_diffs
-}
-
-/// Demangles symbols in a file and writes result to path.
-fn demangle_file(file: &Path, path: &Path) -> anyhow::Result<()> {
-    let mut file =
-        BufReader::new(File::open(file).context("Cannot open file containing Rust symbols")?);
-    let mut output = BufWriter::new(
-        File::create(path).context("Cannot create file with demangled Rust symbols")?,
-    );
-
-    rustc_demangle::demangle_stream(&mut file, &mut output, false)
-        .context("Cannot demangle symbols")?;
-
-    Ok(())
 }
 
 /// Compares two Cachegrind output files using cg_diff and writes result to path.

--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -39,7 +39,6 @@ use collector::runtime::{profile_runtime, RuntimeCompilationOpts};
 use collector::toolchain::{
     create_toolchain_from_published_version, get_local_toolchain, Sysroot, Toolchain,
 };
-use collector::utils::mangling::demangle_file;
 use collector::utils::wait_for_future;
 
 fn n_normal_benchmarks_remaining(n: usize) -> String {
@@ -162,22 +161,10 @@ fn generate_cachegrind_diffs(
                 let id_diff = format!("{}-{}", id1, id2);
                 let cgout1 = out_dir.join(filename("cgout", id1));
                 let cgout2 = out_dir.join(filename("cgout", id2));
-                let cgfilt1 = out_dir.join(filename("cgfilt", id1));
-                let cgfilt2 = out_dir.join(filename("cgfilt", id2));
                 let cgfilt_diff = out_dir.join(filename("cgfilt-diff", &id_diff));
                 let cgann_diff = out_dir.join(filename("cgann-diff", &id_diff));
 
-                if let Err(e) = demangle_file(&cgout1, &cgfilt1) {
-                    errors.incr();
-                    eprintln!("collector error: {:?}", e);
-                    continue;
-                }
-                if let Err(e) = demangle_file(&cgout2, &cgfilt2) {
-                    errors.incr();
-                    eprintln!("collector error: {:?}", e);
-                    continue;
-                }
-                if let Err(e) = cg_diff(&cgfilt1, &cgfilt2, &cgfilt_diff) {
+                if let Err(e) = cg_diff(&cgout1, &cgout2, &cgfilt_diff) {
                     errors.incr();
                     eprintln!("collector error: {:?}", e);
                     continue;

--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -665,14 +665,22 @@ fn main_result() -> anyhow::Result<i32> {
 
             println!("Profiling {rustc}");
             let (toolchain1, suite1) = get_suite(&rustc, "1")?;
-            let profile1 = profile_runtime(profiler.clone(), toolchain1, suite1, &benchmark)?;
+            let profile1 = profile_runtime(profiler.clone(), &toolchain1, suite1, &benchmark)?;
 
             if let Some(rustc2) = rustc2 {
                 match profiler {
                     RuntimeProfiler::Cachegrind => {
                         println!("Profiling {rustc2}");
                         let (toolchain2, suite2) = get_suite(&rustc2, "2")?;
-                        let profile2 = profile_runtime(profiler, toolchain2, suite2, &benchmark)?;
+                        let profile2 = profile_runtime(profiler, &toolchain2, suite2, &benchmark)?;
+
+                        let output = profile1.parent().unwrap().join(format!(
+                            "cgann-diff-{}-{}-{benchmark}",
+                            toolchain1.id, toolchain2.id
+                        ));
+                        cachegrind_diff(&profile1, &profile2, &output)
+                            .context("Cannot generate Cachegrind diff")?;
+                        println!("Cachegrind diff stored in `{}`", output.display());
                     }
                 }
             } else {

--- a/collector/src/runtime/profile.rs
+++ b/collector/src/runtime/profile.rs
@@ -17,7 +17,7 @@ pub enum RuntimeProfiler {
 /// Profiles a single runtime benchmark and returns a path to the result.
 pub fn profile_runtime(
     profiler: RuntimeProfiler,
-    toolchain: Toolchain,
+    toolchain: &Toolchain,
     suite: BenchmarkSuite,
     benchmark: &str,
 ) -> anyhow::Result<PathBuf> {

--- a/collector/src/runtime/profile.rs
+++ b/collector/src/runtime/profile.rs
@@ -1,32 +1,35 @@
 use std::fs::create_dir_all;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 use anyhow::Context;
 
 use crate::command_output;
 use crate::runtime::BenchmarkSuite;
+use crate::toolchain::Toolchain;
 
 #[derive(Clone, Debug, clap::ValueEnum)]
 pub enum RuntimeProfiler {
     Cachegrind,
 }
 
+/// Profiles a single runtime benchmark and returns a path to the result.
 pub fn profile_runtime(
     profiler: RuntimeProfiler,
+    toolchain: Toolchain,
     suite: BenchmarkSuite,
     benchmark: &str,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<PathBuf> {
     let Some(group) = suite.get_group_by_benchmark(benchmark) else {
         return Err(anyhow::anyhow!("Benchmark `{benchmark}` not found"));
     };
 
-    let result_dir = Path::new("results");
+    let result_dir = Path::new("results-runtime");
     create_dir_all(result_dir)?;
 
     let (mut cmd, out_file) = match profiler {
         RuntimeProfiler::Cachegrind => {
-            let out_file = result_dir.join(format!("cgout-{benchmark}"));
+            let out_file = result_dir.join(format!("cgout-{}-{benchmark}", toolchain.id));
             let mut cmd = Command::new("valgrind");
             cmd.arg("--tool=cachegrind")
                 .arg("--branch-sim=no")
@@ -40,10 +43,5 @@ pub fn profile_runtime(
     cmd.arg(&group.binary).arg("profile").arg(benchmark);
     command_output(&mut cmd).context("Cannot run profiler")?;
 
-    println!(
-        "Profiling complete, result can be found in `{}`",
-        out_file.display()
-    );
-
-    Ok(())
+    Ok(out_file)
 }

--- a/collector/src/utils/cachegrind.rs
+++ b/collector/src/utils/cachegrind.rs
@@ -1,8 +1,9 @@
+use crate::utils::is_installed;
 use crate::utils::mangling::demangle_file;
 use anyhow::Context;
 use std::io::{BufRead, Write};
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::{fs, io};
 
 /// Annotate and demangle the output of Cachegrind using the `cg_annotate` tool.
@@ -62,5 +63,56 @@ pub fn cachegrind_annotate(
         .arg("--show-percs=yes")
         .arg(cgout_output);
     fs::write(cgann_output, cg_annotate_cmd.output()?.stdout)?;
+    Ok(())
+}
+
+/// Creates a diff between two `cgout` files, and annotates the diff.
+pub fn cachegrind_diff(cgout_a: &Path, cgout_b: &Path, output: &Path) -> anyhow::Result<()> {
+    let cgout_diff = tempfile::NamedTempFile::new()?.into_temp_path();
+
+    run_cg_diff(cgout_a, cgout_b, &cgout_diff).context("Cannot run cg_diff")?;
+    annotate_diff(&cgout_diff, output).context("Cannot run cg_annotate")?;
+
+    Ok(())
+}
+
+/// Compares two Cachegrind output files using `cg_diff` and writes the result to `path`.
+fn run_cg_diff(cgout1: &Path, cgout2: &Path, path: &Path) -> anyhow::Result<()> {
+    if !is_installed("cg_diff") {
+        anyhow::bail!("`cg_diff` not installed.");
+    }
+    let output = Command::new("cg_diff")
+        .arg(r"--mod-filename=s/\/rustc\/[^\/]*\///")
+        .arg("--mod-funcname=s/[.]llvm[.].*//")
+        .arg(cgout1)
+        .arg(cgout2)
+        .stderr(Stdio::inherit())
+        .output()
+        .context("failed to run `cg_diff`")?;
+
+    if !output.status.success() {
+        anyhow::bail!("failed to generate cachegrind diff");
+    }
+
+    fs::write(path, output.stdout).context("failed to write `cg_diff` output")?;
+
+    Ok(())
+}
+
+/// Postprocess Cachegrind output file and writes the result to `path`.
+fn annotate_diff(cgout: &Path, path: &Path) -> anyhow::Result<()> {
+    let output = Command::new("cg_annotate")
+        .arg("--show-percs=no")
+        .arg(cgout)
+        .stderr(Stdio::inherit())
+        .output()
+        .context("failed to run `cg_annotate`")?;
+
+    if !output.status.success() {
+        anyhow::bail!("failed to annotate cachegrind output");
+    }
+
+    fs::write(path, output.stdout).context("failed to write `cg_annotate` output")?;
+
     Ok(())
 }

--- a/collector/src/utils/cachegrind.rs
+++ b/collector/src/utils/cachegrind.rs
@@ -1,0 +1,60 @@
+use std::io::{BufRead, Write};
+use std::path::Path;
+use std::process::Command;
+use std::{fs, io};
+
+/// Annotate the output of Cachegrind using the `cg_annotate` tool.
+pub fn cachegrind_annotate(
+    input: &Path,
+    cgout_output: &Path,
+    cgann_output: &Path,
+) -> anyhow::Result<()> {
+    // It's useful to filter all `file:function` entries from
+    // jemalloc into a single fake
+    // `<all-jemalloc-files>:<all-jemalloc-functions>` entry. That
+    // way the cost of all allocations is visible in one line,
+    // rather than spread across many small entries.
+    //
+    // The downside is that we don't get any annotations within
+    // jemalloc source files, but this is no real loss, given that
+    // jemalloc is basically a black box whose code we never look
+    // at anyway. DHAT is the best way to profile allocations.
+    let reader = io::BufReader::new(fs::File::open(input)?);
+    let mut writer = io::BufWriter::new(fs::File::create(cgout_output)?);
+    let mut in_jemalloc_file = false;
+
+    // A Cachegrind profile contains `fn=<function-name>` lines,
+    // `fl=<filename>` lines, and everything else. We just need to
+    // modify the `fn=` and `fl=` lines that refer to jemalloc
+    // code.
+    for line in reader.lines() {
+        let line = line?;
+        if line.starts_with("fl=") {
+            // All jemalloc filenames have `/jemalloc/` or
+            // something like `/jemalloc-sys-1e20251078fe5355/` in
+            // them.
+            in_jemalloc_file = line.contains("/jemalloc");
+            if in_jemalloc_file {
+                writeln!(writer, "fl=<all-jemalloc-files>")?;
+                continue;
+            }
+        } else if line.starts_with("fn=") {
+            // Any function within a jemalloc file is a jemalloc
+            // function.
+            if in_jemalloc_file {
+                writeln!(writer, "fn=<all-jemalloc-functions>")?;
+                continue;
+            }
+        }
+        writeln!(writer, "{}", line)?;
+    }
+    writer.flush()?;
+
+    let mut cg_annotate_cmd = Command::new("cg_annotate");
+    cg_annotate_cmd
+        .arg("--auto=yes")
+        .arg("--show-percs=yes")
+        .arg(cgout_output);
+    fs::write(cgann_output, cg_annotate_cmd.output()?.stdout)?;
+    Ok(())
+}

--- a/collector/src/utils/mangling.rs
+++ b/collector/src/utils/mangling.rs
@@ -1,0 +1,18 @@
+use anyhow::Context;
+use std::fs::File;
+use std::io::{BufReader, BufWriter};
+use std::path::Path;
+
+/// Demangles Rust symbols in a file and writes result to path.
+pub fn demangle_file(file: &Path, path: &Path) -> anyhow::Result<()> {
+    let mut file =
+        BufReader::new(File::open(file).context("Cannot open file containing Rust symbols")?);
+    let mut output = BufWriter::new(
+        File::create(path).context("Cannot create file with demangled Rust symbols")?,
+    );
+
+    rustc_demangle::demangle_stream(&mut file, &mut output, false)
+        .context("Cannot demangle symbols")?;
+
+    Ok(())
+}

--- a/collector/src/utils/mod.rs
+++ b/collector/src/utils/mod.rs
@@ -3,6 +3,7 @@ use std::future::Future;
 pub mod cachegrind;
 pub mod fs;
 pub mod git;
+pub mod mangling;
 pub mod read2;
 
 pub fn wait_for_future<F: Future<Output = R>, R>(f: F) -> R {

--- a/collector/src/utils/mod.rs
+++ b/collector/src/utils/mod.rs
@@ -1,5 +1,6 @@
 use std::future::Future;
 
+pub mod cachegrind;
 pub mod fs;
 pub mod git;
 pub mod read2;

--- a/collector/src/utils/mod.rs
+++ b/collector/src/utils/mod.rs
@@ -1,4 +1,5 @@
 use std::future::Future;
+use std::process::Command;
 
 pub mod cachegrind;
 pub mod fs;
@@ -12,4 +13,9 @@ pub fn wait_for_future<F: Future<Output = R>, R>(f: F) -> R {
         .build()
         .unwrap()
         .block_on(f)
+}
+
+/// Checks if the given binary can be executed.
+pub fn is_installed(name: &str) -> bool {
+    Command::new(name).output().is_ok()
 }


### PR DESCRIPTION
This PR adds the ability to compare two Cachegrind profiles of a runtime benchmark using `cg_diff`. It also refactors similar functionality for compile time benchmarks, to allow reusing the implementation and remove some unneeded temporary files. The need to have an external `rustfilt` binary installed was also removed, demangling is now performed using the `rustc-demangle` crate.