### PR TITLE
Do not hide runtime tab when there are no results

### DIFF
--- a/site/frontend/src/pages/compare/page.vue
+++ b/site/frontend/src/pages/compare/page.vue
@@ -81,17 +81,15 @@ async function loadCompareData(
       )
     )
   );
-  if (response.runtime_comparisons.length > 0) {
-    runtimeSummary.value = computeSummary(
-      filterNonRelevant(
+  runtimeSummary.value = computeSummary(
+    filterNonRelevant(
+      defaultRuntimeFilter,
+      computeRuntimeComparisonsWithNonRelevant(
         defaultRuntimeFilter,
-        computeRuntimeComparisonsWithNonRelevant(
-          defaultRuntimeFilter,
-          response.runtime_comparisons
-        )
+        response.runtime_comparisons
       )
-    );
-  }
+    )
+  );
 }
 
 function updateSelection(params: SelectionParams) {
@@ -120,16 +118,12 @@ const selector = loadSelectorFromUrl(urlParams);
 const initialTab: Tab = loadTabFromUrl(urlParams) ?? Tab.CompileTime;
 const tab: Ref<Tab> = ref(initialTab);
 const activeTab = computed((): Tab => {
-  if (tab.value === Tab.Runtime && !runtimeDataAvailable.value) {
-    return Tab.CompileTime;
-  }
   if (tab.value === Tab.ArtifactSize && !artifactSizeAvailable.value) {
     return Tab.CompileTime;
   }
   return tab.value;
 });
 
-const runtimeDataAvailable = computed(() => runtimeSummary.value !== null);
 const artifactSizeAvailable = computed(
   () =>
     data.value != null &&
@@ -174,7 +168,7 @@ loadCompareData(selector, loading);
           :benchmark-info="info"
         />
       </template>
-      <template v-if="runtimeDataAvailable && activeTab === Tab.Runtime">
+      <template v-if="activeTab === Tab.Runtime">
         <RuntimeBenchmarksPage
           :data="data"
           :selector="selector"

--- a/site/frontend/src/pages/compare/tabs.vue
+++ b/site/frontend/src/pages/compare/tabs.vue
@@ -15,7 +15,7 @@ const props = withDefaults(
   defineProps<{
     data: CompareResponse;
     compileTimeSummary: SummaryGroup;
-    runtimeSummary: SummaryGroup | null;
+    runtimeSummary: SummaryGroup;
     initialTab?: Tab;
   }>(),
   {
@@ -65,7 +65,7 @@ function SummaryTable({summary}: {summary: SummaryGroup}) {
       </table>
     );
   }
-  return <div>No relevant results</div>;
+  return <div>No results</div>;
 }
 
 function formatArtifactSize(size: number): string {
@@ -78,8 +78,6 @@ function formatArtifactSize(size: number): string {
 const bootstrapA = props.data.a.bootstrap_total;
 const bootstrapB = props.data.b.bootstrap_total;
 const bootstrapValid = bootstrapA > 0.0 && bootstrapB > 0.0;
-
-const runtimeAvailable = computed(() => props.runtimeSummary !== null);
 
 const totalSizeA = Object.values(props.data.a.component_sizes).reduce(
   (a, b) => a + b,
@@ -109,7 +107,6 @@ const activeTab: Ref<Tab> = ref(props.initialTab);
       </div>
     </div>
     <div
-      v-if="runtimeAvailable"
       class="tab"
       title="Runtime benchmarks: measure how long does it take to execute (i.e. how fast are) programs compiled by the compared rustc."
       :class="{selected: activeTab === Tab.Runtime}"


### PR DESCRIPTION
This was just a temporary precaution until we bootstrap enough data for runtime benchmarks. Now it shouldn't be needed. This PR removes the special case.

Fixes: https://github.com/rust-lang/rustc-perf/issues/1727