### PR TITLE
Add a cache for self profiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
 name = "analyzeme"
 version = "9.2.0"
 source = "git+https://github.com/rust-lang/measureme?tag=9.2.0#9f51cde2e5dd3ef0392f0f6a7201f4946502ef41"
@@ -949,6 +955,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+dependencies = [
+ "ahash 0.8.3",
+ "allocator-api2",
+]
+
+[[package]]
 name = "hashlink"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1368,6 +1384,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "lru"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efa59af2ddfad1854ae27d75009d538d0998b4b2fd47083e743ac1a10e46c60"
+dependencies = [
+ "hashbrown 0.14.2",
 ]
 
 [[package]]
@@ -2416,6 +2441,7 @@ dependencies = [
  "jemallocator",
  "lazy_static",
  "log",
+ "lru",
  "mime",
  "parking_lot 0.12.1",
  "pretty_assertions",

--- a/site/Cargo.toml
+++ b/site/Cargo.toml
@@ -48,6 +48,7 @@ uuid = { version = "1.3.0", features = ["v4"] }
 tera = "1.18"
 rust-embed = { version = "6.6.0", features = ["include-exclude", "interpolate-folder-path"] }
 humansize = "2"
+lru = "0.12.0"
 
 [target.'cfg(unix)'.dependencies]
 jemallocator = "0.5"

--- a/site/src/self_profile.rs
+++ b/site/src/self_profile.rs
@@ -1,8 +1,13 @@
 //! This module handles self-profile "rich" APIs (e.g., chrome profiler JSON)
 //! generation from the raw artifacts on demand.
 
+use crate::api::self_profile::ArtifactSize;
+use crate::api::{self_profile, ServerResult};
+use crate::load::SiteCtxt;
 use anyhow::Context;
 use bytes::Buf;
+use database::ArtifactId;
+use std::time::Duration;
 use std::{collections::HashMap, io::Read, time::Instant};
 
 mod codegen_schedule;
@@ -115,6 +120,116 @@ pub(crate) async fn get_self_profile_raw_data(url: &str) -> anyhow::Result<Vec<u
     );
 
     extract(&compressed)
+}
+
+#[derive(Clone)]
+pub struct SelfProfileWithAnalysis {
+    pub profile: self_profile::SelfProfile,
+    pub profiling_data: analyzeme::AnalysisResults,
+}
+
+pub(crate) async fn download_and_analyze_self_profile(
+    ctxt: &SiteCtxt,
+    aid: ArtifactId,
+    benchmark: &str,
+    profile: &str,
+    scenario: database::Scenario,
+    metric: Option<f64>,
+) -> ServerResult<SelfProfileWithAnalysis> {
+    let conn = ctxt.conn().await;
+    let aids_and_cids = conn
+        .list_self_profile(aid.clone(), benchmark, profile, &scenario.to_string())
+        .await;
+
+    let Some((anum, cid)) = aids_and_cids.first() else {
+        return Err(format!("no self-profile found for {aid}"));
+    };
+    let profiling_data =
+        match fetch_raw_self_profile_data(*anum, benchmark, profile, scenario, *cid).await {
+            Ok(d) => extract_profiling_data(d)
+                .map_err(|e| format!("error extracting self profiling data: {}", e))?,
+            Err(e) => return Err(format!("could not fetch raw profile data: {e:?}")),
+        };
+    let profiling_data = profiling_data.perform_analysis();
+    let profile =
+        get_self_profile_data(metric, &profiling_data).map_err(|e| format!("{}: {}", aid, e))?;
+    Ok(SelfProfileWithAnalysis {
+        profile,
+        profiling_data,
+    })
+}
+
+fn get_self_profile_data(
+    cpu_clock: Option<f64>,
+    profile: &analyzeme::AnalysisResults,
+) -> ServerResult<self_profile::SelfProfile> {
+    let total_time: Duration = profile.query_data.iter().map(|qd| qd.self_time).sum();
+
+    let query_data = profile
+        .query_data
+        .iter()
+        .map(|qd| self_profile::QueryData {
+            label: qd.label.as_str().into(),
+            self_time: qd.self_time.as_nanos() as u64,
+            percent_total_time: ((qd.self_time.as_secs_f64() / total_time.as_secs_f64()) * 100.0)
+                as f32,
+            number_of_cache_misses: qd.number_of_cache_misses as u32,
+            number_of_cache_hits: qd.number_of_cache_hits as u32,
+            invocation_count: qd.invocation_count as u32,
+            blocked_time: qd.blocked_time.as_nanos() as u64,
+            incremental_load_time: qd.incremental_load_time.as_nanos() as u64,
+        })
+        .collect();
+
+    let totals = self_profile::QueryData {
+        label: "Totals".into(),
+        self_time: total_time.as_nanos() as u64,
+        // TODO: check against wall-time from perf stats
+        percent_total_time: cpu_clock
+            .map(|w| ((total_time.as_secs_f64() / w) * 100.0) as f32)
+            // sentinel "we couldn't compute this time"
+            .unwrap_or(-100.0),
+        number_of_cache_misses: profile
+            .query_data
+            .iter()
+            .map(|qd| qd.number_of_cache_misses as u32)
+            .sum(),
+        number_of_cache_hits: profile
+            .query_data
+            .iter()
+            .map(|qd| qd.number_of_cache_hits as u32)
+            .sum(),
+        invocation_count: profile
+            .query_data
+            .iter()
+            .map(|qd| qd.invocation_count as u32)
+            .sum(),
+        blocked_time: profile
+            .query_data
+            .iter()
+            .map(|qd| qd.blocked_time.as_nanos() as u64)
+            .sum(),
+        incremental_load_time: profile
+            .query_data
+            .iter()
+            .map(|qd| qd.incremental_load_time.as_nanos() as u64)
+            .sum(),
+    };
+
+    let artifact_sizes = profile
+        .artifact_sizes
+        .iter()
+        .map(|a| ArtifactSize {
+            label: a.label.as_str().into(),
+            bytes: a.value,
+        })
+        .collect();
+
+    Ok(self_profile::SelfProfile {
+        query_data,
+        totals,
+        artifact_sizes: Some(artifact_sizes),
+    })
 }
 
 fn extract(compressed: &[u8]) -> anyhow::Result<Vec<u8>> {


### PR DESCRIPTION
The self-profiles are downloaded from S3 on each request to the detailed results page. Each file has ~12 MiB, downloading and analysing takes ~0.5-1s, and for the detailed page we download two of these profiles.

After download and post-processing, the profile only takes about ~50 KiB in memory, so I think that it makes sense to cache these profiles. This PR adds such a cache, with 1000 entries (using a LRU cache), so that it should take ~50 MiB in memory at most.

If you don't think that a cache is necessary, we could at least keep the first commit, which refactors profile download and should make it easier to reuse it for other use-cases (e.g. for doing more analyses in the [benchmark detail endpoint](https://github.com/rust-lang/rustc-perf/pull/1744)).