### PR TITLE
Update cargo-llvm-lines on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Install profilers
-        run: cargo install --version 0.4.12 cargo-llvm-lines
+        run: cargo install --version 0.4.36 cargo-llvm-lines
 
       # Bytehound is currently broken, removing it to keep CI green.
       #- name: Install Bytehound


### PR DESCRIPTION
Old versions of `cargo-llvm-lines` didn't correctly propagate the used Cargo version. This broke CI because Cargo made a backwards incompatible change in `pkgid` output recently. However, `0.4.12` should already propagate the version, so it's weird. Lets see what CI says.