### PR TITLE
Simplify handling of self-profile data in `collector`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,6 +356,7 @@ dependencies = [
 name = "collector"
 version = "0.1.0"
 dependencies = [
+ "analyzeme 11.0.0",
  "anyhow",
  "benchlib",
  "cargo_metadata",

--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -41,6 +41,7 @@ object = "0.32.1"
 tabled = { version = "0.14.0" , features = ["ansi-str"]}
 humansize = "2.1.3"
 regex = "1.7.1"
+analyzeme = { git = "https://github.com/rust-lang/measureme", branch = "stable" }
 
 benchlib = { path = "benchlib" }
 

--- a/collector/README.md
+++ b/collector/README.md
@@ -155,8 +155,7 @@ The following options alter the behaviour of the `bench_local` subcommand.
   choices are one or more (comma-separated) of `Llvm`, `Cranelift`. The default
   is `Llvm`.
 - `--self-profile`: use rustc's `-Zself-profile` option to produce
-  query/function tables in the output. The `measureme` tool must be installed
-  for this to work.
+  query/function tables in the output.
 
 `RUST_LOG=debug` can be specified to enable verbose logging, which is useful
 for debugging `collector` itself.

--- a/collector/collect.sh
+++ b/collector/collect.sh
@@ -19,9 +19,6 @@ while : ; do
         rustup update
         cargo +nightly build --release -p collector
 
-        # Install measureme tooling
-        cargo install --git https://github.com/rust-lang/measureme --branch stable flamegraph crox summarize
-
         target/release/collector bench_next $SITE_URL --self-profile --bench-rustc --db $DATABASE
         STATUS=$?
         echo finished run at `date` with exit code $STATUS

--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -1593,12 +1593,6 @@ fn bench_compile(
         shared.artifact_id, shared.toolchain.triple
     );
 
-    if config.is_self_profile {
-        if let Err(e) = check_measureme_installed() {
-            panic!("{}Or omit --self-profile` to opt out\n", e);
-        }
-    }
-
     let bench_rustc = config.bench_rustc;
 
     let start = Instant::now();

--- a/collector/src/compile/execute/bencher.rs
+++ b/collector/src/compile/execute/bencher.rs
@@ -282,44 +282,6 @@ impl SelfProfileS3Upload {
             .context("create temporary file")
             .unwrap();
         let filename = match files {
-            SelfProfileFiles::Seven {
-                string_index,
-                string_data,
-                events,
-            } => {
-                let tarball = snap::write::FrameEncoder::new(Vec::new());
-                let mut builder = tar::Builder::new(tarball);
-                builder.mode(tar::HeaderMode::Deterministic);
-
-                let append_file = |builder: &mut tar::Builder<_>,
-                                   file: &Path,
-                                   name: &str|
-                 -> anyhow::Result<()> {
-                    if file.exists() {
-                        // Silently ignore missing files, the new self-profile
-                        // experiment with one file has a different structure.
-                        builder.append_path_with_name(file, name)?;
-                    }
-                    Ok(())
-                };
-
-                append_file(&mut builder, &string_index, "self-profile.string_index")
-                    .expect("append string index");
-                append_file(&mut builder, &string_data, "self-profile.string_data")
-                    .expect("append string data");
-                append_file(&mut builder, &events, "self-profile.events").expect("append events");
-                builder.finish().expect("complete tarball");
-                std::fs::write(
-                    upload.path(),
-                    builder
-                        .into_inner()
-                        .expect("get")
-                        .into_inner()
-                        .expect("snap success"),
-                )
-                .expect("wrote tarball");
-                format!("self-profile-{}.tar.sz", collection)
-            }
             SelfProfileFiles::Eight { file } => {
                 let data = std::fs::read(file).expect("read profile data");
                 let mut data = snap::read::FrameEncoder::new(&data[..]);

--- a/collector/src/compile/execute/bencher.rs
+++ b/collector/src/compile/execute/bencher.rs
@@ -16,7 +16,7 @@ use futures::{future, StreamExt};
 use std::collections::VecDeque;
 use std::future::Future;
 use std::io::Read;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::pin::Pin;
 use std::process::Command;
 use std::{env, process};
@@ -214,7 +214,8 @@ impl<'a> Processor for BenchProcessor<'a> {
                 }
                 Err(
                     e @ (DeserializeStatError::ParseError { .. }
-                    | DeserializeStatError::XperfError(..)),
+                    | DeserializeStatError::XperfError(..)
+                    | DeserializeStatError::IOError(..)),
                 ) => {
                     panic!("process_perf_stat_output failed: {:?}", e);
                 }

--- a/collector/src/compile/execute/mod.rs
+++ b/collector/src/compile/execute/mod.rs
@@ -650,7 +650,6 @@ impl Stats {
 
 #[derive(serde::Deserialize, Clone)]
 pub struct SelfProfile {
-    pub query_data: Vec<QueryData>,
     pub artifact_sizes: Vec<ArtifactSize>,
 }
 
@@ -659,14 +658,4 @@ pub struct ArtifactSize {
     pub label: QueryLabel,
     #[serde(rename = "value")]
     pub size: u64,
-}
-
-#[derive(serde::Deserialize, Clone)]
-pub struct QueryData {
-    pub label: QueryLabel,
-    pub self_time: Duration,
-    pub number_of_cache_hits: u32,
-    pub invocation_count: u32,
-    pub blocked_time: Duration,
-    pub incremental_load_time: Duration,
 }

--- a/collector/src/compile/execute/mod.rs
+++ b/collector/src/compile/execute/mod.rs
@@ -485,14 +485,7 @@ enum DeserializeStatError {
 }
 
 enum SelfProfileFiles {
-    Seven {
-        string_data: PathBuf,
-        string_index: PathBuf,
-        events: PathBuf,
-    },
-    Eight {
-        file: PathBuf,
-    },
+    Eight { file: PathBuf },
 }
 
 fn process_stat_output(


### PR DESCRIPTION
This PR performs several changes to the way we handle self-profile files in the `collector`, in order to simplify it:
- Self-profile data handling is moved from `rustc-fake` to `collector`.
- Instead of invoking the `summarize` binary, the `analyzeme` crate is used directly to parse the self-profile results.
- Handling of the old "3 file format" self-profile data was removed. This format cannot be read by `analyzeme` since 2020, so even if we were able to upload this format to S3 from the `collector` (for some veeeery old `rustc` versions), it could not be read by the site, which uses the `stable` version of `analyzeme` (currently `0.11`).
- The `measureme` binaries are no longer installed on the `collector`, since the binaries are no longer used during benchmarking.