### PR TITLE
collector: reduce size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "8b79b82693f705137f8fb9b37871d99e4f9a7df12b917eed79c3d3954830a60b"
 dependencies = [
  "cfg-if",
  "getrandom",
@@ -1503,9 +1503,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "openssl"

--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -40,7 +40,7 @@ console = "0.15"
 object = "0.32.1"
 tabled = { version = "0.14.0" , features = ["ansi-str"]}
 humansize = "2.1.3"
-regex = "1.7.1"
+regex = { version = "1.7.1", default-features = false, features = ["std", "perf"] }
 analyzeme = { git = "https://github.com/rust-lang/measureme", branch = "stable" }
 
 benchlib = { path = "benchlib" }

--- a/collector/src/runtime/benchmark.rs
+++ b/collector/src/runtime/benchmark.rs
@@ -1,6 +1,3 @@
-use core::option::Option;
-use core::option::Option::Some;
-use core::result::Result::Ok;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;

--- a/database/src/bin/sqlite-to-postgres.rs
+++ b/database/src/bin/sqlite-to-postgres.rs
@@ -9,7 +9,6 @@ use database::pool::{postgres, sqlite, ConnectionManager};
 use futures_util::sink::SinkExt;
 use hashbrown::HashMap;
 use serde::{Serialize, Serializer};
-use std::convert::{TryFrom, TryInto};
 use std::io::Write;
 use std::time::Instant;
 

--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -8,7 +8,6 @@ use chrono::{DateTime, TimeZone, Utc};
 use hashbrown::HashMap;
 use native_tls::{Certificate, TlsConnector};
 use postgres_native_tls::MakeTlsConnector;
-use std::convert::TryInto;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;

--- a/site/src/self_profile/codegen_schedule.rs
+++ b/site/src/self_profile/codegen_schedule.rs
@@ -2,7 +2,6 @@ use analyzeme::ProfilingData;
 use anyhow::Context;
 use hashbrown::HashMap;
 use serde::Serializer;
-use std::convert::TryInto;
 use std::time::Duration;
 
 #[derive(serde::Deserialize, Debug)]

--- a/site/src/server.rs
+++ b/site/src/server.rs
@@ -16,7 +16,6 @@ use hyper::StatusCode;
 use log::{debug, error, info};
 use parking_lot::{Mutex, RwLock};
 use ring::hmac;
-use rmp_serde;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use uuid::Uuid;


### PR DESCRIPTION
First 2 commits fixes build with old `ahash` and new unused imports warning with fresh nightly; 3rd one disables `unicode` feature for `regex` crate as it currently unused in `collector` crate.

Size diff can be see with `cargo build -p collector`, otherwise regex's features will be merged and give no size difference.

Fixes: https://github.com/rust-lang/rustc-perf/issues/1821