### PR TITLE
Remove github banner from graphs page

### DIFF
--- a/site/frontend/src/pages/graphs/page.vue
+++ b/site/frontend/src/pages/graphs/page.vue
@@ -147,18 +147,4 @@ loadGraphData(selector, loading);
     </div>
     <AsOf :info="info" />
   </div>
-  <a href="https://github.com/rust-lang-nursery/rustc-perf">
-    <img
-      style="
-        position: absolute;
-        top: 0;
-        right: 0;
-        border: 0;
-        clip-path: polygon(8% 0%, 100% 92%, 100% 0%);
-      "
-      src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67"
-      alt="Fork me on GitHub"
-      data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"
-    />
-  </a>
 </template>


### PR DESCRIPTION
As discussed in this [zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/247081-t-compiler.2Fperformance/topic/fork.20me.20on.20github), this PR removes the old school "Fork me on github" banner: it hides important parts of the UI, on mobile.

It was removed everywhere but the graphs page in https://github.com/rust-lang/rustc-perf/pull/1176, and we have "Contribute on github" links in all page footers to replace the banner's link to this repository.
