### PR TITLE
Escape pipe symbol in rolled up build PR descriptions

### DIFF
--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -75,7 +75,8 @@ pub async fn unroll_rollup(
                         format!("{}…", m.split_at(59).0)
                     }
                 })
-                .unwrap_or_else(|| format!("#{}", c.original_pr_number));
+                .unwrap_or_else(|| format!("#{}", c.original_pr_number))
+                .replace('|', "\\|");
             writeln!(
                 &mut string,
                 "|#{pr}|{message}|{commit}|",


### PR DESCRIPTION
I haven't found any crate for Markdown escaping, so I just escaped the pipe manually.

Fixes: https://github.com/rust-lang/rustc-perf/issues/1837