### PR TITLE
When printing binary stats diff, combine all unchanged rows into one

### DIFF
--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -1300,6 +1300,30 @@ fn print_binary_stats(
         }
     }
     rows.sort_by_cached_key(|row| Reverse((row.diff.abs(), row.before, row.name.clone())));
+
+    // Combine all unchanged rows into one.
+    if use_diff {
+        let mut unchanged_count = 0;
+        let mut total_unchanged = 0;
+        rows.retain(|row| {
+            if row.diff == 0 {
+                unchanged_count += 1;
+                total_unchanged += row.before;
+                false
+            } else {
+                true
+            }
+        });
+        if total_unchanged > 0 {
+            rows.push(Row {
+                name: format!("<{unchanged_count} unchanged rows>"),
+                before: total_unchanged,
+                after: total_unchanged,
+                diff: 0,
+            });
+        }
+    }
+
     rows.push(Row {
         name: "Total".to_string(),
         before: total_before,


### PR DESCRIPTION
With this change and #1843, the diff from https://github.com/rust-lang/rust/pull/121665#issuecomment-1987102294 (`cargo run --bin collector --release binary_stats --symbols +516b6162a2ea8e66678c09e8243ebd83e4b8eeea --rustc2 +70aa0b86c066e721012852a9851fdf8586117823 --include helloworld`) becomes nice and readable. Without this change, there are hundreds of unchanged symbols, and many of them have very long names which completely breaks the table layout.

```
┌────────────────────────────────────────────────────────────────────────────────────┬───────────────┬──────────────┬───────┬──────────┐
│ Symbol                                                                             │ Size (before) │ Size (after) │  Diff │ Diff (%) │
├────────────────────────────────────────────────────────────────────────────────────┼───────────────┼──────────────┼───────┼──────────┤
│ std::backtrace_rs::symbolize::gimli::Context::new                                  │     17.34 KiB │    17.61 KiB │  +276 │    +1.6% │
│ addr2line::ResUnit<R>::find_function_or_location::{{closure}}                      │     11.51 KiB │    11.76 KiB │  +252 │    +2.1% │
│ std::backtrace_rs::symbolize::gimli::resolve                                       │     14.44 KiB │    14.68 KiB │  +243 │    +1.6% │
│ core::option::Option<&T>::cloned                                                   │           0 B │        174 B │  +174 │  +100.0% │
│ gimli::read::rnglists::RngListIter<R>::next                                        │      3.16 KiB │     3.32 KiB │  +171 │    +5.3% │
│ addr2line::render_file                                                             │         838 B │        950 B │  +112 │   +13.4% │
│ <gimli::read::line::LineProgramHeader<R,Offset> as core::clone::Clone>::clone      │      1.08 KiB │     1.19 KiB │  +109 │    +9.9% │
│ alloc::raw_vec::RawVec<T,A>::reserve_for_push                                      │      3.11 KiB │     3.01 KiB │  -102 │    -3.2% │
│ gimli::read::dwarf::Unit<R>::new                                                   │      9.98 KiB │    10.04 KiB │   +63 │    +0.6% │
│ gimli::read::unit::Attribute<R>::value                                             │      1.29 KiB │     1.33 KiB │   +39 │    +3.0% │
│ addr2line::LoopingLookup<T,L,F>::new_lookup                                        │      1.49 KiB │     1.52 KiB │   +30 │    +2.0% │
│ alloc::raw_vec::RawVec<T,A>::reserve::do_reserve_and_handle                        │         903 B │        873 B │   -30 │    -3.3% │
│ gimli::read::abbrev::Abbreviations::insert                                         │      4.75 KiB │     4.72 KiB │   -26 │    -0.5% │
│ addr2line::Lines::parse                                                            │      9.68 KiB │     9.69 KiB │   +17 │    +0.2% │
│ miniz_oxide::inflate::core::decompress                                             │      7.69 KiB │     7.71 KiB │   +16 │    +0.2% │
│ addr2line::function::Function<R>::parse_children                                   │      5.25 KiB │     5.23 KiB │   -16 │    -0.3% │
│ addr2line::ResUnit<R>::dwarf_and_unit_dwo                                          │      1.34 KiB │     1.35 KiB │   +16 │    +1.2% │
│ gimli::read::dwarf::Dwarf<R>::attr_string                                          │         586 B │        602 B │   +16 │    +2.7% │
│ gimli::read::unit::DebugInfoUnitHeadersIter<R>::next                               │      2.13 KiB │     2.14 KiB │   +12 │    +0.6% │
│ std::panic::get_backtrace_style                                                    │         340 B │        352 B │   +12 │    +3.5% │
│ <std::sys::pal::unix::stdio::Stderr as std::io::Write>::write                      │          91 B │         81 B │   -10 │   -11.0% │
│ <std::sys::pal::unix::stdio::Stderr as std::io::Write>::write_vectored             │          89 B │         79 B │   -10 │   -11.2% │
│ alloc::raw_vec::finish_grow                                                        │         567 B │        574 B │    +7 │    +1.2% │
│ std::path::PathBuf::_set_extension                                                 │         611 B │        605 B │    -6 │    -1.0% │
│ alloc::ffi::c_str::CString::_from_vec_unchecked                                    │         337 B │        331 B │    -6 │    -1.8% │
│ alloc::string::String::try_reserve                                                 │         190 B │        184 B │    -6 │    -3.2% │
│ <addr2line::LocationRangeUnitIter as core::iter::traits::iterator::Iterator>::next │         355 B │        360 B │    +5 │    +1.4% │
│ std::io::Write::write_all_vectored                                                 │      1.29 KiB │     1.29 KiB │    +4 │    +0.3% │
│ <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt  │         578 B │        576 B │    -2 │    -0.3% │
│ addr2line::function::name_attr                                                     │         419 B │        417 B │    -2 │    -0.5% │
│ gimli::read::abbrev::Attributes::push                                              │         368 B │        367 B │    -1 │    -0.3% │
│ <std::io::stdio::StdoutRaw as std::io::Write>::write_all                           │         262 B │        261 B │    -1 │    -0.4% │
│ std::io::Write::write_all                                                          │         221 B │        220 B │    -1 │    -0.5% │
│ <675 unchanged rows>                                                               │    149.25 KiB │   149.25 KiB │     0 │     0.0% │
│────────────────────────────────────────────────────────────────────────────────────│───────────────│──────────────│───────│──────────│
│ Total                                                                              │    251.36 KiB │   252.68 KiB │ +1355 │    +0.5% │
└────────────────────────────────────────────────────────────────────────────────────┴───────────────┴──────────────┴───────┴──────────┘
```