### PR TITLE
Eagerly load self-profile files

### DIFF
--- a/collector/src/bin/rustc-fake.rs
+++ b/collector/src/bin/rustc-fake.rs
@@ -3,7 +3,7 @@ use std::ffi::OsString;
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant};
 
 fn determinism_env(cmd: &mut Command) {
     // Since rust-lang/rust#89836, rustc stable crate IDs include a hash of the
@@ -33,20 +33,6 @@ fn run_with_determinism_env(mut cmd: Command) {
         "command did not complete successfully: {:?}",
         cmd
     );
-}
-
-// We want each rustc execution to have a separate self-profile directory,
-// to avoid overwriting the results. PID of this process and timestamp should
-// hopefully be unique enough.
-fn create_self_profile_dir() -> PathBuf {
-    let pid = std::process::id();
-    let timestamp = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_millis();
-    let name = format!("self-profile-output-{pid}-{timestamp}");
-
-    std::env::current_dir().unwrap().join(name)
 }
 
 fn main() {
@@ -116,7 +102,7 @@ fn main() {
                     .arg(&tool)
                     .args(&args);
 
-                let prof_out_dir = create_self_profile_dir();
+                let prof_out_dir = std::env::current_dir().unwrap().join("self-profile-output");
                 if wrapper == "PerfStatSelfProfile" {
                     cmd.arg(&format!(
                         "-Zself-profile={}",
@@ -187,7 +173,7 @@ fn main() {
                 let mut tool = Command::new(tool);
                 tool.args(&args);
 
-                let prof_out_dir = create_self_profile_dir();
+                let prof_out_dir = std::env::current_dir().unwrap().join("self-profile-output");
                 if wrapper == "XperfStatSelfProfile" {
                     tool.arg(&format!(
                         "-Zself-profile={}",


### PR DESCRIPTION
After the recent self-profile refactorings, I thought that we might simplify the self-profile handling even more, by eagerly loading the self-profile file into memory, which avoids the hack with generating a unique self-profile directory.

This also simplifies code.