### PR TITLE
Update `fetch-latest` to use ZSTD instead of Snappy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1498,7 +1498,7 @@ checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "flate2",
  "memchr",
- "ruzstd",
+ "ruzstd 0.5.0",
 ]
 
 [[package]]
@@ -2134,6 +2134,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruzstd"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5174a470eeb535a721ae9fdd6e291c2411a906b96592182d05217591d5c5cf7b"
+dependencies = [
+ "byteorder",
+ "derive_more",
+ "twox-hash",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2336,6 +2347,7 @@ dependencies = [
  "rmp-serde",
  "rust-embed",
  "rust_team_data",
+ "ruzstd 0.6.0",
  "semver",
  "serde",
  "serde_derive",

--- a/site/Cargo.toml
+++ b/site/Cargo.toml
@@ -38,7 +38,7 @@ database = { path = "../database" }
 bytes = "1.0"
 url = "2"
 analyzeme = { git = "https://github.com/rust-lang/measureme", branch = "stable" }
-inferno = { version="0.11", default-features = false }
+inferno = { version = "0.11", default-features = false }
 mime = "0.3"
 prometheus = "0.13"
 uuid = { version = "1.3.0", features = ["v4"] }
@@ -46,6 +46,7 @@ tera = { version = "1.19", default-features = false }
 rust-embed = { version = "6.6.0", features = ["include-exclude", "interpolate-folder-path"] }
 humansize = "2"
 lru = "0.12.0"
+ruzstd = "0.6.0"
 
 [target.'cfg(unix)'.dependencies]
 jemallocator = "0.5"

--- a/site/src/bin/fetch-latest.rs
+++ b/site/src/bin/fetch-latest.rs
@@ -1,15 +1,17 @@
 use anyhow::Context as _;
-use snap::read::FrameDecoder;
+use ruzstd::StreamingDecoder;
 use std::io::Write;
 
 fn main() -> anyhow::Result<()> {
     let destination = std::env::args()
         .nth(1)
         .ok_or(anyhow::anyhow!("destination file should be first argument"))?;
-    let resp = reqwest::blocking::get("https://perf-data.rust-lang.org/export.db.sz")
+    let resp = reqwest::blocking::get("https://perf-data.rust-lang.org/export.db.zst")
         .context("fetching database")?;
     let resp = resp.error_for_status().context("fetching database")?;
-    let mut decoder = FrameDecoder::new(std::io::BufReader::new(resp));
+
+    let mut reader = std::io::BufReader::new(resp);
+    let mut decoder = StreamingDecoder::new(&mut reader).context("cannot decode")?;
     let mut file = std::io::BufWriter::new(
         std::fs::File::create(destination).context("creating destination file")?,
     );


### PR DESCRIPTION
I decided to use `ruzstd` instead of `zstd-rs`, to avoid a dependency on a C library (`zstd`).