### PR TITLE
Runtime benchmark codegen diff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,6 +360,7 @@ dependencies = [
  "cargo_metadata",
  "chrono",
  "clap",
+ "console",
  "database",
  "env_logger",
  "filetime",
@@ -378,6 +379,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "similar",
  "snap",
  "tar",
  "tempfile",
@@ -387,6 +389,19 @@ dependencies = [
  "walkdir",
  "windows-sys 0.36.1",
  "xz2",
+]
+
+[[package]]
+name = "console"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -638,6 +653,12 @@ name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -2354,6 +2375,12 @@ checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "similar"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
 
 [[package]]
 name = "siphasher"

--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -35,6 +35,8 @@ rayon = "1.5.2"
 cargo_metadata = "0.15.0"
 thousands = "0.2.0"
 rustc-demangle = { version = "0.1", features = ["std"] }
+similar = "2.2"
+console = "0.15"
 
 benchlib = { path = "benchlib" }
 

--- a/collector/README.md
+++ b/collector/README.md
@@ -490,6 +490,16 @@ It is also possible to profile runtime benchmarks using the following command:
 Currently, a `<PROFILER>` can be `cachegrind`, which will run the runtime benchmark under
 `Cachegrind`.
 
+## Codegen diff
+You can use the `codegen_diff` command to display the assembly, LLVM IR or MIR difference between two
+versions of `rustc` for individual functions of a single runtime benchmark group:
+
+```
+./target/release/collector codegen_diff <asm|asm-source|llvm|mir> <benchmark-name> <rustc> <rustc2>
+```
+
+Codegen diff is currently only implemented for runtime benchmarks.
+
 ## How `rustc` wrapping works
 When a crate is benchmarked or profiled, the real `rustc` is replaced with the `rustc-fake` binary,
 which parses commands passed from the `collector` and invokes the actual profiling or benchmarking

--- a/collector/runtime-benchmarks/raytracer/Cargo.lock
+++ b/collector/runtime-benchmarks/raytracer/Cargo.lock
@@ -299,7 +299,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "raytrace"
+name = "raytracer-bench"
 version = "0.1.0"
 dependencies = [
  "benchlib",

--- a/collector/runtime-benchmarks/raytracer/Cargo.toml
+++ b/collector/runtime-benchmarks/raytracer/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "raytrace"
+name = "raytracer-bench"
 version = "0.1.0"
 authors = ["Jason Orendorff <jason.orendorff@gmail.com>"]
 edition = "2021"

--- a/collector/src/codegen.rs
+++ b/collector/src/codegen.rs
@@ -1,0 +1,290 @@
+use std::collections::HashMap;
+use std::io::IsTerminal;
+use std::path::Path;
+use std::process::Command;
+
+use anyhow::Context;
+use rayon::iter::IntoParallelRefIterator;
+use rayon::iter::ParallelIterator;
+use similar::{ChangeTag, DiffOp, TextDiff};
+
+use crate::command_output;
+use crate::runtime::BenchmarkGroupCrate;
+use crate::toolchain::Toolchain;
+
+#[derive(Copy, Clone, Debug, clap::ValueEnum)]
+pub enum CodegenType {
+    /// Display assembly with Intel syntax.
+    #[value(name = "asm")]
+    Assembly,
+    /// Display assembly with Intel syntax, interspersed with Rust source code.
+    #[value(name = "asm-source")]
+    AssemblyWithSource,
+    /// Display LLVM IR.
+    LLVM,
+    /// Display MIR.
+    MIR,
+}
+
+/// Write the codegen diff of all functions of the given runtime benchmark group between the two toolchains to stdout.
+pub fn codegen_diff(
+    codegen_type: CodegenType,
+    toolchain1: Toolchain,
+    toolchain2: Toolchain,
+    group: BenchmarkGroupCrate,
+) -> anyhow::Result<()> {
+    if !check_cargo_asm() {
+        return Err(anyhow::anyhow!("`cargo-show-asm` does not seem to be installed. Run `cargo install cargo-show-asm` first."));
+    }
+
+    // List functions and their indices from the baseline compiler
+    let functions1 = gather_functions(&toolchain1, &group.path, codegen_type)?;
+
+    // Create a map from function name to its index for the second compiler
+    let function2_map: HashMap<String, u32> =
+        gather_functions(&toolchain2, &group.path, codegen_type)?
+            .into_iter()
+            .map(|entry| (entry.name, entry.index))
+            .collect();
+
+    let mut diffs = functions1
+        .par_iter()
+        .map(|function| {
+            // Find the corresponding index for this function in the second compiler
+            match function2_map.get(&function.name) {
+                Some(toolchain2_index) => {
+                    let codegen1 =
+                        get_codegen(&toolchain1, &group.path, codegen_type, function.index)
+                            .context("Cannot generate codegen using compiler 1")?;
+                    let codegen2 =
+                        get_codegen(&toolchain2, &group.path, codegen_type, *toolchain2_index)
+                            .context("Cannot generate codegen using compiler 1")?;
+                    if codegen1.trim() != codegen2.trim() {
+                        return Ok(Some(CodegenDiff::new(function, codegen1, codegen2)));
+                    }
+                }
+                None => {
+                    log::warn!(
+                        "Could not find index for function {} for the second compiler",
+                        function.name
+                    );
+                }
+            }
+            Ok::<_, anyhow::Error>(None)
+        })
+        .filter_map(|res| res.transpose())
+        .collect::<anyhow::Result<Vec<CodegenDiff>>>()?;
+
+    let group_namespace = get_namespace(&group.path)?;
+
+    diffs.sort_by(|a, b| {
+        let a_local = a.function.name.contains(&group_namespace);
+        let b_local = b.function.name.contains(&group_namespace);
+
+        a_local
+            // Try to put functions from the benchmark itself first
+            .cmp(&b_local)
+            // We want true to be before false here
+            .reverse()
+            // Then sort in descending order by most insertions/deletions in the diff.
+            // Replacements are often benign changes, like different assembly labels/register
+            // numbers or LLVM IR SSA indices.
+            .then(a.large_changes.cmp(&b.large_changes).reverse())
+            // Then sort in descending order by most overall changes in the diff
+            .then(a.similarity_ratio.partial_cmp(&b.similarity_ratio).unwrap())
+            // If all else is equal, just sort by function name
+            .then(a.function.name.cmp(&b.function.name))
+    });
+
+    let mut output = std::io::stdout().lock();
+    let use_color = output.is_terminal();
+    for diff in diffs {
+        write_diff(&mut output, use_color, &diff).context("Cannot write diff")?;
+    }
+
+    Ok(())
+}
+
+/// Resolve the Cargo crate namespace from the given directory.
+fn get_namespace(directory: &Path) -> anyhow::Result<String> {
+    let output: serde_json::Value = serde_json::from_slice(
+        &command_output(
+            Command::new("cargo")
+                .arg("read-manifest")
+                .current_dir(directory),
+        )?
+        .stdout,
+    )?;
+    output
+        .get("name")
+        .and_then(|v| v.as_str())
+        .map(|s| s.replace('-', "_"))
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Cannot read runtime benchmark group name from {}",
+                directory.display()
+            )
+        })
+}
+
+struct CodegenDiff<'a> {
+    function: &'a FunctionEntry,
+    codegen1: String,
+    codegen2: String,
+    // How many insertions/removals (rather than replacements) are in this diff?
+    large_changes: u64,
+    // How much is codegen1 same as codegen2. 1.0 means that they are the same.
+    similarity_ratio: f32,
+}
+
+impl<'a> CodegenDiff<'a> {
+    fn new(function: &'a FunctionEntry, codegen1: String, codegen2: String) -> Self {
+        let diff = TextDiff::from_lines(&codegen1, &codegen2);
+        let similarity_ratio = diff.ratio();
+        let large_changes = diff
+            .ops()
+            .iter()
+            .filter(|op| matches!(op, DiffOp::Insert { .. } | DiffOp::Delete { .. }))
+            .count() as u64;
+
+        Self {
+            function,
+            codegen1,
+            codegen2,
+            large_changes,
+            similarity_ratio,
+        }
+    }
+}
+
+fn write_diff<W: std::io::Write>(
+    writer: &mut W,
+    use_color: bool,
+    diff: &CodegenDiff,
+) -> anyhow::Result<()> {
+    use console::Style;
+
+    let text_diff = TextDiff::from_lines(&diff.codegen1, &diff.codegen2);
+
+    writeln!(writer, "Diff for {}", diff.function.name)?;
+    writeln!(writer, "-----------------------------")?;
+    for change in text_diff.iter_all_changes() {
+        let (sign, style) = match change.tag() {
+            ChangeTag::Delete => ("-", Style::new().red()),
+            ChangeTag::Insert => ("+", Style::new().green()),
+            ChangeTag::Equal => (" ", Style::new()),
+        };
+        if use_color {
+            write!(
+                writer,
+                "{}{}",
+                style.apply_to(sign).bold(),
+                style.apply_to(change)
+            )?;
+        } else {
+            write!(writer, "{}{}", sign, change)?;
+        }
+    }
+    writeln!(writer, "-----------------------------")?;
+
+    Ok(())
+}
+
+type FunctionIndex = u32;
+
+fn get_codegen(
+    toolchain: &Toolchain,
+    dir: &Path,
+    codegen: CodegenType,
+    function_index: FunctionIndex,
+) -> anyhow::Result<String> {
+    let mut cmd = cargo_asm(toolchain, dir, codegen);
+    match codegen {
+        CodegenType::Assembly | CodegenType::AssemblyWithSource => {
+            // Simplify assembly output to remove unneeded stuff
+            cmd.arg("--simplify");
+        }
+        CodegenType::LLVM | CodegenType::MIR => {}
+    }
+    cmd.arg(format!("{}", function_index));
+
+    Ok(String::from_utf8(command_output(&mut cmd)?.stdout)?)
+}
+
+#[derive(Debug)]
+struct FunctionEntry {
+    index: FunctionIndex,
+    name: String,
+}
+
+fn gather_functions(
+    toolchain: &Toolchain,
+    dir: &Path,
+    codegen: CodegenType,
+) -> anyhow::Result<Vec<FunctionEntry>> {
+    log::info!("Gathering functions from toolchain {}", toolchain.id);
+    let output = cargo_asm(toolchain, dir, codegen).output()?;
+    let output = String::from_utf8_lossy(&output.stdout);
+
+    let functions: Vec<FunctionEntry> = output
+        .lines()
+        .filter_map(|line| {
+            let line = line.trim();
+            if let Some((index, rest)) = line.split_once(' ') {
+                let index = index.parse::<u32>().ok();
+                let function = rest.trim_start_matches('"');
+                let function = function.rsplit_once('"').map(|v| v.0);
+
+                if let (Some(index), Some(function)) = (index, function) {
+                    return Some(FunctionEntry {
+                        index,
+                        name: function.to_string(),
+                    });
+                }
+            }
+            None
+        })
+        .collect();
+    log::info!("Found {} function(s)", functions.len());
+    Ok(functions)
+}
+
+fn cargo_asm(toolchain: &Toolchain, dir: &Path, codegen: CodegenType) -> Command {
+    let mut cmd = Command::new("cargo");
+    cmd.arg("asm").arg("--no-color");
+    cmd.current_dir(dir);
+
+    cmd.env("RUSTC", &toolchain.components.rustc);
+
+    // We want to make sure that the symbol names of functions will be as similar as possible
+    // between any two versions of the compiler. It seems that using the `v0` mangling scheme is
+    // better in this regard vs the `legacy` scheme. It also produces more understandable names
+    // of symbols.
+    cmd.env("RUSTFLAGS", "-Csymbol-mangling-version=v0");
+
+    match codegen {
+        CodegenType::Assembly => {
+            cmd.arg("--intel");
+        }
+        CodegenType::AssemblyWithSource => {
+            cmd.arg("--intel").arg("--rust");
+        }
+        CodegenType::LLVM => {
+            cmd.arg("--llvm");
+        }
+        CodegenType::MIR => {
+            cmd.arg("--mir");
+        }
+    }
+
+    cmd
+}
+
+/// Checks if `cargo-show-asm` is installed and available under `cargo asm`.
+fn check_cargo_asm() -> bool {
+    let output = Command::new("cargo").arg("--list").output().unwrap();
+    let output = String::from_utf8_lossy(&output.stdout);
+    output
+        .lines()
+        .any(|line| line.split_whitespace().next() == Some("asm"))
+}

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -6,6 +6,7 @@ use std::fmt;
 use std::process::{self, Command};
 
 pub mod api;
