### PR TITLE
Allow benchmarking and profiling stable benchmarks

### DIFF
--- a/collector/README.md
+++ b/collector/README.md
@@ -135,6 +135,9 @@ The following options alter the behaviour of the `bench_local` subcommand.
   comma-separated list of benchmark prefixes. When this option is specified, a
   benchmark is included in the run only if its name matches one of the given
   prefixes.
+- `--category <CATEGORIES>`: benchmark categories that should be included. The
+  possible choices are one or more (comma-separated) of `Primary`, `Secondary`,
+  `Stable`, and `All`. The default is `Primary,Secondary`.
 - `--profiles <PROFILES>`: the profiles to be benchmarked. The possible choices
   are one or more (comma-separated) of `Check`, `Debug`, `Doc`, `Opt`, and
   `All`. The default is `Check,Debug,Opt`.

--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -322,6 +322,10 @@ struct LocalOptions {
     /// Include only benchmarks matching a prefix in this comma-separated list
     #[arg(long)]
     include: Option<String>,
+
+    /// Include only benchmarks belonging to the given categories.
+    #[arg(long, value_parser = EnumArgParser::<Category>::default(), default_value = "Primary,Secondary")]
+    category: MultiEnumValue<Category>,
 }
 
 #[derive(Debug, clap::Args)]
@@ -605,7 +609,7 @@ struct DownloadCommand {
     force: bool,
 
     /// What category does the benchmark belong to
-    #[arg(long, short('c'), value_enum, global = true, default_value = "primary")]
+    #[arg(long, short('c'), value_enum, global = true, default_value = "Primary")]
     category: Category,
 
     /// What artifact type (library or binary) does the benchmark build.
@@ -909,7 +913,7 @@ fn main_result() -> anyhow::Result<i32> {
                 local.exclude.as_deref(),
                 local.exclude_suffix.as_deref(),
             )?;
-            benchmarks.retain(|b| b.category().is_primary_or_secondary());
+            benchmarks.retain(|b| local.category.0.contains(&b.category()));
 
             let artifact_id = ArtifactId::Tag(toolchain.id.clone());
             let mut conn = rt.block_on(pool.connection());
@@ -1082,7 +1086,7 @@ fn main_result() -> anyhow::Result<i32> {
                 local.exclude.as_deref(),
                 local.exclude_suffix.as_deref(),
             )?;
-            benchmarks.retain(|b| b.category().is_primary_or_secondary());
+            benchmarks.retain(|b| local.category.0.contains(&b.category()));
 
             let mut errors = BenchmarkErrors::new();
 

--- a/collector/src/compile/benchmark/category.rs
+++ b/collector/src/compile/benchmark/category.rs
@@ -3,6 +3,7 @@ use std::fmt;
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, clap::ValueEnum)]
 #[serde(rename_all = "kebab-case")]
+#[value(rename_all = "PascalCase")]
 pub enum Category {
     Primary,
     Secondary,


### PR DESCRIPTION
By adding a `--category` flag to `bench_local` and `profile_local`.

Fixes: https://github.com/rust-lang/rustc-perf/issues/1777