### PR TITLE
Add brotli compression of static assets

### DIFF
--- a/site/frontend/.parcelrc
+++ b/site/frontend/.parcelrc
@@ -1,0 +1,9 @@
+{
+    "extends": "@parcel/config-default",
+    "compressors": {
+        "*.{css,js}": [
+          "...",
+          "@parcel/compressor-brotli"
+        ]
+      }
+}

--- a/site/frontend/package-lock.json
+++ b/site/frontend/package-lock.json
@@ -20,6 +20,7 @@
       },
       "devDependencies": {
         "@babel/types": "^7.21.4",
+        "@parcel/compressor-brotli": "^2.8.3",
         "@parcel/transformer-vue": "^2.8.3",
         "@types/highcharts": "^7.0.0",
         "@types/msgpack-lite": "^0.1.8",
@@ -769,6 +770,23 @@
       },
       "engines": {
         "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/compressor-brotli": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/compressor-brotli/-/compressor-brotli-2.8.3.tgz",
+      "integrity": "sha512-RavknrtGFagtlTdD5Km94bot6MViFRW/IUFH/bUHCTgl5WB1hD5qJaS8xbO0HJt1/jvuWzrGu5lqfo3MR+QFKQ==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/plugin": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0",
+        "parcel": "^2.8.3"
       },
       "funding": {
         "type": "opencollective",

--- a/site/frontend/package.json
+++ b/site/frontend/package.json
@@ -12,6 +12,7 @@
   "license": "MIT",
   "devDependencies": {
     "@babel/types": "^7.21.4",
+    "@parcel/compressor-brotli": "^2.8.3",
     "@parcel/transformer-vue": "^2.8.3",
     "@types/highcharts": "^7.0.0",
     "@types/msgpack-lite": "^0.1.8",


### PR DESCRIPTION
Let me know if the rust code isn't idiomatic. This achieves a 200kb reduction in compare.js size from ~292kb to ~77kb.