### PR TITLE
Fix regex for the `binary_stats` command

### DIFF
--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -38,9 +38,9 @@ rustc-demangle = { version = "0.1", features = ["std"] }
 similar = "2.2"
 console = "0.15"
 object = "0.32.1"
-tabled = { version = "0.14.0" , features = ["ansi-str"]}
+tabled = { version = "0.14.0", features = ["ansi-str"] }
 humansize = "2.1.3"
-regex = { version = "1.7.1", default-features = false, features = ["std", "perf"] }
+regex = "1.7.1"
 analyzeme = { git = "https://github.com/rust-lang/measureme", branch = "stable" }
 
 benchlib = { path = "benchlib" }


### PR DESCRIPTION
Regressed in https://github.com/rust-lang/rustc-perf/pull/1833.