### PR TITLE
fix: add minimum width to graphs

### DIFF
--- a/site/frontend/src/graph/render.ts
+++ b/site/frontend/src/graph/render.ts
@@ -492,7 +492,7 @@ export function renderPlots(
         cacheStates[Object.keys(cacheStates)[0]].interpolated_indices;
 
       let plotOpts = genPlotOpts({
-        width,
+        width: 380,
         height: 300,
         yAxisLabel,
         series: seriesOpts,

--- a/site/frontend/src/graph/render.ts
+++ b/site/frontend/src/graph/render.ts
@@ -492,7 +492,7 @@ export function renderPlots(
         cacheStates[Object.keys(cacheStates)[0]].interpolated_indices;
 
       let plotOpts = genPlotOpts({
-        width: 380,
+        width,
         height: 300,
         yAxisLabel,
         series: seriesOpts,

--- a/site/frontend/src/pages/graphs/page.vue
+++ b/site/frontend/src/pages/graphs/page.vue
@@ -68,7 +68,7 @@ async function loadGraphData(selector: GraphsSelector, loading: Ref<boolean>) {
   // Then draw the plots.
   await nextTick();
 
-  const width = Math.floor(window.innerWidth / 4) - 40;
+  const width = Math.max(Math.floor(window.innerWidth / 4) - 40, 380);
   const opts = {width};
 
   // If we select a smaller subset of benchmarks, then just show them.


### PR DESCRIPTION
Added a set width and height here as the graphs dont seem to resize beyond 380px on larger screens as it is.

Fixes: https://github.com/rust-lang/rustc-perf/issues/1731

Results from my phone:
![IMG_8112](https://github.com/rust-lang/rustc-perf/assets/14011425/4585b3c9-4db7-432b-b16d-428870d0e49b)
