### PR TITLE
Improve message printed when the site starts

### DIFF
--- a/site/src/main.rs
+++ b/site/src/main.rs
@@ -38,10 +38,7 @@ async fn main() {
                 eprintln!("Loading complete but no data identified; exiting.");
                 std::process::exit(1);
             }
-            eprintln!(
-                "Loading complete; {} commits and {} artifacts",
-                commits, artifacts,
-            );
+            eprintln!("Loading complete; found {} artifacts", commits + artifacts);
             eprintln!(
                 "View the results in a web browser at 'http://localhost:{port}/compare.html'"
             );


### PR DESCRIPTION
The distinction between commits and artifacts is confusing (local compiler versions were actually under artifacts).