+pub mod codegen;
 pub mod compile;
 pub mod runtime;
 pub mod toolchain;

--- a/collector/src/runtime/benchmark.rs
+++ b/collector/src/runtime/benchmark.rs
@@ -113,9 +113,10 @@ impl BenchmarkFilter {
     }
 }
 
-struct BenchmarkGroupCrate {
-    name: String,
-    path: PathBuf,
+/// A single crate located in the runtime benchmark directory.
+pub struct BenchmarkGroupCrate {
+    pub name: String,
+    pub path: PathBuf,
 }
 
 /// Determines whether runtime benchmarks will be recompiled from scratch in a temporary directory
@@ -129,6 +130,13 @@ pub struct BenchmarkSuiteCompilation {
     pub suite: BenchmarkSuite,
     // Maps benchmark group name to compilation error
     pub failed_to_compile: HashMap<String, String>,
+}
+
+impl BenchmarkSuiteCompilation {
+    pub fn extract_suite(self) -> BenchmarkSuite {
+        assert!(self.failed_to_compile.is_empty());
+        self.suite
+    }
 }
 
 #[derive(Default)]
@@ -355,7 +363,7 @@ fn gather_benchmarks(binary: &Path) -> anyhow::Result<Vec<String>> {
 }
 
 /// Finds all runtime benchmarks (crates) in the given directory.
-fn get_runtime_benchmark_groups(
+pub fn get_runtime_benchmark_groups(
     directory: &Path,
     group: Option<String>,
 ) -> anyhow::Result<Vec<BenchmarkGroupCrate>> {

--- a/collector/src/runtime/benchmark.rs
+++ b/collector/src/runtime/benchmark.rs
@@ -31,6 +31,8 @@ pub struct BenchmarkGroup {
 /// A collection of benchmark suites gathered from a directory.
 #[derive(Debug)]
 pub struct BenchmarkSuite {
+    /// Toolchain used to compile this suite.
+    pub toolchain: Toolchain,
     pub groups: Vec<BenchmarkGroup>,
     /// This field holds onto a temporary directory containing the compiled binaries with the
     /// runtime benchmarks. It is only stored here in order not to be dropped too soon.
@@ -42,11 +44,13 @@ impl BenchmarkSuite {
     /// that matches the filter.
     pub fn filter(self, filter: &BenchmarkFilter) -> Self {
         let BenchmarkSuite {
+            toolchain,
             groups,
             _tmp_artifacts_dir,
         } = self;
 
         Self {
+            toolchain,
             groups: groups
                 .into_iter()
                 .filter(|group| {
@@ -214,6 +218,7 @@ pub fn prepare_runtime_benchmark_suite(
 
     Ok(BenchmarkSuiteCompilation {
         suite: BenchmarkSuite {
+            toolchain: toolchain.clone(),
             groups,
             _tmp_artifacts_dir: temp_dir,
         },

--- a/collector/src/runtime/mod.rs
+++ b/collector/src/runtime/mod.rs
@@ -8,8 +8,9 @@ use thousands::Separable;
 
 use benchlib::comm::messages::{BenchmarkMessage, BenchmarkResult, BenchmarkStats};
 pub use benchmark::{
-    prepare_runtime_benchmark_suite, runtime_benchmark_dir, BenchmarkFilter, BenchmarkGroup,
-    BenchmarkSuite, BenchmarkSuiteCompilation, CargoIsolationMode,
+    get_runtime_benchmark_groups, prepare_runtime_benchmark_suite, runtime_benchmark_dir,
+    BenchmarkFilter, BenchmarkGroup, BenchmarkGroupCrate, BenchmarkSuite,
+    BenchmarkSuiteCompilation, CargoIsolationMode,
 };
 use database::{ArtifactIdNumber, CollectionId, Connection};
 


### PR DESCRIPTION
This PR adds a new command to `collector`, called `codegen_diff`. It takes as input the name of a single runtime benchmark group, the type of codegen you are interested in (assembly, assembly interleraved with Rust source, LLVM IR or MIR) and two versions of the compiler. It then uses the [cargo-show-asm](https://github.com/pacak/cargo-show-asm) tool to compute the codegen and diff it between the two compiler versions.

The diff is computed separately for each symbol (function) found in the benchmark crate. We therefore have to match the same function between two `rustc` versions (toolchains) by its symbol name. By default, `cargo asm` doesn't include hashes in the symbol names, which helps making sure that the name will stay the same, but it also means that a different version of the same function (e.g. one monomorphized with a different generic argument) will get matched between two toolchains. There is a `cargo asm` flag called `--full-name` which includes the hashes in the symbol names, which would resolve this issue. However, there is a problem with that - different versions of the compiler produce different hashes, and this doesn't seem to be [easily fixable](https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/Pinning.20function.20mangling.20hash). Therefore, I don't include the hashes in the symbol names, and I also opted in to the `v0` mangling scheme, as it seems to me that with it more functions are matched even without the hashes. 

The diff for each function is then printed to stdout, with colors if the output is a terminal. Eventually we might want to display some small HTML page so that the diff is easier to understand (?).