### PR TITLE
Add artifact size summary to PR comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2381,6 +2381,7 @@ dependencies = [
  "hex",
  "home",
  "http",
+ "humansize",
  "hyper",
  "inferno",
  "itertools",

--- a/site/Cargo.toml
+++ b/site/Cargo.toml
@@ -47,6 +47,7 @@ prometheus = "0.13"
 uuid = { version = "1.3.0", features = ["v4"] }
 tera = "1.18"
 rust-embed = { version = "6.6.0", features = ["include-exclude", "interpolate-folder-path"] }
+humansize = "2"
 
 [target.'cfg(unix)'.dependencies]
 jemallocator = "0.5"


### PR DESCRIPTION
Same as with bootstrap time, some PRs can inadvertedly change the size of the compiler toolchain (even if other benchmarks don't show anything). It would be nice to see this in the comment directly, because otherwise if there are no compile time changes, people sometimes don't even go to the compare page, or they might not notice the artifact size tab.