### PR TITLE
Load 'perf/info' and 'perf/get' in Comparison page asynchronously

### DIFF
--- a/site/frontend/src/pages/compare/page.vue
+++ b/site/frontend/src/pages/compare/page.vue
@@ -112,7 +112,6 @@ const runtimeSummary: Ref<SummaryGroup | null> = ref(null);
 
 const loading = ref(false);
 
-const info = await loadBenchmarkInfo();
 const selector = loadSelectorFromUrl(urlParams);
 
 const initialTab: Tab = loadTabFromUrl(urlParams) ?? Tab.CompileTime;
@@ -138,6 +137,7 @@ function changeTab(newTab: Tab) {
 
 const data: Ref<CompareResponse | null> = ref(null);
 loadCompareData(selector, loading);
+let info = await loadBenchmarkInfo();
 </script>
 
 <template>


### PR DESCRIPTION
Previously, 'perf/info' would load then a request would be made to 'perf/get' in `loadCompareData`. By moving `await` after `loadCompareData`, `perf/get` is requested then `perf/info` without a wait in between. I don't know if `await` is necessary but doesn't seem to hurt.

I don't know much js, but hopefully this is fine as it seems to work locally. It saves about 50-100ms for me.