### PR TITLE
To allow the `/perf/status_page` to run even if the current collection is empty

### DIFF
--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -1096,7 +1096,7 @@ impl Connection for SqliteConnection {
                 "
                 select
                     step,
-                    end_time is not null,
+                    end is not null,
                     coalesce(end, strftime('%s', 'now')) - start,
                     (select end - start
                         from collector_progress as cp

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -1114,8 +1114,8 @@ impl Connection for SqliteConnection {
                 Ok(crate::Step {
                     name: row.get(0)?,
                     is_done: row.get(1)?,
-                    duration: Duration::from_secs(row.get::<_, i64>(2)? as u64),
-                    expected: Duration::from_secs(row.get::<_, i64>(3)? as u64),
+                    duration: Duration::from_secs(row.get::<_, i64>(2).unwrap_or_default() as u64),
+                    expected: Duration::from_secs(row.get::<_, i64>(3).unwrap_or_default() as u64),
                 })
             })
             .unwrap()

--- a/site/src/load.rs
+++ b/site/src/load.rs
@@ -454,12 +454,11 @@ fn sort_queue(
         let level_len = partition_in_place(unordered_queue[finished..].iter_mut(), |(_, mr)| {
             mr.parent_sha().map_or(true, |parent| done.contains(parent))
         });
-        assert!(
-            level_len != 0,
-            "at least one commit is ready done={:#?}, {:?}",
-            done,
-            &unordered_queue[finished..]
-        );
+
+        if level_len == 0 {
+            return vec![];
+        }
+
         let level = &mut unordered_queue[finished..][..level_len];
         level.sort_unstable_by_key(|(c, mr)| {
             (


### PR DESCRIPTION
For now, because of some reasons we can't see `/status.html` page locally. This PR fixes that issue.

Changes I made:
- fix collector_progress table's column name of sqlite version: `end_time` to `end`
- give a default value the same as postgres version
- returns empty vec instead of panic if there's no ready commit

Here's the successfully working screenshot of `/status.html` using the latest dump we can get from `fetch-latest` binary.
![](https://gyazo.com/6ab3951db9f3b586dff9eafcc55d514a.png)