### PR TITLE
Integrate Clippy into the project

### DIFF
--- a/collector/benchlib/src/benchmark.rs
+++ b/collector/benchlib/src/benchmark.rs
@@ -119,8 +119,15 @@ impl<'a> BenchmarkGroup<'a> {
 
     fn profile_benchmark(self, args: ProfileArgs) -> anyhow::Result<()> {
         let Some(benchmark) = self.benchmarks.get(args.benchmark.as_str()) else {
-            return Err(anyhow::anyhow!("Benchmark `{}` not found. Available benchmarks: {}", args.benchmark,
-                self.benchmarks.keys().map(|s| s.to_string()).collect::<Vec<_>>().join(", ")));
+            return Err(anyhow::anyhow!(
+                "Benchmark `{}` not found. Available benchmarks: {}",
+                args.benchmark,
+                self.benchmarks
+                    .keys()
+                    .map(|s| s.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
         };
         (benchmark.profile_fn)();
 

--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -375,6 +375,10 @@ struct CompileTimeOptions {
     /// The path to the local rustdoc to measure
     #[arg(long)]
     rustdoc: Option<PathBuf>,
+
+    /// The path to the local clippy to measure
+    #[arg(long)]
+    clippy: Option<PathBuf>
 }
 
 #[derive(Debug, clap::Args)]
@@ -663,6 +667,7 @@ fn main_result() -> anyhow::Result<i32> {
                     None,
                     None,
                     None,
+                    None,
                     id,
                     target_triple.clone(),
                 )?;
@@ -721,6 +726,7 @@ fn main_result() -> anyhow::Result<i32> {
                     None,
                     None,
                     None,
+                    None,
                     id,
                     target_triple.clone(),
                 )?;
@@ -757,6 +763,7 @@ fn main_result() -> anyhow::Result<i32> {
                 &profiles,
                 &local.rustc,
                 opts.rustdoc.as_deref(),
+                opts.clippy.as_deref(),
                 local.cargo.as_deref(),
                 local.id.as_deref(),
                 "",
@@ -949,6 +956,7 @@ fn main_result() -> anyhow::Result<i32> {
                         profiles,
                         rustc,
                         opts.rustdoc.as_deref(),
+                        opts.clippy.as_deref(),
                         local.cargo.as_deref(),
                         local.id.as_deref(),
                         suffix,
@@ -1062,6 +1070,7 @@ fn get_local_toolchain_for_runtime_benchmarks(
     get_local_toolchain(
         &[Profile::Opt],
         &local.rustc,
+        None,
         None,
         local.cargo.as_deref(),
         local.id.as_deref(),

--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -1197,9 +1197,18 @@ fn bench_published_artifact(
     let artifact_id = ArtifactId::Tag(toolchain.id.clone());
 
     let profiles = if collector::version_supports_doc(&toolchain.id) {
-        Profile::all()
+        vec![
+            Profile::Check,
+            Profile::Debug,
+            Profile::Doc,
+            Profile::Opt
+        ]
     } else {
-        Profile::all_non_doc()
+        vec![
+            Profile::Check,
+            Profile::Debug,
+            Profile::Opt,
+        ]
     };
     let scenarios = if collector::version_supports_incremental(&toolchain.id) {
         Scenario::all()

--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -38,7 +38,7 @@ use collector::runtime::{
 };
 use collector::runtime::{profile_runtime, RuntimeCompilationOpts};
 use collector::toolchain::{
-    create_toolchain_from_published_version, get_local_toolchain, Sysroot, Toolchain,
+    create_toolchain_from_published_version, get_local_toolchain, Sysroot, Toolchain, ToolchainConfig,
 };
 use collector::utils::cachegrind::cachegrind_diff;
 use collector::utils::{is_installed, wait_for_future};
@@ -664,10 +664,7 @@ fn main_result() -> anyhow::Result<i32> {
                 let toolchain = get_local_toolchain(
                     &[Profile::Opt],
                     rustc,
-                    None,
-                    None,
-                    None,
-                    None,
+                    ToolchainConfig::default(),
                     id,
                     target_triple.clone(),
                 )?;
@@ -723,10 +720,7 @@ fn main_result() -> anyhow::Result<i32> {
                 let toolchain = get_local_toolchain(
                     &[Profile::Opt],
                     rustc,
-                    None,
-                    None,
-                    None,
-                    None,
+                    ToolchainConfig::default(),
                     id,
                     target_triple.clone(),
                 )?;
@@ -762,10 +756,11 @@ fn main_result() -> anyhow::Result<i32> {
             let toolchain = get_local_toolchain(
                 &profiles,
                 &local.rustc,
-                opts.rustdoc.as_deref(),
-                opts.clippy.as_deref(),
-                local.cargo.as_deref(),
-                local.id.as_deref(),
+                *ToolchainConfig::default()
+                    .rustdoc(opts.rustdoc.as_deref())
+                    .clippy(opts.clippy.as_deref())
+                    .cargo(local.cargo.as_deref())
+                    .id(local.id.as_deref()),
                 "",
                 target_triple,
             )?;
@@ -955,10 +950,11 @@ fn main_result() -> anyhow::Result<i32> {
                     let toolchain = get_local_toolchain(
                         profiles,
                         rustc,
-                        opts.rustdoc.as_deref(),
-                        opts.clippy.as_deref(),
-                        local.cargo.as_deref(),
-                        local.id.as_deref(),
+                        *ToolchainConfig::default()
+                            .rustdoc(opts.rustdoc.as_deref())
+                            .clippy(opts.clippy.as_deref())
+                            .cargo(local.cargo.as_deref())
+                            .id(local.id.as_deref()),
                         suffix,
                         target_triple.clone(),
                     )?;
@@ -1070,10 +1066,9 @@ fn get_local_toolchain_for_runtime_benchmarks(
     get_local_toolchain(
         &[Profile::Opt],
         &local.rustc,
-        None,
-        None,
-        local.cargo.as_deref(),
-        local.id.as_deref(),
+        *ToolchainConfig::default()
+            .cargo(local.cargo.as_deref())
+            .id(local.id.as_deref()),
         "",
         target_triple.to_string(),
     )

--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -38,7 +38,8 @@ use collector::runtime::{
 };
 use collector::runtime::{profile_runtime, RuntimeCompilationOpts};
 use collector::toolchain::{
-    create_toolchain_from_published_version, get_local_toolchain, Sysroot, Toolchain, ToolchainConfig,
+    create_toolchain_from_published_version, get_local_toolchain, Sysroot, Toolchain,
+    ToolchainConfig,
 };
 use collector::utils::cachegrind::cachegrind_diff;
 use collector::utils::{is_installed, wait_for_future};
@@ -378,7 +379,7 @@ struct CompileTimeOptions {
 
     /// The path to the local clippy to measure
     #[arg(long)]
-    clippy: Option<PathBuf>
+    clippy: Option<PathBuf>,
 }
 
 #[derive(Debug, clap::Args)]
@@ -1197,18 +1198,9 @@ fn bench_published_artifact(
     let artifact_id = ArtifactId::Tag(toolchain.id.clone());
 
     let profiles = if collector::version_supports_doc(&toolchain.id) {
-        vec![
-            Profile::Check,
-            Profile::Debug,
-            Profile::Doc,
-            Profile::Opt
-        ]
+        vec![Profile::Check, Profile::Debug, Profile::Doc, Profile::Opt]
     } else {
-        vec![
-            Profile::Check,
-            Profile::Debug,
-            Profile::Opt,
-        ]
+        vec![Profile::Check, Profile::Debug, Profile::Opt]
     };
     let scenarios = if collector::version_supports_incremental(&toolchain.id) {
         Scenario::all()

--- a/collector/src/bin/rustc-fake.rs
+++ b/collector/src/bin/rustc-fake.rs
@@ -35,8 +35,11 @@ fn main() {
     let mut args = args_os.collect::<Vec<_>>();
     let rustc = env::var_os("RUSTC_REAL").unwrap();
     let actually_rustdoc = name.ends_with("rustdoc-fake");
+    let actually_clippy = name.ends_with("clippy-fake");
     let tool = if actually_rustdoc {
         env::var_os("RUSTDOC_REAL").unwrap()
+    } else if actually_clippy {
+        env::var_os("CLIPPY_REAL").unwrap()
     } else {
         rustc
     };

--- a/collector/src/compile/benchmark/profile.rs
+++ b/collector/src/compile/benchmark/profile.rs
@@ -12,13 +12,15 @@ pub enum Profile {
     Debug,
     Doc,
     Opt,
+    Clippy,
 }
 
 impl Profile {
     pub fn all() -> Vec<Self> {
-        vec![Profile::Check, Profile::Debug, Profile::Doc, Profile::Opt]
+        vec![Profile::Check, Profile::Debug, Profile::Doc, Profile::Opt, Profile::Clippy]
     }
 
+    // This also leaves Clippy out
     pub fn all_non_doc() -> Vec<Self> {
         vec![Profile::Check, Profile::Debug, Profile::Opt]
     }

--- a/collector/src/compile/benchmark/profile.rs
+++ b/collector/src/compile/benchmark/profile.rs
@@ -17,7 +17,7 @@ pub enum Profile {
 
 impl Profile {
     pub fn all() -> Vec<Self> {
-        vec![Profile::Check, Profile::Debug, Profile::Doc, Profile::Opt, Profile::Clippy]
+        vec![Profile::Check, Profile::Debug, Profile::Doc, Profile::Opt]
     }
 
     // This also leaves Clippy out

--- a/collector/src/compile/execute/bencher.rs
+++ b/collector/src/compile/execute/bencher.rs
@@ -87,6 +87,7 @@ impl<'a> BenchProcessor<'a> {
             Profile::Debug => database::Profile::Debug,
             Profile::Doc => database::Profile::Doc,
             Profile::Opt => database::Profile::Opt,
+            Profile::Clippy => database::Profile::Clippy,
         };
 
         if let Some(files) = stats.2 {

--- a/collector/src/toolchain.rs
+++ b/collector/src/toolchain.rs
@@ -123,10 +123,7 @@ impl SysrootDownload {
         let components = ToolchainComponents::from_binaries_and_libdir(
             sysroot_bin("rustc")?,
             Some(sysroot_bin("rustdoc")?),
-            match sysroot_bin("cargo-clippy") {
-                Err(_) => None,
-                Ok(path) => Some(path),
-            },
+            sysroot_bin("cargo-clippy").ok(),
             sysroot_bin("cargo")?,
             &self.directory.join(&self.rust_sha).join("lib"),
         )?;

--- a/collector/src/toolchain.rs
+++ b/collector/src/toolchain.rs
@@ -448,7 +448,7 @@ pub fn get_local_toolchain(
             Some(clippy)
         } else {
             anyhow::bail!(
-                    "'Clippy' build specified but '--clippy' not specified and no 'cargo-clippy' found \
+                    "'Clippy' build specified but '--cargo-clippy' not specified and no 'cargo-clippy' found \
                     next to 'rustc'"
                 );
         }

--- a/collector/src/toolchain.rs
+++ b/collector/src/toolchain.rs
@@ -123,7 +123,10 @@ impl SysrootDownload {
         let components = ToolchainComponents::from_binaries_and_libdir(
             sysroot_bin("rustc")?,
             Some(sysroot_bin("rustdoc")?),
-            Some(sysroot_bin("clippy")?),
+            match sysroot_bin("cargo-clippy") {
+                Err(_) => None,
+                Ok(path) => Some(path)
+            },
             sysroot_bin("cargo")?,
             &self.directory.join(&self.rust_sha).join("lib"),
         )?;
@@ -292,7 +295,7 @@ impl ToolchainComponents {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Default)]
 pub struct ToolchainConfig<'a> {
     rustdoc: Option<&'a Path>,
     clippy: Option<&'a Path>,
@@ -301,15 +304,6 @@ pub struct ToolchainConfig<'a> {
 }
 
 impl<'a> ToolchainConfig<'a> {
-    pub fn default() -> Self {
-        Self {
-            rustdoc: None,
-            clippy: None,
-            cargo: None,
-            id: None
-        }
-    }
-
     pub fn rustdoc(&mut self, rustdoc: Option<&'a Path>) -> &mut Self {
         self.rustdoc = rustdoc;
         self

--- a/collector/src/toolchain.rs
+++ b/collector/src/toolchain.rs
@@ -125,7 +125,7 @@ impl SysrootDownload {
             Some(sysroot_bin("rustdoc")?),
             match sysroot_bin("cargo-clippy") {
                 Err(_) => None,
-                Ok(path) => Some(path)
+                Ok(path) => Some(path),
             },
             sysroot_bin("cargo")?,
             &self.directory.join(&self.rust_sha).join("lib"),
@@ -435,26 +435,27 @@ pub fn get_local_toolchain(
             None
         };
 
-        let clippy =
-        if let Some(clippy) = &toolchain_config.clippy {
-            Some(clippy.canonicalize().with_context(|| {
+    let clippy = if let Some(clippy) = &toolchain_config.clippy {
+        Some(
+            clippy.canonicalize().with_context(|| {
                 format!("failed to canonicalize clippy executable {:?}", clippy)
-            })?)
-        } else if profiles.contains(&Profile::Clippy) {
-            // We need a `clippy`. Look for one next to `rustc`.
-            if let Ok(clippy) = rustc.with_file_name("cargo-clippy").canonicalize() {
-                debug!("found clippy: {:?}", &clippy);
-                Some(clippy)
-            } else {
-                anyhow::bail!(
+            })?,
+        )
+    } else if profiles.contains(&Profile::Clippy) {
+        // We need a `clippy`. Look for one next to `rustc`.
+        if let Ok(clippy) = rustc.with_file_name("cargo-clippy").canonicalize() {
+            debug!("found clippy: {:?}", &clippy);
+            Some(clippy)
+        } else {
+            anyhow::bail!(
                     "'Clippy' build specified but '--clippy' not specified and no 'cargo-clippy' found \
                     next to 'rustc'"
                 );
-            }
-        } else {
-            // No `clippy` provided, but none needed.
-            None
-        };
+        }
+    } else {
+        // No `clippy` provided, but none needed.
+        None
+    };
     let cargo = if let Some(cargo) = &toolchain_config.cargo {
         cargo
             .canonicalize()
@@ -483,7 +484,9 @@ pub fn get_local_toolchain(
     let lib_dir = get_lib_dir_from_rustc(&rustc).context("Cannot find libdir for rustc")?;
 
     Ok(Toolchain {
-        components: ToolchainComponents::from_binaries_and_libdir(rustc, rustdoc, clippy, cargo, &lib_dir)?,
+        components: ToolchainComponents::from_binaries_and_libdir(
+            rustc, rustdoc, clippy, cargo, &lib_dir,
+        )?,
         id,
         triple: target_triple,
     })
@@ -530,8 +533,13 @@ pub fn create_toolchain_from_published_version(
 
     let lib_dir = get_lib_dir_from_rustc(&rustc)?;
 
-    let components =
-        ToolchainComponents::from_binaries_and_libdir(rustc, Some(rustdoc), Some(clippy), cargo, &lib_dir)?;
+    let components = ToolchainComponents::from_binaries_and_libdir(
+        rustc,
+        Some(rustdoc),
+        Some(clippy),
+        cargo,
+        &lib_dir,
+    )?;
 
     Ok(Toolchain {
         components,

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -224,6 +224,8 @@ pub enum Profile {
     Doc,
     /// An optimized "release" build
     Opt,
+    /// A Clippy run
+    Clippy
 }
 
 impl Profile {
@@ -233,6 +235,7 @@ impl Profile {
             Profile::Opt => "opt",
             Profile::Debug => "debug",
             Profile::Doc => "doc",
+            Profile::Clippy => "clippy"
         }
     }
 }
@@ -245,6 +248,7 @@ impl std::str::FromStr for Profile {
             "debug" => Profile::Debug,
             "doc" => Profile::Doc,
             "opt" => Profile::Opt,
+            "clippy" => Profile::Clippy,
             _ => return Err(format!("{} is not a profile", s)),
         })
     }

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -225,7 +225,7 @@ pub enum Profile {
     /// An optimized "release" build
     Opt,
     /// A Clippy run
-    Clippy
+    Clippy,
 }
 
 impl Profile {
@@ -235,7 +235,7 @@ impl Profile {
             Profile::Opt => "opt",
             Profile::Debug => "debug",
             Profile::Doc => "doc",
-            Profile::Clippy => "clippy"
+            Profile::Clippy => "clippy",
         }
     }
 }

--- a/site/src/request_handlers/dashboard.rs
+++ b/site/src/request_handlers/dashboard.rs
@@ -150,7 +150,7 @@ pub struct ByProfile<T> {
     pub debug: T,
     pub doc: T,
     pub opt: T,
-    pub clippy: T
+    pub clippy: T,
 }
 
 impl<T> ByProfile<T> {
@@ -177,7 +177,7 @@ impl<T> std::ops::Index<Profile> for ByProfile<T> {
             Profile::Debug => &self.debug,
             Profile::Doc => &self.doc,
             Profile::Opt => &self.opt,
-            Profile::Clippy => &self.clippy
+            Profile::Clippy => &self.clippy,
         }
     }
 }

--- a/site/src/request_handlers/dashboard.rs
+++ b/site/src/request_handlers/dashboard.rs
@@ -150,6 +150,7 @@ pub struct ByProfile<T> {
     pub debug: T,
     pub doc: T,
     pub opt: T,
+    pub clippy: T
 }
 
 impl<T> ByProfile<T> {
@@ -163,6 +164,7 @@ impl<T> ByProfile<T> {
             debug: f(Profile::Debug).await?,
             doc: f(Profile::Doc).await?,
             opt: f(Profile::Opt).await?,
+            clippy: f(Profile::Clippy).await?,
         })
     }
 }
@@ -175,6 +177,7 @@ impl<T> std::ops::Index<Profile> for ByProfile<T> {
             Profile::Debug => &self.debug,
             Profile::Doc => &self.doc,
             Profile::Opt => &self.opt,
+            Profile::Clippy => &self.clippy
         }
     }
 }


### PR DESCRIPTION
This PR integrates Clippy into the project.
A user can run the `clippy` profile with a local Clippy build, with the `--clippy` flag targetting to the Clippy executable:

```sh
$ cargo run --bin collector  -- bench_local +nightly --profiles Clippy --clippy ../clippy/target/release/cargo-clippy
```

---

But I'm having some problems with the bot integration, so some feedback and tips in those files would be very appreciated.

* Would the bot run this on every commit, where is it configured? (we don't want to run it every commit)
Thanks for the feedback :heart: 