### PR TITLE
Print correct port in startup message

### DIFF
--- a/site/src/main.rs
+++ b/site/src/main.rs
@@ -42,7 +42,9 @@ async fn main() {
                 "Loading complete; {} commits and {} artifacts",
                 commits, artifacts,
             );
-            eprintln!("View the results in a web browser at 'http://localhost:{}/compare.html'", port);
+            eprintln!(
+                "View the results in a web browser at 'http://localhost:{port}/compare.html'"
+            );
             // Spawn off a task to post the results of any commit results that we
             // are now aware of.
             site::github::post_finished(&res).await;


### PR DESCRIPTION
I'm fairly new to rust, so I'm not sure if there is a difference between `{}` and `{:?}` for `u16`s but this seems to work.
Fixes #1853 