### PR TITLE
allow soft-unstable on stable `html5ever` benchmark

### DIFF
--- a/collector/compile-benchmarks/html5ever/build.rs
+++ b/collector/compile-benchmarks/html5ever/build.rs
@@ -7,6 +7,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(soft_unstable)]
+
 extern crate phf_codegen;
 extern crate rustc_serialize;
 


### PR DESCRIPTION
The `RustcEncodable` and  `RustcDecodable` derives are being de-stabilized and removed from the future prelude by https://github.com/rust-lang/rust/pull/116016 but for the time being (and via https://github.com/rust-lang/rust/pull/123182) we can still build them by ignoring the lint.

This should unbreak the `html5ever` benchmark that is in the stable set of benchmarks.