### PR TITLE
Improve symbol name normalization

### DIFF
--- a/collector/src/artifact_stats.rs
+++ b/collector/src/artifact_stats.rs
@@ -95,7 +95,7 @@ static RUSTC_HASH_REGEX: OnceLock<Regex> = OnceLock::new();
 
 /// Demangle the symbol and remove rustc mangling hashes.
 fn normalize_symbol_name(symbol: &str) -> String {
-    let regex = RUSTC_HASH_REGEX.get_or_init(|| Regex::new(r#"[a-z0-9]{15,16}"#).unwrap());
+    let regex = RUSTC_HASH_REGEX.get_or_init(|| Regex::new(r#"(::)?\b[a-z0-9]{15,17}\b"#).unwrap());
 
     let symbol = rustc_demangle::demangle(symbol).to_string();
     regex.replace_all(&symbol, "").to_string()


### PR DESCRIPTION
It seems that hashes can be 17 characters, so with the old code you can end up with a diff for every symbol:

```
│ gimli::read::unit::AttributeValue<R,Offset>::udata_value::4 │ 86 B │  0 B │ -86 │ -100.0% │
│ gimli::read::unit::AttributeValue<R,Offset>::udata_value::3 │  0 B │ 86 B │ +86 │ +100.0% │
```

Also, remove the preceding `::` if it exists, and add word boundaries to make it slightly more precise.

This makes the diff usable for the changes in https://github.com/rust-lang/rust/pull/121665#issuecomment-1987102294, e.g. when running `cargo run --bin collector --release binary_stats --symbols +516b6162a2ea8e66678c09e8243ebd83e4b8eeea --rustc2 +70aa0b86c066e721012852a9851fdf8586117823 --include helloworld`.

For the symbols above, I now get
```
gimli::read::unit::AttributeValue<R,Offset>::udata_value
```
with zero size diff, as expected.