### PR TITLE
Fix compilation of the css runtime benchmark

### DIFF
--- a/collector/runtime-benchmarks/css/Cargo.lock
+++ b/collector/runtime-benchmarks/css/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
  "getrandom",
  "once_cell",


### PR DESCRIPTION
`ahash` has released a minor version that fixes the recent `std_simd` problem.