### PR TITLE
Fix error code of benchmarks

### DIFF
--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -1231,7 +1231,7 @@ fn run_benchmarks(
     let end = start.elapsed();
     rt.block_on(connection.record_duration(collector.artifact_row_id, end));
 
-    compile_result.or(runtime_result)
+    compile_result.and(runtime_result)
 }
 
 /// Perform benchmarks on a published artifact.


### PR DESCRIPTION
This was broken when I introduced runtime benchmarks (so ~5 months ago :sweat_smile:). It meant that `bench_local` exited with error code 0 even if there were some benchmark errors, which could hide benchmark errors on CI.

`or` meant that we swallowed the error if the result was `Err`. Instead, we want to return the result if it is `Err`, and only use the second result when the first was `Ok`.