### PR TITLE
Bump rustc-serialize version for stable benchmarks

### DIFF
--- a/collector/compile-benchmarks/html5ever/Cargo.lock
+++ b/collector/compile-benchmarks/html5ever/Cargo.lock
@@ -250,9 +250,9 @@ checksum = "8dde11f18c108289bef24469638a04dce49da56084f2d50618b226e47eb04509"
 
 [[package]]
 name = "rustc-serialize"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
+checksum = "fe834bc780604f4674073badbad26d7219cadfb4a2275802db12cbae17498401"
 
 [[package]]
 name = "rustc-test"

--- a/collector/compile-benchmarks/piston-image/Cargo.lock
+++ b/collector/compile-benchmarks/piston-image/Cargo.lock
@@ -276,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-serialize"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
+checksum = "fe834bc780604f4674073badbad26d7219cadfb4a2275802db12cbae17498401"
 
 [[package]]
 name = "scoped_threadpool"

--- a/collector/compile-benchmarks/style-servo/Cargo.lock
+++ b/collector/compile-benchmarks/style-servo/Cargo.lock
@@ -902,9 +902,9 @@ checksum = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
 
 [[package]]
 name = "rustc-serialize"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
+checksum = "fe834bc780604f4674073badbad26d7219cadfb4a2275802db12cbae17498401"
 
 [[package]]
 name = "same-file"


### PR DESCRIPTION
The 0.3.25 release fixes a type system breaking change in this benchmark, see
https://github.com/rust-lang-deprecated/rustc-serialize/pull/200 for context.