### PR TITLE
Redesign status page

### DIFF
--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -710,6 +710,7 @@ pub struct CompileBenchmark {
 
 #[derive(Debug)]
 pub struct ArtifactCollection {
+    pub artifact: ArtifactId,
     pub duration: Duration,
     pub end_time: DateTime<Utc>,
 }

--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -158,7 +158,7 @@ pub trait Connection: Send + Sync {
 
     async fn in_progress_steps(&self, aid: &ArtifactId) -> Vec<Step>;
 
-    async fn last_artifact_collection(&self) -> Option<ArtifactCollection>;
+    async fn last_n_artifact_collections(&self, n: u32) -> Vec<ArtifactCollection>;
 
     /// Returns the sha of the parent commit, if available.
     ///

--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -1214,21 +1214,31 @@ where
             })
             .collect()
     }
-    async fn last_artifact_collection(&self) -> Option<ArtifactCollection> {
+    async fn last_n_artifact_collections(&self, n: u32) -> Vec<ArtifactCollection> {
         self.conn()
-            .query_opt(
-                "select date_recorded, duration \
-                from artifact_collection_duration \
+            .query(
+                "select art.name, art.date, art.type, acd.date_recorded, acd.duration \
+                from artifact_collection_duration as acd \
+                join artifact as art on art.id = acd.aid \
                 order by date_recorded desc \
-                limit 1;",
-                &[],
+                limit $1;",
+                &[&n],
             )
             .await
             .unwrap()
-            .map(|r| ArtifactCollection {
-                end_time: r.get(0),
-                duration: Duration::from_secs(r.get::<_, i32>(1) as u64),
+            .into_iter()
+            .map(|r| {
+                let sha = r.get::<_, String>(0);
+                let date = r.get::<_, Option<DateTime<Utc>>>(1);
+                let ty = r.get::<_, String>(2);
+
+                ArtifactCollection {
+                    artifact: parse_artifact_id(&ty, &sha, date),
+                    end_time: r.get(3),
+                    duration: Duration::from_secs(r.get::<_, i32>(4) as u64),
+                }
             })
+            .collect()
     }
     async fn parent_of(&self, sha: &str) -> Option<String> {
         self.conn()
@@ -1372,23 +1382,7 @@ where
             .unwrap()?;
         let date = row.get::<_, Option<DateTime<Utc>>>(0);
         let ty = row.get::<_, String>(1);
-
-        match ty.as_str() {
-            "master" => Some(ArtifactId::Commit(Commit {
-                sha: artifact.to_owned(),
-                date: Date(date.expect("date present for master commits")),
-                r#type: CommitType::Master,
-            })),
-            "try" => Some(ArtifactId::Commit(Commit {
-                sha: artifact.to_owned(),
-                date: date
-                    .map(Date)
-                    .unwrap_or_else(|| Date::ymd_hms(2000, 1, 1, 0, 0, 0)),
-                r#type: CommitType::Try,
-            })),
-            "release" => Some(ArtifactId::Tag(artifact.to_owned())),
-            _ => panic!("unknown artifact type: {:?}", ty),
-        }
+        Some(parse_artifact_id(&ty, artifact, date))
     }
 
     async fn purge_artifact(&self, aid: &ArtifactId) {
@@ -1399,5 +1393,24 @@ where
             .execute("delete from artifact where name = $1", &[&info.name])
             .await
             .unwrap();
+    }
+}
+
+fn parse_artifact_id(ty: &str, sha: &str, date: Option<DateTime<Utc>>) -> ArtifactId {
+    match ty {
+        "master" => ArtifactId::Commit(Commit {
+            sha: sha.to_owned(),
+            date: Date(date.expect("date present for master commits")),
+            r#type: CommitType::Master,
+        }),
+        "try" => ArtifactId::Commit(Commit {
+            sha: sha.to_owned(),
+            date: date
+                .map(Date)
+                .unwrap_or_else(|| Date::ymd_hms(2000, 1, 1, 0, 0, 0)),
+            r#type: CommitType::Try,
+        }),
+        "release" => ArtifactId::Tag(sha.to_owned()),
+        _ => panic!("unknown artifact type: {:?}", ty),
     }
 }

--- a/site/frontend/package-lock.json
+++ b/site/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "date-fns": "^2.30.0",
         "highcharts": "6.0.7",
         "msgpack-lite": "^0.1.26",
         "parcel": "^2.8.3",
@@ -134,6 +135,22 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.15.tgz",
+      "integrity": "sha512-T0O+aa+4w0u06iNmapipJXMV4HoUir03hpx3/YqXXhu9xim3w+dVphjFWl1OH8NbZHw5Lbm9k45drDkgq2VNNA==",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
     },
     "node_modules/@babel/types": {
       "version": "7.21.4",
@@ -2290,6 +2307,21 @@
       "version": "2.6.21",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
       "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w=="
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
     },
     "node_modules/de-indent": {
       "version": "1.0.2",

--- a/site/frontend/package.json
+++ b/site/frontend/package.json
@@ -20,6 +20,7 @@
     "vue-tsc": "^1.8.3"
   },
   "dependencies": {
+    "date-fns": "^2.30.0",
     "highcharts": "6.0.7",
     "msgpack-lite": "^0.1.26",
     "parcel": "^2.8.3",

--- a/site/frontend/src/pages/status/data.ts
+++ b/site/frontend/src/pages/status/data.ts
@@ -1,4 +1,4 @@
-interface Commit {
+export interface Commit {
   sha: string;
   date: string;
   type: "Try" | "Master";
@@ -16,7 +16,7 @@ interface Step {
   current_progress: number;
 }
 
-type Artifact =
+export type Artifact =
   | {
       Commit: Commit;
     }
@@ -24,7 +24,7 @@ type Artifact =
       Tag: string;
     };
 
-type MissingReason =
+export type MissingReason =
   | {
       Master: {
         pr: number;
@@ -34,6 +34,7 @@ type MissingReason =
     }
   | {
       Try: {
+        pr: number;
         parent_sha: string;
         include: string | null;
         exclude: string | null;

--- a/site/frontend/src/pages/status/data.ts
+++ b/site/frontend/src/pages/status/data.ts
@@ -16,20 +16,43 @@ interface Step {
   current_progress: number;
 }
 
-/**
- * The `any` types in the interface below were chosen because the types are quite complex
- * on the Rust side (they are modeled with enums encoded in a way that is not so simple to model in
- * TS).
- */
+type Artifact =
+  | {
+      Commit: Commit;
+    }
+  | {
+      Tag: string;
+    };
+
+type MissingReason =
+  | {
+      Master: {
+        pr: number;
+        parent_sha: string;
+        is_try_parent: boolean;
+      };
+    }
+  | {
+      Try: {
+        parent_sha: string;
+        include: string | null;
+        exclude: string | null;
+        runs: number | null;
+      };
+    }
+  | {
+      InProgress: MissingReason;
+    };
+
 interface CurrentState {
-  artifact: any;
+  artifact: Artifact;
   progress: Step[];
 }
 
 export interface StatusResponse {
   last_commit: Commit | null;
   benchmarks: BenchmarkStatus[];
-  missing: Array<[Commit, any]>;
+  missing: Array<[Commit, MissingReason]>;
   current: CurrentState | null;
   most_recent_end: number | null;
 }

--- a/site/frontend/src/pages/status/data.ts
+++ b/site/frontend/src/pages/status/data.ts
@@ -4,7 +4,7 @@ export interface Commit {
   type: "Try" | "Master";
 }
 
-interface BenchmarkStatus {
+export interface BenchmarkError {
   name: string;
   error: string;
 }
@@ -50,10 +50,16 @@ interface CurrentState {
   progress: Step[];
 }
 
+export interface FinishedRun {
+  artifact: Artifact;
+  pr: number | null;
+  errors: BenchmarkError[];
+  duration: number;
+  finished_at: number;
+}
+
 export interface StatusResponse {
-  last_commit: Commit | null;
-  benchmarks: BenchmarkStatus[];
-  missing: Array<[Commit, MissingReason]>;
+  finished_runs: FinishedRun[];
   current: CurrentState | null;
-  most_recent_end: number | null;
+  missing: Array<[Commit, MissingReason]>;
 }

--- a/site/frontend/src/pages/status/expansion.ts
+++ b/site/frontend/src/pages/status/expansion.ts
@@ -1,0 +1,19 @@
+import {ref} from "vue";
+
+export function useExpandedStore() {
+  const expanded = ref(new Set());
+
+  function isExpanded(sha: string) {
+    return expanded.value.has(sha);
+  }
+
+  function toggleExpanded(sha: string) {
+    if (isExpanded(sha)) {
+      expanded.value.delete(sha);
+    } else {
+      expanded.value.add(sha);
+    }
+  }
+
+  return {toggleExpanded, isExpanded};
+}

--- a/site/frontend/src/pages/status/page.vue
+++ b/site/frontend/src/pages/status/page.vue
@@ -69,26 +69,15 @@ function formatCommitAsHtml(commit: Commit, reason: MissingReason): string {
   return `${pullRequestUrlAsHtml(pr)} (${type}): ${url}`;
 }
 
-function formatReason(reason: any): string {
-  if (typeof reason == "string") {
-    return reason;
-  } else if (reason.InProgress) {
-    return `${formatReason(reason.InProgress)} - in progress`;
-  } else if (reason["Master"] !== undefined && reason.Master.pr) {
-    return `<a href="https://github.com/rust-lang/rust/pull/${
-      reason["Master"].pr
-    }">
-                    #${reason["Master"].pr}</a>${
-      reason.Master.is_try_parent ? " - Try commit parent" : ""
+function formatMissingReason(reason: MissingReason): string {
+  if (reason.hasOwnProperty("InProgress")) {
+    return `${formatMissingReason(reason["InProgress"])} - in progress`;
+  } else if (reason.hasOwnProperty("Master")) {
+    return `${pullRequestUrlAsHtml(reason["Master"].pr)}${
+      reason["Master"].is_try_parent ? " - Try commit parent" : ""
     }`;
-  } else if (reason["Master"] !== undefined && reason.Master.pr == 0) {
-    return "Master";
-  } else if (reason["Try"] !== undefined && reason.Try.pr) {
-    return `
-                Try for
-                <a href="https://github.com/rust-lang/rust/pull/${reason["Try"].pr}">
-                    #${reason["Try"].pr}
-                </a>`;
+  } else if (reason.hasOwnProperty("Try")) {
+    return `Try for ${pullRequestUrlAsHtml(reason["Try"].pr)}`;
   } else {
     // Should never happen, but a reasonable fallback
     return JSON.stringify(reason);
@@ -214,7 +203,7 @@ loadStatus(loading);
           <tr v-for="[commit, reason] in data.missing">
             <td>{{ new Date(commit.date).toLocaleString() }}</td>
             <td v-html="commitUrlAsHtml(commit.sha)"></td>
-            <td v-html="formatReason(reason)"></td>
+            <td v-html="formatMissingReason(reason)"></td>
           </tr>
         </tbody>
       </table>

--- a/site/frontend/src/pages/status/page.vue
+++ b/site/frontend/src/pages/status/page.vue
@@ -2,13 +2,31 @@
 import {getJson} from "../../utils/requests";
 import {STATUS_DATA_URL} from "../../urls";
 import {withLoading} from "../../utils/loading";
-import {computed, ref, Ref} from "vue";
-import {Artifact, Commit, MissingReason, StatusResponse} from "./data";
+import {computed, ref, Ref, watch} from "vue";
+import {
+  Artifact,
+  BenchmarkError,
+  Commit,
+  FinishedRun,
+  MissingReason,
+  StatusResponse,
+} from "./data";
+import {
+  addSeconds,
+  differenceInSeconds,
+  format,
+  fromUnixTime,
+  sub,
+  subSeconds,
+} from "date-fns";
+import {CompileTestCase} from "../compare/compile/common";
+import {useExpandedStore} from "./expansion";
 
 async function loadStatus(loading: Ref<boolean>) {
   data.value = await withLoading(loading, () =>
     getJson<StatusResponse>(STATUS_DATA_URL)
   );
+  console.log(data.value);
 }
 
 function formatDuration(seconds: number): string {
@@ -19,11 +37,11 @@ function formatDuration(seconds: number): string {
 
   let s = "";
   if (hours > 0) {
-    s = `${hours}h${mins < 10 ? "0" + mins : mins}m${
+    s = `${hours}h ${mins < 10 ? "0" + mins : mins}m ${
       secs < 10 ? "0" + secs : secs
     }s`;
   } else {
-    s = `${mins < 10 ? " " + mins : mins}m${secs < 10 ? "0" + secs : secs}s`;
+    s = `${mins < 10 ? " " + mins : mins}m ${secs < 10 ? "0" + secs : secs}s`;
   }
   return s;
 }
@@ -57,31 +75,41 @@ function commitUrlAsHtml(sha: string): string {
   )}</a>`;
 }
 
-function pullRequestUrlAsHtml(pr: number): string {
+function pullRequestUrlAsHtml(pr: number | null): string {
+  if (pr === null) {
+    return "";
+  }
   return `<a href="https://github.com/rust-lang/rust/pull/${pr}">#${pr}</a>`;
 }
 
 function formatCommitAsHtml(commit: Commit, reason: MissingReason): string {
   const url = commitUrlAsHtml(commit.sha);
-  const type = commit.type === "Try" ? "try" : "master";
+  const type = commit.type === "Try" ? "Try" : "Master";
   const pr = getArtifactPr(reason);
 
-  return `${pullRequestUrlAsHtml(pr)} (${type}): ${url}`;
+  return `${type} commit ${url} (${pullRequestUrlAsHtml(pr)})`;
 }
 
-function formatMissingReason(reason: MissingReason): string {
-  if (reason.hasOwnProperty("InProgress")) {
-    return `${formatMissingReason(reason["InProgress"])} - in progress`;
-  } else if (reason.hasOwnProperty("Master")) {
-    return `${pullRequestUrlAsHtml(reason["Master"].pr)}${
-      reason["Master"].is_try_parent ? " - Try commit parent" : ""
-    }`;
-  } else if (reason.hasOwnProperty("Try")) {
-    return `Try for ${pullRequestUrlAsHtml(reason["Try"].pr)}`;
-  } else {
-    // Should never happen, but a reasonable fallback
-    return JSON.stringify(reason);
-  }
+interface CurrentRun {
+  commit: Commit;
+  missing_reason: MissingReason;
+  start: Date;
+  expected_end: Date;
+  expected_total: number;
+  progress: number;
+}
+
+interface TimelineEntry {
+  pr: number | null;
+  kind: string;
+  sha: string;
+  status: string;
+  end_time: Date;
+  end_estimated: boolean;
+  duration: number | null;
+  errors: BenchmarkError[];
+  warning: boolean;
+  current: boolean;
 }
 
 const timeLeft = computed(() => {
@@ -89,28 +117,138 @@ const timeLeft = computed(() => {
   let left = 0;
   for (const step of steps) {
     if (!step.is_done) {
-      left += step.expected_duration - step.current_progress;
+      left += Math.max(0, step.expected_duration - step.current_progress);
     }
   }
   return left;
 });
-const recentEndDate = computed(() => {
-  return new Date(data.value.most_recent_end * 1000);
-});
-const currentCommitAndReason: Ref<[Commit, MissingReason] | null> = computed(
-  () => {
-    const current = data.value?.current ?? null;
-    if (current === null) return null;
-    const sha = getArtifactSha(current.artifact);
 
-    for (const [commit, reason] of data.value.missing) {
-      if (commit.sha === sha && reason.hasOwnProperty("InProgress")) {
-        return [commit, reason["InProgress"]];
-      }
+const currentRun: Ref<CurrentRun | null> = computed(() => {
+  const current = data.value?.current ?? null;
+  if (current === null) return null;
+  const sha = getArtifactSha(current.artifact);
+
+  const elapsed = current.progress.reduce(
+    (prev, current) => prev + current.current_progress,
+    0
+  );
+  const start = subSeconds(new Date(), elapsed);
+  const expected_total = current.progress.reduce(
+    (prev, current) => prev + current.expected_duration,
+    0
+  );
+  const progress = Math.min(1, elapsed / Math.max(1, expected_total));
+
+  for (const [commit, reason] of data.value.missing) {
+    if (commit.sha === sha && reason.hasOwnProperty("InProgress")) {
+      return {
+        commit,
+        missing_reason: reason["InProgress"],
+        start,
+        expected_end: addSeconds(new Date(), timeLeft.value),
+        expected_total,
+        progress,
+      };
     }
-    return null;
   }
-);
+  return null;
+});
+const lastFinishedRun: Ref<FinishedRun | null> = computed(() => {
+  const finished = data?.value.finished_runs;
+  if (finished.length === 0) return null;
+  return finished[0];
+});
+const expectedDuration: Ref<number | null> = computed(() => {
+  if (data.value === null) return null;
+  const current = currentRun.value;
+  if (current !== null) {
+    return current.expected_total;
+  } else {
+    return lastFinishedRun.value?.duration;
+  }
+});
+
+// Timeline of past, current and future runs.
+// Ordered from future to past - at the beginning is the item with the least
+// priority in the queue, and at the end is the oldest finished run.
+const timeline: Ref<TimelineEntry[]> = computed(() => {
+  if (data.value === null) return [];
+  const timeline: TimelineEntry[] = [];
+
+  const current = currentRun.value;
+  const currentTimeLeft = timeLeft.value ?? 0;
+  const expectedRunDuration = expectedDuration.value;
+
+  // The next commit to be benchmarked will be at last position of `queued`
+  const queued = data.value.missing
+    .filter(([_, reason]) => !reason.hasOwnProperty("InProgress"))
+    .reverse();
+  let queued_before = queued.length - 1;
+  for (const [commit, reason] of queued) {
+    const expected_end = addSeconds(
+      current?.expected_end ?? new Date(),
+      currentTimeLeft + queued_before * expectedRunDuration
+    );
+
+    let kind = commit.type;
+    if (reason.hasOwnProperty("Master") && reason["Master"].is_try_parent) {
+      kind += " (try parent)";
+    }
+
+    timeline.push({
+      pr: getArtifactPr(reason),
+      kind,
+      sha: commit.sha,
+      status: `Queued (#${queued_before + 1})`,
+      end_time: expected_end,
+      end_estimated: true,
+      errors: [],
+      duration: null,
+      warning: false,
+      current: false,
+    });
+    queued_before -= 1;
+  }
+
+  if (current !== null) {
+    timeline.push({
+      pr: getArtifactPr(current.missing_reason),
+      kind: current.commit.type,
+      sha: current.commit.sha,
+      status: "In progress",
+      end_time: current.expected_end,
+      end_estimated: true,
+      errors: [],
+      duration: null,
+      warning: false,
+      current: true,
+    });
+  }
+
+  for (const run of data.value.finished_runs) {
+    const kind = run.artifact.hasOwnProperty("Tag")
+      ? run.artifact["Tag"]
+      : run.artifact["Commit"].type;
+
+    timeline.push({
+      pr: run.pr,
+      kind,
+      sha: getArtifactSha(run.artifact),
+      status: "Finished",
+      end_time: fromUnixTime(run.finished_at),
+      end_estimated: false,
+      errors: run.errors,
+      duration: run.duration,
+      warning: kind !== "Try" && run.errors.length > 0,
+      current: false,
+    });
+  }
+
+  return timeline;
+});
+
+const {toggleExpanded: toggleExpandedErrors, isExpanded: hasExpandedErrors} =
+  useExpandedStore();
 
 const loading = ref(true);
 
@@ -119,22 +257,42 @@ loadStatus(loading);
 </script>
 
 <template>
-  <div v-if="data !== null">
-    <div>
-      <div v-if="data.current !== null">
-        <p>
-          Currently benchmarking:
-          <span
-            v-html="
-              formatCommitAsHtml(
-                currentCommitAndReason[0],
-                currentCommitAndReason[1]
-              )
-            "
-          ></span
-          >.<br />
-          Time left: {{ formatDuration(timeLeft) }}
-        </p>
+  <div class="wrapper" v-if="data !== null">
+    <div class="current column-centered">
+      <h3><b>Current collection</b></h3>
+      <div class="column-centered" v-if="currentRun !== null">
+        <div
+          class="benchmark"
+          v-html="
+            formatCommitAsHtml(currentRun.commit, currentRun.missing_reason)
+          "
+        ></div>
+        <table class="current-table">
+          <thead>
+            <tr>
+              <th>Start</th>
+              <th>Progress</th>
+              <th>Expected end</th>
+              <th>Time left</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>{{ format(currentRun.start, "HH:mm") }}</td>
+              <td>
+                <progress
+                  max="100"
+                  :value="currentRun.progress * 100"
+                ></progress>
+              </td>
+              <td>
+                {{ format(currentRun.expected_end, "HH:mm") }}
+              </td>
+              <td>{{ timeLeft <= 0 ? "?" : formatDuration(timeLeft) }}</td>
+            </tr>
+          </tbody>
+        </table>
+        <h4 style="margin-top: 20px">Detailed progress</h4>
         <table>
           <thead>
             <tr>
@@ -172,69 +330,156 @@ loadStatus(loading);
           </tbody>
         </table>
       </div>
-      <div v-else>
-        <p>
-          No current collection in progress.
-          <template v-if="data.most_recent_end !== null"
-            >Last one finished at {{ recentEndDate.toLocaleString() }} local
-            time,
-            {{
-              formatDuration(
-                Math.trunc((Date.now() - recentEndDate.getTime()) / 1000)
+      <div class="column-centered" v-else>
+        <div>No benchmark in progress.</div>
+        <div>
+          Last collection finished at
+          {{ fromUnixTime(lastFinishedRun.finished_at).toLocaleString() }} ({{
+            formatDuration(
+              differenceInSeconds(
+                new Date(),
+                fromUnixTime(lastFinishedRun.finished_at)
               )
-            }}
-            ago.
-          </template>
-        </p>
+            )
+          }}
+          ago)
+        </div>
       </div>
-      <p>
-        Queue ({{ data.missing.length }} total):<br />
-        Times are local.
-      </p>
-      <table class="missing-commits">
+    </div>
+    <div class="column-centered timeline">
+      <h3><b>Timeline</b></h3>
+      <div style="margin-bottom: 10px">
+        Queue length: {{ data.missing.length }}
+      </div>
+      <table>
         <thead>
           <tr>
-            <th>Commit Date</th>
+            <th>PR</th>
+            <th>Kind</th>
             <th>SHA</th>
-            <th>Reason</th>
+            <th>Status</th>
+            <th>Run end</th>
+            <th>Duration</th>
+            <th>Errors</th>
           </tr>
         </thead>
         <tbody>
-          <tr v-for="[commit, reason] in data.missing">
-            <td>{{ new Date(commit.date).toLocaleString() }}</td>
-            <td v-html="commitUrlAsHtml(commit.sha)"></td>
-            <td v-html="formatMissingReason(reason)"></td>
-          </tr>
+          <template v-for="item in timeline">
+            <tr v-if="item.current">
+              <td colspan="7"><hr /></td>
+            </tr>
+            <tr :class="{active: item.sha === currentRun?.commit?.sha}">
+              <td class="centered" v-html="pullRequestUrlAsHtml(item.pr)"></td>
+              <td class="centered">
+                {{ item.kind }}<template v-if="item.warning">❗</template>
+              </td>
+              <td class="centered" v-html="commitUrlAsHtml(item.sha)"></td>
+              <td class="centered">{{ item.status }}</td>
+              <td>
+                {{ item.end_time.toLocaleString()
+                }}<template v-if="item.end_estimated"> (est.)</template>
+              </td>
+              <td v-if="item.duration !== null">
+                {{ formatDuration(item.duration) }}
+              </td>
+              <td v-else class="centered">?</td>
+              <td v-if="item.errors.length > 0">
+                <button @click="toggleExpandedErrors(item.sha)">
+                  {{ hasExpandedErrors(item.sha) ? "Hide" : "Show" }}
+                  {{ item.errors.length }} error{{
+                    item.errors.length !== 1 ? "s" : ""
+                  }}
+                </button>
+              </td>
+              <td v-else></td>
+            </tr>
+            <tr v-if="hasExpandedErrors(item.sha)">
+              <td colspan="7" style="padding: 10px 0">
+                <div v-for="benchmark in item.errors">
+                  <div>
+                    <details open>
+                      <summary>{{ benchmark.name }}</summary>
+                      <pre class="error">{{ benchmark.error }}</pre>
+                    </details>
+                  </div>
+                </div>
+              </td>
+            </tr>
+            <tr v-if="item.current">
+              <td colspan="7"><hr /></td>
+            </tr>
+          </template>
         </tbody>
       </table>
     </div>
-    <span>Benchmarking errors for last commit:</span>
-    <div v-if="data.last_commit !== null">
-      <p>SHA: {{ data.last_commit.sha }}, date: {{ data.last_commit.date }}</p>
-    </div>
-    <div v-for="benchmark in data.benchmarks">
-      <div>
-        <details open>
-          <summary>{{ benchmark.name }} - error</summary>
-          <pre>{{ benchmark.error }}</pre>
-        </details>
-      </div>
-    </div>
   </div>
   <div v-else>Loading status…</div>
+  <div style="margin-top: 10px">Times are local.</div>
 </template>
 
 <style scoped lang="scss">
+.timeline {
+  table {
+    border-collapse: collapse;
+    font-size: 1.1em;
+
+    th,
+    td {
+      padding: 0.2em;
+    }
+
+    th {
+      text-align: center;
+    }
+    td {
+      text-align: left;
+      padding: 0 0.5em;
+
+      &.centered {
+        text-align: center;
+      }
+    }
+    tr.active {
+      font-weight: bold;
+    }
+  }
+}
+.wrapper {
+  display: flex;
+  flex-wrap: wrap;
+  column-gap: 100px;
+}
+.current {
+  .benchmark {
+    margin-bottom: 10px;
+    font-size: 1.2em;
+  }
+}
+.column-centered {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.current-table {
+  border-collapse: collapse;
+  font-size: 1.1em;
+
+  td,
+  th {
+    padding: 0 10px;
+  }
+  tbody > tr {
+    td {
+      padding-top: 5px;
+      text-align: center;
+    }
+  }
+}
 .aligned {
   text-align: right;
 }
-.missing-commits {
-  th {
-    text-align: center;
-  }
-  td {
-    text-align: left;
-    padding: 0 0.5em;
-  }
+.error {
+  padding: 10px;
+  background-color: #f7f7f7;
 }
 </style>

--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -233,7 +233,7 @@ pub mod status {
     use serde::{Deserialize, Serialize};
 
     #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-    pub struct BenchmarkStatus {
+    pub struct BenchmarkError {
         pub name: String,
         pub error: String,
     }
@@ -255,13 +255,22 @@ pub mod status {
     }
 
     #[derive(Serialize, Debug)]
+    pub struct FinishedRun {
+        pub artifact: ArtifactId,
+        pub pr: Option<u32>,
+        pub errors: Vec<BenchmarkError>,
+        // In seconds
+        pub duration: u64,
+        // Unix timestamp
+        pub finished_at: u64,
+    }
+
+    #[derive(Serialize, Debug)]
     pub struct Response {
-        pub last_commit: Option<Commit>,
-        pub benchmarks: Vec<BenchmarkStatus>,
-        pub missing: Vec<(Commit, MissingReason)>,
+        // Ordered from newest to oldest
+        pub finished_runs: Vec<FinishedRun>,
         pub current: Option<CurrentState>,
-        // None if no recent end, otherwise seconds since epoch
-        pub most_recent_end: Option<i64>,
+        pub missing: Vec<(Commit, MissingReason)>,
     }
 }
 

--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -332,8 +332,10 @@ async fn estimate_queue_info(
 
     // Guess the expected full run duration of a waiting commit
     let last_duration = conn
-        .last_artifact_collection()
+        .last_n_artifact_collections(1)
         .await
+        .into_iter()
+        .next()
         .map(|collection| collection.duration)
         .unwrap_or(Duration::ZERO);
 

--- a/site/src/request_handlers/status_page.rs
+++ b/site/src/request_handlers/status_page.rs
@@ -2,14 +2,16 @@ use std::str;
 use std::sync::Arc;
 
 use crate::api::status;
+use crate::api::status::FinishedRun;
 use crate::db::{ArtifactId, Lookup};
 use crate::load::SiteCtxt;
 
-pub async fn handle_status_page(ctxt: Arc<SiteCtxt>) -> status::Response {
-    let idx = ctxt.index.load();
-    let last_commit = idx.commits().last().cloned();
+// How many historical (finished) runs should be returned from the status API.
+const FINISHED_RUN_COUNT: u64 = 5;
 
+pub async fn handle_status_page(ctxt: Arc<SiteCtxt>) -> status::Response {
     let missing = ctxt.missing_commits().await;
+
     // FIXME: no current builds
     let conn = ctxt.conn().await;
     let current = if let Some(artifact) = conn.in_progress_artifacts().await.pop() {
@@ -33,29 +35,41 @@ pub async fn handle_status_page(ctxt: Arc<SiteCtxt>) -> status::Response {
         None
     };
 
-    let errors = if let Some(last) = &last_commit {
-        conn.get_error(ArtifactId::from(last.clone()).lookup(&idx).unwrap())
-            .await
-    } else {
-        Default::default()
-    };
-    let benchmark_state = errors
-        .into_iter()
-        .map(|(name, error)| {
-            let error = prettify_log(&error).unwrap_or(error);
-            status::BenchmarkStatus { name, error }
-        })
-        .collect::<Vec<_>>();
+    // FIXME: load at least one master commit with errors, if no master commit is in last N commits?
+    // FIXME: cache this whole thing, or write a specific SQL query for it
+    let mut finished_runs = Vec::new();
+    let idx = ctxt.index.load();
+
+    let recent_collections = conn
+        .last_n_artifact_collections(FINISHED_RUN_COUNT as u32)
+        .await;
+    for collection in recent_collections {
+        let errors = conn
+            .get_error(collection.artifact.lookup(&idx).unwrap())
+            .await;
+        let mut pr = None;
+        if let ArtifactId::Commit(ref commit) = collection.artifact {
+            pr = conn.pr_of(&commit.sha).await;
+        }
+        finished_runs.push(FinishedRun {
+            artifact: collection.artifact,
+            pr,
+            errors: errors
+                .into_iter()
+                .map(|(name, error)| {
+                    let error = prettify_log(&error).unwrap_or(error);
+                    status::BenchmarkError { name, error }
+                })
+                .collect::<Vec<_>>(),
+            duration: collection.duration.as_secs(),
+            finished_at: collection.end_time.timestamp() as u64,
+        });
+    }
 
     status::Response {
-        last_commit,
-        benchmarks: benchmark_state,
+        finished_runs,
         missing,
         current,
-        most_recent_end: conn
-            .last_artifact_collection()
-            .await
-            .map(|d| d.end_time.timestamp()),
     }
 }
 


### PR DESCRIPTION
This PR redesigns the status page so that we can see the history of runs, to have better visibility of historical benchmark errors, and also to have a more obvious estimation of when will a given PR finish.

![image](https://github.com/rust-lang/rustc-perf/assets/4539057/2cb7da24-206f-49da-87c3-622c98de67b3)

This patch can be used to hardcode data for testing locally:
<details>
<summary>Patch</summary>

```
diff --git a/site/src/request_handlers/status_page.rs b/site/src/request_handlers/status_page.rs
index e1e2563e..f2ae5f04 100644
--- a/site/src/request_handlers/status_page.rs
+++ b/site/src/request_handlers/status_page.rs
@@ -1,18 +1,46 @@
+use database::{Commit, CommitType, Date};
 use std::str;
 use std::sync::Arc;
 
 use crate::api::status;
-use crate::api::status::FinishedRun;
+use crate::api::status::{CurrentState, FinishedRun};
 use crate::db::{ArtifactId, Lookup};
-use crate::load::SiteCtxt;
+use crate::load::{MissingReason, SiteCtxt};
+use crate::server::status::BenchmarkError;
 
 // How many historical (finished) runs should be returned from the status API.
 const FINISHED_RUN_COUNT: u64 = 5;
 
 pub async fn handle_status_page(ctxt: Arc<SiteCtxt>) -> status::Response {
-    let missing = ctxt.missing_commits().await;
-
-    // FIXME: no current builds
+    let mut missing = vec![
+        (
+            Commit {
+                sha: "abcdef".to_string(),
+                date: Date::ymd_hms(2023, 1, 1, 0, 0, 0),
+                r#type: CommitType::Try,
+            },
+            MissingReason::Try {
+                pr: 123,
+                parent_sha: "foobar".to_string(),
+                include: None,
+                exclude: None,
+                runs: None,
+            },
+        ),
+        (
+            Commit {
+                sha: "abcdef2".to_string(),
+                date: Date::ymd_hms(2023, 2, 1, 0, 0, 0),
+                r#type: CommitType::Master,
+            },
+            MissingReason::Master {
+                pr: 421,
+                parent_sha: "foobar2".to_string(),
+                is_try_parent: true,
+            },
+        ),
+    ]; //ctxt.missing_commits().await;
+       // FIXME: no current builds
     let conn = ctxt.conn().await;
     let current = if let Some(artifact) = conn.in_progress_artifacts().await.pop() {
         let steps = conn
@@ -35,8 +63,76 @@ pub async fn handle_status_page(ctxt: Arc<SiteCtxt>) -> status::Response {
         None
     };
 
-    // FIXME: load at least one master commit with errors, if no master commit is in last N commits?
-    // FIXME: cache this whole thing, or write a specific SQL query for it
+    // let current: Option<CurrentState> = None;
+    let current = Some(status::CurrentState {
+        artifact: ArtifactId::Commit(Commit {
+            sha: "abcdef123".to_string(),
+            date: Date::ymd_hms(2023, 09, 11, 18, 00, 00),
+            r#type: CommitType::Try,
+        }),
+        progress: vec![
+            status::Step {
+                step: "a".to_string(),
+                is_done: true,
+                expected_duration: 120,
+                current_progress: 80,
+            },
+            status::Step {
+                step: "b".to_string(),
+                is_done: true,
+                expected_duration: 90,
+                current_progress: 120,
+            },
+            status::Step {
+                step: "c".to_string(),
+                is_done: false,
+                expected_duration: 140,
+                current_progress: 40,
+            },
+            status::Step {
+                step: "runtime:a".to_string(),
+                is_done: false,
+                expected_duration: 3,
+                current_progress: 0,
+            },
+            status::Step {
+                step: "runtime:b".to_string(),
+                is_done: false,
+                expected_duration: 4,
+                current_progress: 0,
+            },
+            status::Step {
+                step: "rustc".to_string(),
+                is_done: false,
+                expected_duration: 1000,
+                current_progress: 0,
+            },
+            status::Step {
+                step: "d".to_string(),
+                is_done: false,
+                expected_duration: 120,
+                current_progress: 0,
+            },
+        ],
+    });
+
+    if let Some(ref current) = current {
+        if let ArtifactId::Commit(ref commit) = current.artifact {
+            missing.push((
+                commit.clone(),
+                MissingReason::InProgress(Some(Box::new(MissingReason::Try {
+                    pr: 1240,
+                    parent_sha: "foo".to_string(),
+                    include: None,
+                    exclude: None,
+                    runs: None,
+                }))),
+            ));
+        }
+    }
+
+    /*// TODO: load at least one master commit with errors, if no master commit is in last N commits?
+    // TODO: cache this whole thing, or write a specific SQL query for it
     let mut finished_runs = Vec::new();
     let idx = ctxt.index.load();
 
@@ -64,7 +160,51 @@ pub async fn handle_status_page(ctxt: Arc<SiteCtxt>) -> status::Response {
             duration: collection.duration.as_secs(),
             finished_at: collection.end_time.timestamp() as u64,
         });
-    }
+    }*/
+    let mut finished_runs = vec![
+        FinishedRun {
+            artifact: ArtifactId::Commit(Commit {
+                sha: "abcdef".to_string(),
+                date: Date::ymd_hms(2023, 09, 05, 01, 02, 03),
+                r#type: CommitType::Try,
+            }),
+            pr: Some(128),
+            errors: vec![],
+            duration: 1234,
+            finished_at: 1694447945,
+        },
+        FinishedRun {
+            artifact: ArtifactId::Commit(Commit {
+                sha: "foobar".to_string(),
+                date: Date::ymd_hms(2023, 09, 04, 01, 02, 03),
+                r#type: CommitType::Master,
+            }),
+            pr: Some(256),
+            errors: vec![
+                BenchmarkError {
+                    name: "foo".to_string(),
+                    error: "ERROR".to_string(),
+                },
+                BenchmarkError {
+                    name: "bar".to_string(),
+                    error: "ERROR 2".to_string(),
+                },
+            ],
+            duration: 1462,
+            finished_at: 1694437945,
+        },
+        FinishedRun {
+            artifact: ArtifactId::Commit(Commit {
+                sha: "foobar2".to_string(),
+                date: Date::ymd_hms(2023, 09, 03, 01, 02, 03),
+                r#type: CommitType::Master,
+            }),
+            pr: Some(100),
+            errors: vec![],
+            duration: 1302,
+            finished_at: 1694427945,
+        },
+    ];
 
     status::Response {
         finished_runs,
```
</details>