### PR TITLE
Add support for benchmarking Cranelift codegen backend

### DIFF
--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -667,6 +667,7 @@ fn main_result() -> anyhow::Result<i32> {
             let get_suite = |rustc: &str, id: &str| {
                 let toolchain = get_local_toolchain(
                     &[Profile::Opt],
+                    &[CodegenBackend::Llvm],
                     rustc,
                     ToolchainConfig::default(),
                     id,
@@ -723,6 +724,7 @@ fn main_result() -> anyhow::Result<i32> {
             let get_toolchain = |rustc: &str, id: &str| {
                 let toolchain = get_local_toolchain(
                     &[Profile::Opt],
+                    &[CodegenBackend::Llvm],
                     rustc,
                     ToolchainConfig::default(),
                     id,
@@ -761,6 +763,7 @@ fn main_result() -> anyhow::Result<i32> {
 
             let toolchain = get_local_toolchain(
                 &profiles,
+                &backends,
                 &local.rustc,
                 *ToolchainConfig::default()
                     .rustdoc(opts.rustdoc.as_deref())
@@ -960,6 +963,7 @@ fn main_result() -> anyhow::Result<i32> {
                 |rustc: &str, suffix: &str| -> anyhow::Result<String> {
                     let toolchain = get_local_toolchain(
                         profiles,
+                        &[CodegenBackend::Llvm],
                         rustc,
                         *ToolchainConfig::default()
                             .rustdoc(opts.rustdoc.as_deref())
@@ -1085,6 +1089,7 @@ fn get_local_toolchain_for_runtime_benchmarks(
 ) -> anyhow::Result<Toolchain> {
     get_local_toolchain(
         &[Profile::Opt],
+        &[CodegenBackend::Llvm],
         &local.rustc,
         *ToolchainConfig::default()
             .cargo(local.cargo.as_deref())

--- a/collector/src/compile/benchmark/codegen_backend.rs
+++ b/collector/src/compile/benchmark/codegen_backend.rs
@@ -2,10 +2,11 @@
 #[value(rename_all = "PascalCase")]
 pub enum CodegenBackend {
     Llvm,
+    Cranelift,
 }
 
 impl CodegenBackend {
     pub fn all() -> Vec<CodegenBackend> {
-        vec![CodegenBackend::Llvm]
+        vec![CodegenBackend::Llvm, CodegenBackend::Cranelift]
     }
 }

--- a/collector/src/compile/execute/bencher.rs
+++ b/collector/src/compile/execute/bencher.rs
@@ -94,6 +94,7 @@ impl<'a> BenchProcessor<'a> {
 
         let backend = match backend {
             CodegenBackend::Llvm => database::CodegenBackend::Llvm,
+            CodegenBackend::Cranelift => database::CodegenBackend::Cranelift,
         };
 
         if let Some(files) = stats.2 {

--- a/collector/src/compile/execute/mod.rs
+++ b/collector/src/compile/execute/mod.rs
@@ -262,6 +262,14 @@ impl<'a> CargoProcess<'a> {
                 cmd.arg("-Ztimings");
             }
             cmd.arg("--");
+
+            match self.backend {
+                CodegenBackend::Llvm => {}
+                CodegenBackend::Cranelift => {
+                    cmd.arg("-Zcodegen-backend=cranelift");
+                }
+            }
+
             // --wrap-rustc-with is not a valid rustc flag. But rustc-fake
             // recognizes it, strips it (and its argument) out, and uses it as an
             // indicator that the rustc invocation should be profiled. This works

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -367,12 +367,15 @@ impl PartialOrd for Scenario {
 pub enum CodegenBackend {
     /// The default LLVM backend
     Llvm,
+    /// Cranelift codegen backend
+    Cranelift,
 }
 
 impl CodegenBackend {
     pub fn as_str(self) -> &'static str {
         match self {
             CodegenBackend::Llvm => "llvm",
+            CodegenBackend::Cranelift => "cranelift",
         }
     }
 }
@@ -382,6 +385,7 @@ impl FromStr for CodegenBackend {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(match s.to_ascii_lowercase().as_str() {
             "llvm" => CodegenBackend::Llvm,
+            "cranelift" => CodegenBackend::Cranelift,
             _ => return Err(format!("{} is not a codegen backend", s)),
         })
     }

--- a/site/frontend/src/pages/compare/compile/common.ts
+++ b/site/frontend/src/pages/compare/compile/common.ts
@@ -51,6 +51,7 @@ export const defaultCompileFilter: CompileBenchmarkFilter = {
 };
 
 export type Profile = "check" | "debug" | "opt" | "doc";
+export type CodegenBackend = "llvm" | "cranelift";
 export type Category = "primary" | "secondary";
 
 export type CompileBenchmarkMap = Dict<CompileBenchmarkMetadata>;
@@ -74,6 +75,7 @@ export interface CompileBenchmarkComparison {
   benchmark: string;
   profile: Profile;
   scenario: string;
+  backend: CodegenBackend;
   comparison: StatComparison;
 }
 
@@ -81,6 +83,7 @@ export interface CompileTestCase {
   benchmark: string;
   profile: Profile;
   scenario: string;
+  backend: CodegenBackend;
   category: Category;
 }
 
@@ -156,6 +159,7 @@ export function computeCompileComparisonsWithNonRelevant(
           benchmark: c.benchmark,
           profile: c.profile,
           scenario: c.scenario,
+          backend: c.backend,
           category: (benchmarkMap[c.benchmark] || {}).category || "secondary",
         };
         return calculateComparison(c.comparison, testCase);

--- a/site/frontend/src/pages/compare/compile/table/comparisons-table.vue
+++ b/site/frontend/src/pages/compare/compile/table/comparisons-table.vue
@@ -56,6 +56,7 @@ const {toggleExpanded, isExpanded} = useExpandedStore();
           <th>Benchmark</th>
           <th>Profile</th>
           <th>Scenario</th>
+          <th>Backend</th>
           <th>% Change</th>
           <th class="narrow">
             Significance Threshold
@@ -99,6 +100,7 @@ const {toggleExpanded, isExpanded} = useExpandedStore();
               {{ comparison.testCase.profile }}
             </td>
             <td>{{ comparison.testCase.scenario }}</td>
+            <td>{{ comparison.testCase.backend }}</td>
             <td>
               <div class="numeric-aligned">
                 <span v-bind:class="percentClass(comparison.percent)">

--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -271,6 +271,7 @@ pub mod comparison {
         pub benchmark: String,
         pub profile: String,
         pub scenario: String,
+        pub backend: String,
         pub comparison: StatComparison,
     }
 

--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -152,6 +152,7 @@ pub async fn handle_compare(
             benchmark: comparison.benchmark.to_string(),
             profile: comparison.profile.to_string(),
             scenario: comparison.scenario.to_string(),
+            backend: comparison.backend.to_string(),
             comparison: comparison.comparison.into(),
         })
         .collect();


### PR DESCRIPTION
This PR builds on top of https://github.com/rust-lang/rustc-perf/pull/1742 and adds support for benchmarking with the Cranelift codegen backend. There is some more work needed to support it on UI (mainly filters), but I want to leave that for a future PR to keep this one smaller.

Best reviewed commit-by-commit, as usually.