### PR TITLE
collector: beautify warning when include\exclude filters wrong

### DIFF
--- a/collector/benchlib/src/cli.rs
+++ b/collector/benchlib/src/cli.rs
@@ -17,12 +17,12 @@ pub struct BenchmarkArgs {
     pub iterations: u32,
 
     /// Exclude all benchmarks matching a prefix in this comma-separated list
-    #[arg(long)]
-    pub exclude: Option<String>,
+    #[arg(long, value_delimiter = ',')]
+    pub exclude: Vec<String>,
 
     /// Include only benchmarks matching a prefix in this comma-separated list
-    #[arg(long)]
-    pub include: Option<String>,
+    #[arg(long, value_delimiter = ',')]
+    pub include: Vec<String>,
 }
 
 #[derive(clap::Parser, Debug)]

--- a/collector/src/compile/benchmark/mod.rs
+++ b/collector/src/compile/benchmark/mod.rs
@@ -475,7 +475,7 @@ pub fn get_compile_benchmarks(
     let mut excludes = to_hashmap(exclude);
     let mut exclude_suffixes = to_hashmap(exclude_suffix);
 
-    for (path, name) in paths {
+    for (path, name) in paths.clone() {
         let mut skip = false;
 
         let name_matches_prefix = |prefixes: &mut HashMap<&str, usize>| {
@@ -508,9 +508,11 @@ pub fn get_compile_benchmarks(
                 .collect();
             if !unused.is_empty() {
                 bail!(
-                    "Warning: one or more unused --{} entries: {:?}",
+                    r#"Warning: one or more unused --{} entries: {:?} found.
+Expected zero or more entries or substrings from list: {:?}."#,
                     option,
-                    unused
+                    unused,
+                    &paths.iter().map(|(_, name)| name).collect::<Vec<_>>(),
                 );
             }
         }

--- a/collector/src/runtime/benchmark.rs
+++ b/collector/src/runtime/benchmark.rs
@@ -54,13 +54,10 @@ impl BenchmarkSuite {
             groups: groups
                 .into_iter()
                 .filter(|group| {
-                    group.benchmark_names.iter().any(|benchmark| {
-                        passes_filter(
-                            benchmark,
-                            filter.exclude.as_deref(),
-                            filter.include.as_deref(),
-                        )
-                    })
+                    group
+                        .benchmark_names
+                        .iter()
+                        .any(|benchmark| passes_filter(benchmark, &filter.exclude, &filter.include))
                 })
                 .collect(),
             _tmp_artifacts_dir,
@@ -69,13 +66,7 @@ impl BenchmarkSuite {
 
     pub fn filtered_benchmark_count(&self, filter: &BenchmarkFilter) -> u64 {
         self.benchmark_names()
-            .filter(|benchmark| {
-                passes_filter(
-                    benchmark,
-                    filter.exclude.as_deref(),
-                    filter.include.as_deref(),
-                )
-            })
+            .filter(|benchmark| passes_filter(benchmark, &filter.exclude, &filter.include))
             .count() as u64
     }
 
@@ -96,19 +87,19 @@ impl BenchmarkSuite {
 }
 
 pub struct BenchmarkFilter {
-    pub exclude: Option<String>,
-    pub include: Option<String>,
+    pub exclude: Vec<String>,
+    pub include: Vec<String>,
 }
 
 impl BenchmarkFilter {
     pub fn keep_all() -> Self {
         Self {
-            exclude: None,
-            include: None,
+            exclude: vec![],
+            include: vec![],
         }
     }
 
-    pub fn new(exclude: Option<String>, include: Option<String>) -> Self {
+    pub fn new(exclude: Vec<String>, include: Vec<String>) -> Self {
         Self { exclude, include }
     }
 }

--- a/collector/src/runtime/mod.rs
+++ b/collector/src/runtime/mod.rs
@@ -211,11 +211,11 @@ fn execute_runtime_benchmark_binary(
     command.arg("--iterations");
     command.arg(&iterations.to_string());
 
-    if let Some(ref exclude) = filter.exclude {
-        command.args(["--exclude", exclude]);
+    if !filter.exclude.is_empty() {
+        command.args(["--exclude", &filter.exclude.join(",")]);
     }
-    if let Some(ref include) = filter.include {
-        command.args(["--include", include]);
+    if !filter.include.is_empty() {
+        command.args(["--include", &filter.include.join(",")]);
     }
 
     let output = run_command_with_output(&mut command)?;


### PR DESCRIPTION
Fixes #1886

Instead of:
```
$ ./target/debug/collector.exe binary_stats +nightly-x86_64-pc-windows-msvc \
    --rustc2 +nightly-x86_64-pc-windows-msvc --include "helloworldasd" --profile Debug --backend Llvm
collector error: Warning: one or more unused --include entries: ["helloworldasd"]
```
will print:
```
$ ./target/debug/collector.exe binary_stats +nightly-x86_64-pc-windows-msvc \
    --rustc2 +nightly-x86_64-pc-windows-msvc --include "helloworldasd" --profile Debug --backend Llvm
collector error: Warning: one or more unused --include entries: ["helloworldasd"] found.
Expected zero or more entries or substrings from list: ["await-call-tree", "bitmaps-3.1.0", "cargo-0.60.0", "clap-3.1.6", "coercions", "cranelift-codegen-0.82.1", "ctfe-stress-5", "deep-vector", "deeply-nested-multi", "derive", "diesel-1.4.8", "encoding", "exa-0.10.1", "externs", "futures", "helloworld", "helloworld-tiny", "html5ever", "html5ever-0.26.0", "hyper-0.14.18", "image-0.24.1", "inflate", "issue-46449", "issue-58319", "issue-88862", "libc-0.2.124", "many-assoc-items", "match-stress", "piston-image", "projection-caching", "regex", "regex-1.5.5", "regression-31157", "ripgrep-13.0.0", "ripgrep-13.0.0-tiny", "serde-1.0.136", "serde_derive-1.0.136", "stm32f4-0.14.0", "style-servo", "syn", "syn-1.0.89", "token-stream-stress", "tokio-webpush-simple", "tt-muncher", "tuple-stress", "typenum-1.17.0", "ucd", "unicode-normalization-0.1.19", "unify-linearly", "unused-warnings", "webrender-2022", "wf-projection-stress-65510", "wg-grammar"].
```

First commit reworks include\exclude\exclude_suffix args to be parsed by clap as Vec<String> instead of Option<String> and later manually parsed, second one adds existing bench list to error output.