### PR TITLE
Only read expected step durations from master collections

### DIFF
--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -481,11 +481,13 @@ impl PostgresConnection {
                         epoch from interval '0 seconds'::interval +
                         (select cp.end_time - cp.start_time
                         from collector_progress as cp
+                        join artifact on artifact.id = cp.aid
                             where
                                 cp.aid != $1
                                 and cp.step = collector_progress.step
                                 and cp.start_time is not null
                                 and cp.end_time is not null
+                                and artifact.type = 'master'
                             order by start_time desc
                             limit 1
                         ))::int4


### PR DESCRIPTION
The `expected step duration` in the status page was taken out of the duration of the same step for the most recent collection. However, try builds can sometimes have large variations, so we shouldn't probably take them into account. It would probably be best if we used the duration of the same step of the *parent SHA commit*, but that would complicate the query quite a lot, because of the way the DB is currently structured.

We could maybe also only look up master collections in `last_artifact_collection`, to better estimate the total collection durations in PR comments and on the new status page.

Note that I didn't update the SQLite query for this, as the status page doesn't work locally anyway.