### PR TITLE
normalize_symbol_name: also strip numeric suffix

### DIFF
--- a/collector/src/artifact_stats.rs
+++ b/collector/src/artifact_stats.rs
@@ -95,7 +95,8 @@ static RUSTC_HASH_REGEX: OnceLock<Regex> = OnceLock::new();
 
 /// Demangle the symbol and remove rustc mangling hashes.
 fn normalize_symbol_name(symbol: &str) -> String {
-    let regex = RUSTC_HASH_REGEX.get_or_init(|| Regex::new(r#"(::)?\b[a-z0-9]{15,17}\b"#).unwrap());
+    let regex =
+        RUSTC_HASH_REGEX.get_or_init(|| Regex::new(r#"(::)?\b[a-z0-9]{15,17}\b(\.\d+)?"#).unwrap());
 
     let symbol = rustc_demangle::demangle(symbol).to_string();
     regex.replace_all(&symbol, "").to_string()


### PR DESCRIPTION
Some symbols also have a numeric suffix, e.g. in `<core::fmt::Error as core::fmt::Debug>::fmt::h863044c0549d7049.60`.

This results in spurious diffs, e.g. when running `./target/release/collector binary_stats +6f3eb1ce3d50246b2cbc5de3107c0f34889f5cc6 --rustc2 +2105ceeb0f23267f160392bd0e43b1c647590aac --include helloworld-tiny --profile Opt --backend Llvm --symbols`, I see:

```
│ <core::fmt::Error as core::fmt::Debug>::fmt.60 │ 26 B │  0 B │ -26 │ -100.0% │
│ <core::fmt::Error as core::fmt::Debug>::fmt.72 │  0 B │ 26 B │ +26 │ +100.0% │
```

Similar to #1843