### PR TITLE
Fix status page layout

### DIFF
--- a/site/frontend/src/pages/status/page.vue
+++ b/site/frontend/src/pages/status/page.vue
@@ -460,6 +460,11 @@ loadStatus(loading);
   display: flex;
   flex-wrap: wrap;
   column-gap: 100px;
+
+  & > * {
+    max-width: 640px;
+    width: 100%;
+  }
 }
 .current {
   .benchmark {

--- a/site/frontend/src/pages/status/page.vue
+++ b/site/frontend/src/pages/status/page.vue
@@ -428,6 +428,9 @@ loadStatus(loading);
 
 <style scoped lang="scss">
 .timeline {
+  max-width: 100%;
+  width: fit-content;
+
   table {
     border-collapse: collapse;
     font-size: 1.1em;
@@ -455,18 +458,24 @@ loadStatus(loading);
       font-weight: bold;
     }
   }
-}
-.wrapper {
-  display: flex;
-  flex-wrap: wrap;
-  column-gap: 100px;
 
-  & > * {
-    max-width: 640px;
+  @media screen and (min-width: 1440px) {
     width: 100%;
   }
 }
+.wrapper {
+  display: grid;
+  column-gap: 100px;
+  grid-template-columns: 1fr;
+
+  @media screen and (min-width: 1440px) {
+    grid-template-columns: 4fr 6fr;
+  }
+}
 .current {
+  max-width: 100%;
+  width: fit-content;
+
   .benchmark {
     margin-bottom: 10px;
     font-size: 1.2em;
@@ -500,5 +509,6 @@ loadStatus(loading);
   background-color: #f7f7f7;
   max-width: 100%;
   white-space: pre-wrap;
+  word-break: break-word;
 }
 </style>

--- a/site/frontend/src/pages/status/page.vue
+++ b/site/frontend/src/pages/status/page.vue
@@ -498,5 +498,7 @@ loadStatus(loading);
 .error {
   padding: 10px;
   background-color: #f7f7f7;
+  max-width: 100%;
+  white-space: pre-wrap;
 }
 </style>


### PR DESCRIPTION
In this PR, I added default width for every children of `.wrapper`. Also, let it wrap and keep fit within the frame not to break the layout.

Fixes: #1815