### PR TITLE
Add codegen backend filters to compare page UI

### DIFF
--- a/collector/README.md
+++ b/collector/README.md
@@ -148,6 +148,9 @@ The following options alter the behaviour of the `bench_local` subcommand.
   `IncrUnchanged`, `IncrPatched`, and `All`. The default is `All`. Note that
   `IncrFull` is always run if either of `IncrUnchanged` or `IncrPatched` are
   run (even if not requested).
+- `--backends <BACKENDS>`: the codegen backends to be benchmarked. The possible
+  choices are one or more (comma-separated) of `Llvm`, `Cranelift`. The default
+  is `Llvm`.
 - `--self-profile`: use rustc's `-Zself-profile` option to produce
   query/function tables in the output. The `measureme` tool must be installed
   for this to work.
@@ -474,6 +477,7 @@ The following options alter the behaviour of the `profile_local` subcommand.
   diff files will also be produced.
 - `--rustdoc <RUSTDOC>` as for `bench_local`.
 - `--scenarios <SCENARIOS>`: as for `bench_local`.
+- `--backends <BACKENDS>`: as for `bench_local`.
 - `--jobs <JOB-COUNT>`: execute `<JOB-COUNT>` benchmarks in parallel. This is only allowed for certain
 profilers whose results are not affected by system noise (e.g. `callgrind` or `eprintln`).
 

--- a/site/frontend/src/pages/compare/compile/common.ts
+++ b/site/frontend/src/pages/compare/compile/common.ts
@@ -14,6 +14,10 @@ export type CompileBenchmarkFilter = {
     incrUnchanged: boolean;
     incrPatched: boolean;
   };
