### PR TITLE
Allow creating triage report for arbitrary metric

### DIFF
--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -569,6 +569,7 @@ pub mod github {
 }
 
 pub mod triage {
+    use crate::comparison::Metric;
     use collector::Bound;
     use serde::{Deserialize, Serialize};
 
@@ -577,6 +578,8 @@ pub mod triage {
         pub start: Bound,
         #[serde(default)]
         pub end: Bound,
+        #[serde(default)]
+        pub metric: Option<Metric>,
     }
 
     #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/triage/README.md
+++ b/triage/README.md
@@ -30,6 +30,11 @@ Use the API endpoint to automate building the file:
 % curl "https://perf.rust-lang.org/perf/triage?start=$PARENT" > YYYY-MM-DD.md
 ```
 
+You can also analyze binary size regressions/improvements using the following command:
+```
+% curl "https://perf.rust-lang.org/perf/triage?start=$PARENT&metric=size:linked-artifact" > binary-size.md
+```
+
 ## Analysis
 
 The following is a list of items you should look for when interpreting performance results. 


### PR DESCRIPTION
Currently, when we perform triage, if there is a PR that had no big instruction count regressions/improvements, but only regressed/improved binary/metadata size, then it won't be included in the triage. These PRs are not that common, but it would still be nice to observe them, I think.

I'm not sure what's the best way to do that. This PR adds a rather manual approach, where you can create a triage report for binary size changes specifically, and then manually merge the (interesting) results (if any) into the "main" instruction count triage.