### PR TITLE
Remove trace log that logs touching a file

### DIFF
--- a/collector/src/utils/fs.rs
+++ b/collector/src/utils/fs.rs
@@ -43,8 +43,6 @@ pub fn rename<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> anyhow::Result<
 
 /// Touch a file, resetting its modification time.
 pub fn touch(path: &Path) -> anyhow::Result<()> {
-    log::trace!("touching file {:?}", path);
-
     filetime::set_file_mtime(path, filetime::FileTime::now())
         .with_context(|| format!("touching file {:?}", path))?;
 


### PR DESCRIPTION
I don't think that it provides a lot of value, but it sure does provide a lot of garbage output - easily hundreds of thousands of lines per benchmark, which makes it harder to search through the logs.