### PR TITLE
Set resolver to version 2 in workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = ["collector", "collector/benchlib", "site", "database", "intern"]
 exclude = ["rust/src"]
+resolver = "2"
 
 [profile.release.package.site]
 debug = 1


### PR DESCRIPTION
Silences the annoying warning.