### PR TITLE
Document Cargo metadata hash

### DIFF
--- a/collector/src/bin/rustc-fake.rs
+++ b/collector/src/bin/rustc-fake.rs
@@ -16,6 +16,15 @@ fn determinism_env(cmd: &mut Command) {
     // what the actual change between two artifacts is.
     cmd.env("RUSTC_FORCE_INCR_COMP_ARTIFACT_HEADER", "rustc-perf");
     cmd.env("RUSTC_FORCE_RUSTC_VERSION", "rustc-perf");
+
+    // There is another similar source of hashing noise. Cargo queries the version of rustc
+    // using `rustc -vV`, and then hashes part of the output, and passes it to `rustc` using
+    // `-Cmetadata`. This means that two different versions of rustc might have a different metadata
+    // value, and thus different hash value.
+    // However, for rustc-perf, this is mostly a non-issue, because for nightly releases, cargo
+    // currently only hashes the host (which should stay the same, for the time being), and the part
+    // of the rustc version after -, which should be "nightly" for all try builds and also master
+    // commits.
 }
 
 fn run_with_determinism_env(mut cmd: Command) {
@@ -33,6 +42,7 @@ fn main() {
     let name = args_os.next().unwrap().into_string().unwrap();
 
     let mut args = args_os.collect::<Vec<_>>();
+
     let rustc = env::var_os("RUSTC_REAL").unwrap();
     let actually_rustdoc = name.ends_with("rustdoc-fake");
     let actually_clippy = name.ends_with("clippy-fake");


### PR DESCRIPTION
The collector uses `RUSTC_FORCE_RUSTC_VERSION` and `RUSTC_FORCE_INCR_COMP_ARTIFACT_HEADER` to try to limit noise introduced by different stable hashes and mangled method names.

@bjorn3 realized that there is another source of this noise. Cargo uses `rustc -vV` and hashes the output, and then passes this hash to `rustc` using `-Cmetadata`. This happens [here](https://github.com/rust-lang/cargo/blob/e9ba4fe814521061e2d8e6a71ec3ab2789c6f7d5/src/cargo/core/compiler/context/compilation_files.rs#L649-L680).

I experimented with the hash, and it looks like it's mostly a non-issue for rustc-perf, because all try and master builds should have the same hash, because Cargo only hashes the part of the `rustc` version after the dash, which should be `nightly` for all try and master builds (it also hashes the host, but that is, at least for now, constant on the collector server). The hash will be different for beta/stable benchmarks, but there are so rare that this is probably not a problem in practice.

This PR documents this behavior.