### PR TITLE
Show mean of primary/secondary results in GitHub summary comment tooltip

### DIFF
--- a/site/src/github/comparison_summary.rs
+++ b/site/src/github/comparison_summary.rs
@@ -324,8 +324,25 @@ fn write_metric_summary(
                 write_summary_table(&primary, &secondary, false, message);
             }
             DefaultMetricVisibility::Hidden => {
+                let format_summary =
+                    |buffer: &mut Vec<String>, label: &str, summary: &ArtifactComparisonSummary| {
+                        if summary.is_relevant() {
+                            buffer.push(format!(
+                                "{label} {:.1}%",
+                                summary.arithmetic_mean_of_changes()
+                            ));
+                        }
+                    };
+
+                // At this point, we know that at least one of primary or secondary are relevant
+                let mut results = vec![];
+                format_summary(&mut results, "primary", &primary);
+                format_summary(&mut results, "secondary", &secondary);
+
+                let summary = format!("Results ({})", results.join(", "));
+
                 // `<details>` means it is hidden, requiring a click to reveal.
-                message.push_str("<details>\n<summary>Results</summary>\n\n");
+                message.push_str(&format!("<details>\n<summary>{summary}</summary>\n\n"));
                 message.push_str(
                     "This is a less reliable metric that may be of interest but was not \
                 used to determine the overall result at the top of this comment.\n\n",


### PR DESCRIPTION
The performance summary tables in GH comments (e.g. [this one](https://github.com/rust-lang/rust/pull/124256#issuecomment-2109264134)) show all metrics other than instruction count in a collapsed manner. I think that this sometimes leads to missing interesting information in these tables, if no one clicks on them.

This PR adds a short summary of the performance result to the `Results` reveal button, so that it is clear how large is the effect even without clicking on the button. It should look like this:

![image](https://github.com/rust-lang/rustc-perf/assets/4539057/c1dea95e-1eaa-4a3a-b001-b42f8086c4b2)
