### PR TITLE
Give `bench_local` the option to run stable benchmarks

### DIFF
--- a/collector/README.md
+++ b/collector/README.md
@@ -123,7 +123,9 @@ The following options alter the behaviour of the `bench_local` subcommand.
 - `--exclude <EXCLUDE>`: this is used to run a subset of the benchmarks. The
   argument is a comma-separated list of benchmark prefixes. When this option is
   specified, a benchmark is excluded from the run if its name matches one of
-  the given prefixes.
+  the given prefixes. You can also specify `primary`, `secondary` and `stable`
+  to filter on the category of benchmarks. `rust-timer` does not run `stable`
+  benchmarks on PRs.
 - `--exclude-suffix <EXCLUDE>`: this is used to run a subset of the benchmarks. The
   argument is a comma-separated list of benchmark suffixes. When this option is
   specified, a benchmark is excluded from the run if its name matches one of
@@ -134,7 +136,9 @@ The following options alter the behaviour of the `bench_local` subcommand.
 - `--include <INCLUDE>`: the inverse of `--exclude`. The argument is a
   comma-separated list of benchmark prefixes. When this option is specified, a
   benchmark is included in the run only if its name matches one of the given
-  prefixes.
+  prefixes. You can also specify `primary`, `secondary` and `stable` to filter
+  on the category of benchmarks. `rust-timer` only runs `--include primary,secondary`
+  on PRs.
 - `--profiles <PROFILES>`: the profiles to be benchmarked. The possible choices
   are one or more (comma-separated) of `Check`, `Debug`, `Doc`, `Opt`, and
   `All`. The default is `Check,Debug,Opt`.

--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -899,13 +899,12 @@ fn main_result() -> anyhow::Result<i32> {
                 target_triple,
             )?;
 
-            let mut benchmarks = get_compile_benchmarks(
+            let benchmarks = get_compile_benchmarks(
                 &compile_benchmark_dir,
                 local.include.as_deref(),
                 local.exclude.as_deref(),
                 local.exclude_suffix.as_deref(),
             )?;
-            benchmarks.retain(|b| b.category().is_primary_or_secondary());
 
             let artifact_id = ArtifactId::Tag(toolchain.id.clone());
             let mut conn = rt.block_on(pool.connection());


### PR DESCRIPTION
In https://github.com/rust-lang/rustc-perf/issues/1777 I noticed that I couldn't run `category: stable` benchmarks locally; this PR makes this possible.

We can now specify `primary`/`secondary`/`stable` in `--include` and `--exclude`. If there's no `--include`/`--exclude` it defaults to `--exclude stable` which preserves today's behavior. This does change behavior for anyone running `bench_local --exclude ...`: they would need to add `--exclude ...,stable` to bench the same set as today.