### PR TITLE
fix typo

### DIFF
--- a/collector/compile-benchmarks/image-0.24.1/src/image.rs
+++ b/collector/compile-benchmarks/image-0.24.1/src/image.rs
@@ -791,7 +791,7 @@ pub trait ImageEncoder {
     /// This function takes a slice of bytes of the pixel data of the image
     /// and encodes them. Unlike particular format encoders inherent impl encode
     /// methods where endianness is not specified, here image data bytes should
-    /// always be in native endian. The implementor will reorder the endianess
+    /// always be in native endian. The implementor will reorder the endianness
     /// as necessary for the target encoding format.
     ///
     /// See also `ImageDecoder::read_image` which reads byte buffers into

--- a/collector/compile-benchmarks/piston-image/src/tiff/decoder/ifd.rs
+++ b/collector/compile-benchmarks/piston-image/src/tiff/decoder/ifd.rs
@@ -156,7 +156,7 @@ impl Entry {
         let bo = decoder.byte_order();
         match (self.type_, self.count) {
             // TODO check if this could give wrong results
-            // at a different endianess of file/computer.
+            // at a different endianness of file/computer.
             (Type::BYTE, 1) => Ok(Unsigned(self.offset[0] as u32)),
             (Type::SHORT, 1) => Ok(Unsigned(try!(self.r(bo).read_u16()) as u32)),
             (Type::SHORT, 2) => {

--- a/collector/compile-benchmarks/piston-image/src/tiff/decoder/mod.rs
+++ b/collector/compile-benchmarks/piston-image/src/tiff/decoder/mod.rs
@@ -156,9 +156,9 @@ impl<R: Read + Seek> TIFFDecoder<R> {
     }
 
     fn read_header(&mut self) -> ImageResult<()> {
-        let mut endianess = Vec::with_capacity(2);
-        try!(self.reader.by_ref().take(2).read_to_end(&mut endianess));
-        match &*endianess {
+        let mut endianness = Vec::with_capacity(2);
+        try!(self.reader.by_ref().take(2).read_to_end(&mut endianness));
+        match &*endianness {
             b"II" => {
                 self.byte_order = ByteOrder::LittleEndian;
                 self.reader.byte_order = ByteOrder::LittleEndian; },


### PR DESCRIPTION
fix typo: `endianess` -> `endianness`