### PR TITLE
Add option of `-Z threads`

### DIFF
--- a/collector/README.md
+++ b/collector/README.md
@@ -155,6 +155,8 @@ The following options alter the behaviour of the `bench_local` subcommand.
 `RUST_LOG=debug` can be specified to enable verbose logging, which is useful
 for debugging `collector` itself.
 
+`ZTHREADS=<number of threads>` can be used for builds with `parallel-compiler = true` in the build's `config.toml`. This will set up that number as a flag when compiling the benchmarks.
+
 ### How to compare different versions on your own machine
 
 Often you'll want to compare two different compiler versions. For example, you

--- a/collector/src/compile/benchmark/mod.rs
+++ b/collector/src/compile/benchmark/mod.rs
@@ -193,6 +193,13 @@ impl Benchmark {
             cargo_args.push(format!("-j{}", count));
         }
 
+        if let Some(zthreads) = std::env::var("RUSTC_PERF_ZTHREADS")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+        {
+            cargo_args.push(format!("-Zthreads {}", zthreads))
+        }
+
         CargoProcess {
             toolchain,
             processor_name: self.name.clone(),
@@ -227,6 +234,7 @@ impl Benchmark {
         scenarios: &[Scenario],
         toolchain: &Toolchain,
         iterations: Option<usize>,
+        zthreads: usize
     ) -> anyhow::Result<()> {
         if self.config.disabled {
             eprintln!("Skipping {}: disabled", self.name);
@@ -291,6 +299,9 @@ impl Benchmark {
             let mut threads = Vec::with_capacity(profile_dirs.len());
             for (profile, prep_dir) in &profile_dirs {
                 let server = server.clone();
+                if zthreads > 0 {
+                    
+                }
                 let thread = s.spawn::<_, anyhow::Result<()>>(move || {
                     wait_for_future(
                         self.mk_cargo_process(toolchain, prep_dir.path(), *profile)


### PR DESCRIPTION
This PR adds `parallel-compiler = true` support for `rustc-perf`. It work by adding a `ZTHREADS` env. var. and passing it to RUSTFLAGS if it is set.