### PR TITLE
Fix artifact querying for the sections detail

### DIFF
--- a/collector/src/compile/execute/bencher.rs
+++ b/collector/src/compile/execute/bencher.rs
@@ -272,7 +272,11 @@ impl<'a> Processor for BenchProcessor<'a> {
 }
 
 /// Uploads self-profile results to S3
-struct SelfProfileS3Upload(std::process::Child, tempfile::NamedTempFile);
+struct SelfProfileS3Upload(
+    std::process::Child,
+    // This field is used only for its Drop impl
+    #[allow(unused)] tempfile::NamedTempFile,
+);
 
 impl SelfProfileS3Upload {
     fn new(


### PR DESCRIPTION
I was thinking for some time that the section chart contains weird results for some reason, but I couldn't tell why exactly. Well, now I know. It was using completely bogus data to calculate the results. Instead of using the data of the start/end bounds, it was using a range of master commits between start end, and displaying sections for the start bound and then the next master commit. This approach is ok for continous graphs (shown in the benchmark detail), but definitely not for a discrete comparison of self-profiles of two artifacts!