### PR TITLE
Add basic support for selecting a codegen backend for compile benchmarks

### DIFF
--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -896,7 +896,7 @@ fn main_result() -> anyhow::Result<i32> {
 
                     let compile_config = CompileBenchmarkConfig {
                         benchmarks,
-                        profiles: Profile::all(),
+                        profiles: vec![Profile::Check, Profile::Debug, Profile::Doc, Profile::Opt],
                         scenarios: Scenario::all(),
                         iterations: runs.map(|v| v as usize),
                         is_self_profile: self_profile.self_profile,

--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -84,6 +84,7 @@ struct CompileBenchmarkConfig {
     benchmarks: Vec<Benchmark>,
     profiles: Vec<Profile>,
     scenarios: Vec<Scenario>,
+    backends: Vec<CodegenBackend>,
     iterations: Option<usize>,
     is_self_profile: bool,
     bench_rustc: bool,
@@ -185,6 +186,7 @@ fn profile_compile(
     benchmarks: &[Benchmark],
     profiles: &[Profile],
     scenarios: &[Scenario],
+    backends: &[CodegenBackend],
     errors: &mut BenchmarkErrors,
 ) {
     eprintln!("Profiling {} with {:?}", toolchain.id, profiler);
@@ -203,6 +205,7 @@ fn profile_compile(
                 &mut processor,
                 profiles,
                 scenarios,
+                backends,
                 toolchain,
                 Some(1),
             ));
@@ -752,6 +755,7 @@ fn main_result() -> anyhow::Result<i32> {
             log_db(&db);
             let profiles = opts.profiles.0;
             let scenarios = opts.scenarios.0;
+            let backends = opts.codegen_backends.0;
 
             let pool = database::Pool::open(&db.db);
 
@@ -787,6 +791,7 @@ fn main_result() -> anyhow::Result<i32> {
                 benchmarks,
                 profiles,
                 scenarios,
+                backends,
                 iterations: Some(iterations),
                 is_self_profile: self_profile.self_profile,
                 bench_rustc: bench_rustc.bench_rustc,
@@ -865,6 +870,7 @@ fn main_result() -> anyhow::Result<i32> {
                         benchmarks,
                         profiles: vec![Profile::Check, Profile::Debug, Profile::Doc, Profile::Opt],
                         scenarios: Scenario::all(),
+                        backends: vec![CodegenBackend::Llvm],
                         iterations: runs.map(|v| v as usize),
                         is_self_profile: self_profile.self_profile,
                         bench_rustc: bench_rustc.bench_rustc,
@@ -932,6 +938,7 @@ fn main_result() -> anyhow::Result<i32> {
 
             let profiles = &opts.profiles.0;
             let scenarios = &opts.scenarios.0;
+            let backends = &opts.codegen_backends.0;
 
             let mut benchmarks = get_compile_benchmarks(
                 &compile_benchmark_dir,
@@ -970,6 +977,7 @@ fn main_result() -> anyhow::Result<i32> {
                         &benchmarks,
                         profiles,
                         scenarios,
+                        backends,
                         &mut errors,
                     );
                     Ok(id)
@@ -1266,6 +1274,7 @@ fn bench_published_artifact(
             benchmarks: compile_benchmarks,
             profiles,
             scenarios,
+            backends: vec![CodegenBackend::Llvm],
             iterations: Some(3),
             is_self_profile: false,
             bench_rustc: false,
@@ -1373,6 +1382,7 @@ fn bench_compile(
                     processor,
                     &config.profiles,
                     &config.scenarios,
+                    &config.backends,
                     &shared.toolchain,
                     config.iterations,
                 )))

--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -6,6 +6,7 @@ use clap::{Arg, Parser};
 use collector::api::next_artifact::NextArtifact;
 use collector::codegen::{codegen_diff, CodegenType};
 use collector::compile::benchmark::category::Category;
+use collector::compile::benchmark::codegen_backend::CodegenBackend;
 use collector::compile::benchmark::profile::Profile;
 use collector::compile::benchmark::scenario::Scenario;
 use collector::compile::benchmark::{
@@ -334,6 +335,10 @@ struct CompileTimeOptions {
         default_value = "All"
     )]
     scenarios: MultiEnumValue<Scenario>,
+
+    /// Measure the codegen backends in this comma-separated list
+    #[arg(long = "backends", value_parser = EnumArgParser::<CodegenBackend>::default(), default_value = "Llvm")]
+    codegen_backends: MultiEnumValue<CodegenBackend>,
 
     /// The path to the local rustdoc to measure
     #[arg(long)]

--- a/collector/src/compile/benchmark/codegen_backend.rs
+++ b/collector/src/compile/benchmark/codegen_backend.rs
@@ -1,0 +1,11 @@
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, clap::ValueEnum, serde::Deserialize)]
+#[value(rename_all = "PascalCase")]
+pub enum CodegenBackend {
+    Llvm,
+}
+
+impl CodegenBackend {
+    pub fn all() -> Vec<CodegenBackend> {
+        vec![CodegenBackend::Llvm]
+    }
+}

--- a/collector/src/compile/benchmark/mod.rs
+++ b/collector/src/compile/benchmark/mod.rs
@@ -15,6 +15,7 @@ use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 
 pub mod category;
+pub mod codegen_backend;
 pub(crate) mod patch;
 pub mod profile;
 pub mod scenario;

--- a/collector/src/compile/benchmark/profile.rs
+++ b/collector/src/compile/benchmark/profile.rs
@@ -17,11 +17,12 @@ pub enum Profile {
 
 impl Profile {
     pub fn all() -> Vec<Self> {
-        vec![Profile::Check, Profile::Debug, Profile::Doc, Profile::Opt]
-    }
-
-    // This also leaves Clippy out
-    pub fn all_non_doc() -> Vec<Self> {
-        vec![Profile::Check, Profile::Debug, Profile::Opt]
+        vec![
+            Profile::Check,
+            Profile::Debug,
+            Profile::Doc,
+            Profile::Opt,
+            Profile::Clippy,
+        ]
     }
 }

--- a/collector/src/compile/execute/bencher.rs
+++ b/collector/src/compile/execute/bencher.rs
@@ -1,3 +1,4 @@
+use crate::compile::benchmark::codegen_backend::CodegenBackend;
 use crate::compile::benchmark::profile::Profile;
 use crate::compile::benchmark::scenario::Scenario;
 use crate::compile::benchmark::BenchmarkName;
@@ -77,6 +78,7 @@ impl<'a> BenchProcessor<'a> {
         &mut self,
         scenario: database::Scenario,
         profile: Profile,
+        backend: CodegenBackend,
         stats: (Stats, Option<SelfProfile>, Option<SelfProfileFiles>),
     ) {
         let version = get_rustc_perf_commit();
@@ -187,17 +189,22 @@ impl<'a> Processor for BenchProcessor<'a> {
                     }
 
                     let fut = match data.scenario {
-                        Scenario::Full => {
-                            self.insert_stats(database::Scenario::Empty, data.profile, res)
-                        }
+                        Scenario::Full => self.insert_stats(
+                            database::Scenario::Empty,
+                            data.profile,
+                            data.backend,
+                            res,
+                        ),
                         Scenario::IncrFull => self.insert_stats(
                             database::Scenario::IncrementalEmpty,
                             data.profile,
+                            data.backend,
                             res,
                         ),
                         Scenario::IncrUnchanged => self.insert_stats(
                             database::Scenario::IncrementalFresh,
                             data.profile,
+                            data.backend,
                             res,
                         ),
                         Scenario::IncrPatched => {
@@ -205,6 +212,7 @@ impl<'a> Processor for BenchProcessor<'a> {
                             self.insert_stats(
                                 database::Scenario::IncrementalPatch(patch.name),
                                 data.profile,
+                                data.backend,
                                 res,
                             )
                         }

--- a/collector/src/compile/execute/bencher.rs
+++ b/collector/src/compile/execute/bencher.rs
@@ -92,8 +92,14 @@ impl<'a> BenchProcessor<'a> {
             Profile::Clippy => database::Profile::Clippy,
         };
 
+        let backend = match backend {
+            CodegenBackend::Llvm => database::CodegenBackend::Llvm,
+        };
+
         if let Some(files) = stats.2 {
             if env::var_os("RUSTC_PERF_UPLOAD_TO_S3").is_some() {
+                // FIXME: Record codegen backend in the self profile name
+
                 // We can afford to have the uploads run concurrently with
                 // rustc. Generally speaking, they take up almost no CPU time
                 // (just copying data into the network). Plus, during
@@ -131,6 +137,7 @@ impl<'a> BenchProcessor<'a> {
                 self.benchmark.0.as_str(),
                 profile,
                 scenario,
+                backend,
                 stat,
                 value,
             ));

--- a/database/schema.md
+++ b/database/schema.md
@@ -26,15 +26,16 @@ Here is the diagram for compile-time benchmarks:
 │ └────────────┘  └───────────────┘ │└────────────┘ │
 │                                   │               │
 │                                   │               │
-│ ┌───────────────┐  ┌──────────┐   |               │
+│ ┌───────────────┐  ┌──────────┐   │               │
 │ │ pstat_series  │  │ pstat    │   │               │
 │ ├───────────────┤  ├──────────┤   │               │ 
 │ │ id *          │◄┐│ id *     │   │               │
 └─┤ crate         │ └┤ series   │   │               │ 
   │ profile       │  │ aid      ├───┼───────────────┘
-  │ cache         │  │ cid      ├───┘
-  │ statistic     │  │ value    │
-  └───────────────┘  └──────────┘
+  │ scenario      │  │ cid      │   │
+  │ backend       │  │ value    ├───┘
+  │ metric        │  └──────────┘
+  └───────────────┘
 ```
 
 For runtime benchmarks the schema very similar, but there are different table names:
@@ -140,19 +141,20 @@ of a crate, profile, scenario and the metric being collected.
 
 * crate (aka `benchmark`): the benchmarked crate which might be a crate from crates.io or a crate made specifically to stress some part of the compiler.
 * profile: what type of compilation is happening - check build, optimized build (a.k.a. release build), debug build, or doc build.
-* cache (aka `scenario`): describes how much of the incremental cache is full. An empty incremental cache means that the compiler must do a full build.
-* statistic (aka `metric`): the type of metric being collected
+* scenario: describes how much of the incremental cache is full. An empty incremental cache means that the compiler must do a full build.
+* backend: codegen backend used for compilation.
+* metric: the type of metric being collected.
 
 This corresponds to a [`statistic description`](../docs/glossary.md).
 
-There is a separate table for this collection to avoid duplicating crates, prfiles, scenarios etc.
+There is a separate table for this collection to avoid duplicating crates, profiles, scenarios etc.
 many times in the `pstat` table.
 
 ```
 sqlite> select * from pstat_series limit 1;
-id          crate       profile     cache       statistic
-----------  ----------  ----------  ----------  ------------
-1           helloworld  check       full        task-clock:u
+id          crate       profile     scenario    backend  metric
+----------  ----------  ----------  ----------  -------  ------------
+1           helloworld  check       full        llvm     task-clock:u
 ```
 
 ### pstat

--- a/database/src/bin/import-sqlite.rs
+++ b/database/src/bin/import-sqlite.rs
@@ -45,7 +45,7 @@ async fn main() {
         let sqlite_aid = sqlite_conn.artifact_id(&aid).await;
         let postgres_aid = postgres_conn.artifact_id(&aid).await;
 
-        for (&(benchmark, profile, scenario, metric), id) in
+        for (&(benchmark, profile, scenario, backend, metric), id) in
             sqlite_idx.compile_statistic_descriptions()
         {
             if benchmarks.insert(benchmark) {
@@ -73,6 +73,7 @@ async fn main() {
                         &benchmark,
                         profile,
                         scenario,
+                        backend,
                         metric.as_str(),
                         stat,
                     )

--- a/database/src/bin/postgres-to-sqlite.rs
+++ b/database/src/bin/postgres-to-sqlite.rs
@@ -246,11 +246,11 @@ impl Table for PstatSeries {
     }
 
     fn postgres_select_statement(&self, _since_weeks_ago: Option<u32>) -> String {
-        "select id, crate, profile, cache, statistic from ".to_string() + self.name()
+        "select id, crate, profile, scenario, backend, metric from ".to_string() + self.name()
     }
 
     fn sqlite_insert_statement(&self) -> &'static str {
-        "insert into pstat_series (id, crate, profile, cache, statistic) VALUES (?, ?, ?, ?, ?)"
+        "insert into pstat_series (id, crate, profile, scenario, backend, metric) VALUES (?, ?, ?, ?, ?, ?)"
     }
 
     fn sqlite_execute_insert(&self, statement: &mut rusqlite::Statement, row: tokio_postgres::Row) {
@@ -261,6 +261,7 @@ impl Table for PstatSeries {
                 row.get::<_, &str>(2),
                 row.get::<_, &str>(3),
                 row.get::<_, &str>(4),
+                row.get::<_, &str>(5),
             ])
             .unwrap();
     }

--- a/database/src/bin/sqlite-to-postgres.rs
+++ b/database/src/bin/sqlite-to-postgres.rs
@@ -289,8 +289,9 @@ struct PstatSeriesRow<'a> {
     id: i32,
     krate: &'a str,
     profile: &'a str,
-    cache: &'a str,
-    statistic: &'a str,
+    scenario: &'a str,
+    backend: &'a str,
+    metric: &'a str,
 }
 
 impl Table for PstatSeries {
@@ -299,7 +300,7 @@ impl Table for PstatSeries {
     }
 
     fn sqlite_attributes() -> &'static str {
-        "id, crate, profile, cache, statistic"
+        "id, crate, profile, scenario, backend, metric"
     }
 
     fn postgres_generated_id_attribute() -> Option<&'static str> {
@@ -312,8 +313,9 @@ impl Table for PstatSeries {
                 id: row.get(0).unwrap(),
                 krate: row.get_ref(1).unwrap().as_str().unwrap(),
                 profile: row.get_ref(2).unwrap().as_str().unwrap(),
-                cache: row.get_ref(3).unwrap().as_str().unwrap(),
-                statistic: row.get_ref(4).unwrap().as_str().unwrap(),
+                scenario: row.get_ref(3).unwrap().as_str().unwrap(),
+                backend: row.get_ref(4).unwrap().as_str().unwrap(),
+                metric: row.get_ref(5).unwrap().as_str().unwrap(),
             })
             .unwrap();
     }

--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -1,4 +1,4 @@
-use crate::{ArtifactCollection, ArtifactId, ArtifactIdNumber, CompileBenchmark};
+use crate::{ArtifactCollection, ArtifactId, ArtifactIdNumber, CodegenBackend, CompileBenchmark};
 use crate::{CollectionId, Index, Profile, QueuedCommit, Scenario, Step};
 use chrono::{DateTime, Utc};
 use hashbrown::HashMap;
@@ -44,6 +44,7 @@ pub trait Connection: Send + Sync {
         benchmark: &str,
         profile: Profile,
         scenario: Scenario,
+        backend: CodegenBackend,
         metric: &str,
         value: f64,
     );

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -21,6 +21,8 @@ The following is a glossary of domain specific terminology. Although benchmarks 
   - `incr-full`: incremental compilation is used, with an empty incremental cache.
   - `incr-unchanged`: incremental compilation is used, with a full incremental cache and no code changes made.
   - `incr-patched`: incremental compilation is used, with a full incremental cache and some code changes made.
+* **backend**: the codegen backend used for compiling Rust code.
+  - `llvm`: the default codegen backend
 * **category**: a high-level group of benchmarks. Currently, there are three categories, primary (mostly real-world crates), secondary (mostly stress tests), and stable (old real-world crates, only used for the dashboard).
 * **artifact type**: describes what kind of artifact does the benchmark build. Either `library` or `binary`.
 

--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -18,7 +18,7 @@ use crate::api::comparison::CompileBenchmarkMetadata;
 use crate::benchmark_metadata::get_compile_benchmarks_metadata;
 use crate::server::comparison::StatComparison;
 use collector::compile::benchmark::ArtifactType;
-use database::{CommitType, CompileBenchmark};
+use database::{CodegenBackend, CommitType, CompileBenchmark};
 use serde::de::IntoDeserializer;
 use std::cmp;
 use std::collections::{HashMap, HashSet};
@@ -839,6 +839,7 @@ async fn compare_given_commits(
             profile: test_case.profile,
             scenario: test_case.scenario,
             benchmark: test_case.benchmark,
+            backend: test_case.backend,
             comparison,
         },
     )
@@ -1409,6 +1410,7 @@ pub struct CompileTestResultComparison {
     benchmark: Benchmark,
     profile: Profile,
     scenario: Scenario,
+    backend: CodegenBackend,
     comparison: TestResultComparison,
 }
 
@@ -1423,6 +1425,7 @@ impl cmp::PartialEq for CompileTestResultComparison {
         self.benchmark == other.benchmark
             && self.profile == other.profile
             && self.scenario == other.scenario
+            && self.backend == other.backend
     }
 }
 
@@ -1433,6 +1436,7 @@ impl std::hash::Hash for CompileTestResultComparison {
         self.benchmark.hash(state);
         self.profile.hash(state);
         self.scenario.hash(state);
+        self.backend.hash(state);
     }
 }
 


### PR DESCRIPTION
This PR introduces a new parameter for compilation benchmarks - a codegen backend. It adds support for it to the collector and the database. It does not yet modify the web UI, and it also doesn't add other backends than the default one (LLVM).

The database changes will require the most review scrutiny. I tested the DB migration for both SQLite and Postgre locally.

Best reviewed commit by commit.