### PR TITLE
Catch panics in `collector`

### DIFF
--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -966,19 +966,15 @@ fn main_result() -> anyhow::Result<i32> {
 
             let pool = database::Pool::open(&db.db);
 
-            match next {
+            let res = match next {
                 NextArtifact::Release(tag) => {
                     let toolchain = create_toolchain_from_published_version(&tag, &target_triple)?;
-                    let res = bench_published_artifact(
+                    bench_published_artifact(
                         rt.block_on(pool.connection()),
                         &mut rt,
                         toolchain,
                         &benchmark_dirs,
-                    );
-
-                    client.post(format!("{}/perf/onpush", site_url)).send()?;
-
-                    res?;
+                    )
                 }
                 NextArtifact::Commit {
                     commit,
@@ -1034,20 +1030,17 @@ fn main_result() -> anyhow::Result<i32> {
                         toolchain,
                     };
 
-                    let res = run_benchmarks(
+                    run_benchmarks(
                         &mut rt,
                         conn,
                         shared,
                         Some(compile_config),
                         Some(runtime_config),
-                    );
-
-                    client.post(format!("{}/perf/onpush", site_url)).send()?;
-
-                    res?;
+                    )
                 }
-            }
-
+            };
+            client.post(format!("{}/perf/onpush", site_url)).send()?;
+            res?;
             Ok(0)
         }
 


### PR DESCRIPTION
The way the site endpoint is currently set up, it expects that each collector `bench_next` invocation that starts a collection will eventually call the `/perf/onpush` endpoint. However, if the `collector` crashes (which happened today because of a DB timeout), it won't ever call the endpoint. This will cause the following successful collection to mark both collections as completed at once when it calls `/perf/onpush`, which is not intuitive and causes weird situations with GH comments (two comments being posted at once). We should rather just eagerly notify about the error.

We could perhaps somehow store a special error into the DB, letting it know that a panic has happened, but since the panic can happen because of DB not behaving reliably.. it's hard to say if it would work.