### PR TITLE
Make the title clear

### DIFF
--- a/site/frontend/src/pages/graphs/page.vue
+++ b/site/frontend/src/pages/graphs/page.vue
@@ -149,7 +149,7 @@ loadGraphData(selector, loading);
       style="margin-top: 50px; border-top: 1px solid #ccc"
     >
       <div style="padding: 20px 0">
-        <strong>Benchmarks for artifact sizes</strong>
+        <strong>Benchmarks optimized for small binary size</strong>
       </div>
       <div id="size-charts"></div>
     </div>


### PR DESCRIPTION
Hi @Kobzol,

I asked ChatGTP by 

```
"benchmarks that is compiled with compiler flags that should favor small executable size" make a title for this.
```

It gave me `Compiler-Optimized Benchmarks for Small Executable Sizes`

So I decided to combine yours and his 😀.

What do you think? you are boss you call 😎

BTW, I also asked why using plural for "Sizes" here is its answer:

```
"Small Executable Sizes" to indicate that there are multiple sizes being referred to. 
Even though "Executable" is singular, 
"Sizes" is used to denote that there are various sizes or a range of sizes under consideration.

It's a bit idiomatic in English to use the plural form in such cases, 
even if technically referring to a singular concept, 
to encompass the diversity or range implied by the context.
```

---

Fixes: #1869 