### PR TITLE
Add "Rust codegen" as a new compilation section

### DIFF
--- a/site/frontend/src/pages/compare/compile/table/sections-chart.vue
+++ b/site/frontend/src/pages/compare/compile/table/sections-chart.vue
@@ -66,6 +66,20 @@ function getRowWidth(): number {
   return maxTotalWidth.value;
 }
 
+function getTitle(section_name: string): string {
+  if (section_name === "Frontend") {
+    return "Lexing, parsing, macro expansion, borrow checking, type checking, trait solving, ...";
+  } else if (section_name === "Rust codegen") {
+    return "Monomorphization, conversion from MIR to backend IR, ...";
+  } else if (section_name === "Backend") {
+    return "Code generation (with LLVM, Cranelift, ...)";
+  } else if (section_name === "Linker") {
+    return "Linking of the final artifact (with bfd, lld, ...)";
+  } else {
+    return "";
+  }
+}
+
 const chartRows: ComputedRef<Array<[string, CompilationSections]>> = computed(
   () => [
     ["Before", props.before],
@@ -105,6 +119,7 @@ const activeSection: Ref<string | null> = ref(null);
 function activate(section: string) {
   activeSection.value = section;
 }
+
 function deactivate() {
   activeSection.value = null;
 }
@@ -176,6 +191,7 @@ function deactivate() {
               @mouseenter="activate(item.section.name)"
               @mouseleave="deactivate"
               :class="{active: activeSection === item.section.name}"
+              :title="getTitle(item.section.name)"
             >
               <td>
                 <div class="color" :style="{backgroundColor: item.color}"></div>
@@ -196,6 +212,7 @@ function deactivate() {
   display: flex;
   align-items: center;
 }
+
 .chart {
   display: flex;
   justify-content: flex-end;
@@ -240,6 +257,7 @@ function deactivate() {
 .section:last-child {
   border-radius: 0 5px 5px 0;
 }
+
 .legend {
   margin-left: 40px;
 
@@ -249,13 +267,16 @@ function deactivate() {
       padding: 5px;
     }
   }
+
   .color {
     width: 15px;
     height: 15px;
   }
+
   .active {
     font-weight: bold;
   }
+
   .name {
     margin-left: 5px;
   }


### PR DESCRIPTION
Inspired by discussions about my [recent blog post](https://kobzol.github.io/rust/rustc/2024/03/15/rustc-what-takes-so-long.html), I thought that it would be nice if we split the "Backend" section into the actual backend (e.g. LLVM) and the Rust part that monomorphizes stuff and generates LLVM IR from MIR. This PR does that:

![image](https://github.com/rust-lang/rustc-perf/assets/4539057/8fbb6d7f-6dd4-4304-bf9c-531e091e46b4)