+  backend: {
+    llvm: boolean;
+    cranelift: boolean;
+  };
   category: {
     primary: boolean;
     secondary: boolean;
@@ -39,6 +43,10 @@ export const defaultCompileFilter: CompileBenchmarkFilter = {
     incrFull: true,
     incrUnchanged: true,
     incrPatched: true,
+  },
+  backend: {
+    llvm: true,
+    cranelift: true,
   },
   category: {
     primary: true,
@@ -121,6 +129,17 @@ export function computeCompileComparisonsWithNonRelevant(
     }
   }
 
+  function backendFilter(backend: string): boolean {
+    if (backend === "llvm") {
+      return filter.backend.llvm;
+    } else if (backend === "cranelift") {
+      return filter.backend.cranelift;
+    } else {
+      // Unknown, but by default we should show things
+      return true;
+    }
+  }
+
   function artifactFilter(metadata: CompileBenchmarkMetadata | null): boolean {
     if (metadata?.binary === null) return true;
 
@@ -139,13 +158,14 @@ export function computeCompileComparisonsWithNonRelevant(
   }
 
   function shouldShowTestCase(comparison: TestCaseComparison<CompileTestCase>) {
-    const name = `${comparison.testCase.benchmark} ${comparison.testCase.profile} ${comparison.testCase.scenario}`;
+    const name = `${comparison.testCase.benchmark} ${comparison.testCase.profile} ${comparison.testCase.scenario} ${comparison.testCase.backend}`;
     const nameFilter = filter.name && filter.name.trim();
     const nameFiltered = !nameFilter || name.includes(nameFilter);
 
     return (
       profileFilter(comparison.testCase.profile) &&
       scenarioFilter(comparison.testCase.scenario) &&
+      backendFilter(comparison.testCase.backend) &&
       categoryFilter(comparison.testCase.category) &&
       artifactFilter(benchmarkMap[comparison.testCase.benchmark] ?? null) &&
       nameFiltered

--- a/site/frontend/src/pages/compare/compile/compile-page.vue
+++ b/site/frontend/src/pages/compare/compile/compile-page.vue
@@ -65,6 +65,18 @@ function loadFilterFromUrl(
         defaultFilter.scenario.incrPatched
       ),
     },
+    backend: {
+      llvm: getBoolOrDefault(
+        urlParams,
+        "backend-llvm",
+        defaultFilter.backend.llvm
+      ),
+      cranelift: getBoolOrDefault(
+        urlParams,
+        "backend-clif",
+        defaultFilter.backend.cranelift
+      ),
+    },
     category: {
       primary: getBoolOrDefault(
         urlParams,
@@ -137,6 +149,12 @@ function storeFilterToUrl(
     "incrPatched",
     filter.scenario.incrPatched,
     defaultFilter.scenario.incrPatched
+  );
+  storeOrReset("backend-llvm", filter.backend.llvm, defaultFilter.backend.llvm);
+  storeOrReset(
+    "backend-clif",
+    filter.backend.cranelift,
+    defaultFilter.backend.cranelift
   );
   storeOrReset(
     "primary",

--- a/site/frontend/src/pages/compare/compile/filters.vue
+++ b/site/frontend/src/pages/compare/compile/filters.vue
@@ -62,7 +62,7 @@ const opened = createPersistedRef(PREF_FILTERS_OPENED);
                     id="profile-check"
                     v-model="filter.profile.check"
                   />
-                  <span class="cache-label">check</span>
+                  <span class="label">check</span>
                 </label>
                 <Tooltip>Check build that does not generate any code.</Tooltip>
               </li>
@@ -73,7 +73,7 @@ const opened = createPersistedRef(PREF_FILTERS_OPENED);
                     id="profile-debug"
                     v-model="filter.profile.debug"
                   />
-                  <span class="cache-label">debug</span>
+                  <span class="label">debug</span>
                 </label>
                 <Tooltip>Debug build that produces unoptimized code.</Tooltip>
               </li>
@@ -84,7 +84,7 @@ const opened = createPersistedRef(PREF_FILTERS_OPENED);
                     id="profile-opt"
                     v-model="filter.profile.opt"
                   />
-                  <span class="cache-label">opt</span>
+                  <span class="label">opt</span>
                 </label>
                 <Tooltip
                   >Release build that produces as optimized code as possible.
@@ -97,7 +97,7 @@ const opened = createPersistedRef(PREF_FILTERS_OPENED);
                     id="profile-doc"
                     v-model="filter.profile.doc"
                   />
-                  <span class="cache-label">doc</span>
+                  <span class="label">doc</span>
                 </label>
                 <Tooltip
                   >Documentation build that produces HTML documentation site
@@ -124,7 +124,7 @@ const opened = createPersistedRef(PREF_FILTERS_OPENED);
                     id="build-full"
                     v-model="filter.scenario.full"
                   />
-                  <span class="cache-label">full</span>
+                  <span class="label">full</span>
                 </label>
                 <Tooltip
                   >A non-incremental full build starting with empty cache.
@@ -137,7 +137,7 @@ const opened = createPersistedRef(PREF_FILTERS_OPENED);
                     id="build-incremental-full"
                     v-model="filter.scenario.incrFull"
                   />
-                  <span class="cache-label">incr-full</span>
+                  <span class="label">incr-full</span>
                 </label>
                 <Tooltip
                   >An incremental build starting with empty cache.
@@ -150,7 +150,7 @@ const opened = createPersistedRef(PREF_FILTERS_OPENED);
                     id="build-incremental-unchanged"
                     v-model="filter.scenario.incrUnchanged"
                   />
-                  <span class="cache-label">incr-unchanged</span>
+                  <span class="label">incr-unchanged</span>
                 </label>
                 <Tooltip
                   >An incremental build starting with complete cache, and
@@ -165,13 +165,43 @@ const opened = createPersistedRef(PREF_FILTERS_OPENED);
                     id="build-incremental-patched"
                     v-model="filter.scenario.incrPatched"
                   />
-                  <span class="cache-label">incr-patched</span>
+                  <span class="label">incr-patched</span>
                 </label>
                 <Tooltip
                   >An incremental build starting with complete cache, and an
                   altered source directory. The typical variant of this is
                   "println" which represents the addition of a `println!` macro
                   somewhere in the source code.
+                </Tooltip>
+              </li>
+            </ul>
+          </div>
+          <div class="section section-list-wrapper">
+            <div class="section-heading">
+              <div style="width: 160px">
+                <span>Backends</span>
+                <Tooltip
+                  >The different codegen backends used to generate executable
+                  code.
+                </Tooltip>
+              </div>
+            </div>
+            <ul class="states-list">
+              <li>
+                <label>
+                  <input type="checkbox" v-model="filter.backend.llvm" />
+                  <span class="label">LLVM</span>
+                </label>
+                <Tooltip>The default LLVM backend. </Tooltip>
+              </li>
+              <li>
+                <label>
+                  <input type="checkbox" v-model="filter.backend.cranelift" />
+                  <span class="label">Cranelift</span>
+                </label>
+                <Tooltip
+                  >Alternative Cranelift backend, used primarily for faster
+                  debug builds.
                 </Tooltip>
               </li>
             </ul>
@@ -190,14 +220,14 @@ const opened = createPersistedRef(PREF_FILTERS_OPENED);
               <li>
                 <label>
                   <input type="checkbox" v-model="filter.category.primary" />
-                  <span class="cache-label">primary</span>
+                  <span class="label">primary</span>
                 </label>
                 <Tooltip>Real-world benchmarks.</Tooltip>
               </li>
               <li>
                 <label>
                   <input type="checkbox" v-model="filter.category.secondary" />
-                  <span class="cache-label">secondary</span>
+                  <span class="label">secondary</span>
                 </label>
                 <Tooltip>Artificial benchmarks and stress-tests.</Tooltip>
               </li>
@@ -217,13 +247,13 @@ const opened = createPersistedRef(PREF_FILTERS_OPENED);
               <li>
                 <label>
                   <input type="checkbox" v-model="filter.artifact.binary" />
-                  <span class="cache-label">binary</span>
+                  <span class="label">binary</span>
                 </label>
               </li>
               <li>
                 <label>
                   <input type="checkbox" v-model="filter.artifact.library" />
-                  <span class="cache-label">library</span>
+                  <span class="label">library</span>
                 </label>
               </li>
             </ul>
@@ -313,7 +343,7 @@ const opened = createPersistedRef(PREF_FILTERS_OPENED);
   margin-right: 15px;
 }
 
-.cache-label {
+.label {
   font-weight: bold;
 }
 </style>


### PR DESCRIPTION
And also adds missing documentation of the `--backends` parameter.

The UI can be tested locally by running
```bash
$ rustup component add rustc-codegen-cranelift-preview --toolchain nightly
$ cargo run --bin collector bench_local `rustup +nightly which rustc` --include serde --profiles Debug --scenarios Full --backends Llvm,Cranelift
```
and then running the website and comparing the `Id` artifact with itself.