### PR TITLE
Add Catapult as an alternative embedded query trace visualizer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "site/catapult"]
+	path = site/catapult
+	url = https://chromium.googlesource.com/catapult

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2385,6 +2385,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "snap",
+ "tempfile",
  "tera",
  "thiserror",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,7 +327,7 @@ version = "4.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce38afc168d8665cfc75c7b1dd9672e50716a137f433f070991619744a67342a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "clap_derive",
  "clap_lex",
  "is-terminal",
@@ -658,6 +664,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "errno-dragonfly"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,12 +697,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "1.9.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "filetime"
@@ -869,7 +882,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "ignore",
  "walkdir",
 ]
@@ -920,7 +933,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
  "base64 0.13.1",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "headers-core",
  "http",
@@ -1176,7 +1189,7 @@ checksum = "8687c819457e979cc940d09cb16e42a1bf70aa6b60a549de6d3a62a0ee90c69e"
 dependencies = [
  "hermit-abi",
  "io-lifetimes",
- "rustix",
+ "rustix 0.36.10",
  "windows-sys 0.45.0",
 ]
 
@@ -1252,9 +1265,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libm"
@@ -1278,6 +1291,12 @@ name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lock_api"
@@ -1513,7 +1532,7 @@ version = "0.10.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd2523381e46256e40930512c7fd25562b9eae4812cb52078f155e87217c9d1e"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1923,7 +1942,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2043,7 +2062,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01e213bc3ecb39ac32e81e51ebe31fd888a940515173e3a18a35f8c6e896422a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -2114,12 +2133,25 @@ version = "0.36.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fe885c3a125aa45213b68cc1472a49880cb5923dc23f522ad2791b882228778"
 dependencies = [
- "bitflags",
- "errno",
+ "bitflags 1.3.2",
+ "errno 0.2.8",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.1.4",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+dependencies = [
+ "bitflags 2.5.0",
+ "errno 0.3.9",
+ "libc",
+ "linux-raw-sys 0.4.14",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2180,7 +2212,7 @@ version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2492,15 +2524,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.4.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
- "rustix",
- "windows-sys 0.42.0",
+ "rustix 0.38.34",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3042,13 +3073,13 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -3057,7 +3088,16 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -3066,13 +3106,29 @@ version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.5",
+ "windows_aarch64_msvc 0.52.5",
+ "windows_i686_gnu 0.52.5",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.5",
+ "windows_x86_64_gnu 0.52.5",
+ "windows_x86_64_gnullvm 0.52.5",
+ "windows_x86_64_msvc 0.52.5",
 ]
 
 [[package]]
@@ -3082,10 +3138,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3094,10 +3162,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3106,16 +3192,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winnow"

--- a/site/Cargo.toml
+++ b/site/Cargo.toml
@@ -54,6 +54,7 @@ rust-embed = { version = "6.6.0", features = [
 humansize = "2"
 lru = "0.12.0"
 ruzstd = "0.6.0"
+tempfile = "3.10.1"
 
 [target.'cfg(unix)'.dependencies]
 jemallocator = "0.5"

--- a/site/Cargo.toml
+++ b/site/Cargo.toml
@@ -1,5 +1,9 @@
 [package]
-authors = ["Mark-Simulacrum <mark.simulacrum@gmail.com>", "Nicholas Cameron <ncameron@mozilla.com>", "The rustc-perf contributors"]
+authors = [
+    "Mark-Simulacrum <mark.simulacrum@gmail.com>",
+    "Nicholas Cameron <ncameron@mozilla.com>",
+    "The rustc-perf contributors",
+]
 name = "site"
 version = "0.1.0"
 edition = "2021"
@@ -9,7 +13,7 @@ env_logger = "0.10"
 anyhow = "1"
 thiserror = "1"
 futures = "0.3"
-tokio = { version = "1.26", features = ["macros", "time"] }
+tokio = { version = "1.26", features = ["macros", "time", "fs"] }
 log = "0.4"
 serde = { version = "1", features = ["rc"] }
 serde_derive = "1"
@@ -43,7 +47,10 @@ mime = "0.3"
 prometheus = "0.13"
 uuid = { version = "1.3.0", features = ["v4"] }
 tera = { version = "1.19", default-features = false }
-rust-embed = { version = "6.6.0", features = ["include-exclude", "interpolate-folder-path"] }
+rust-embed = { version = "6.6.0", features = [
+    "include-exclude",
+    "interpolate-folder-path",
+] }
 humansize = "2"
 lru = "0.12.0"
 ruzstd = "0.6.0"

--- a/site/frontend/src/components/catapult-iframe.vue
+++ b/site/frontend/src/components/catapult-iframe.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import {ArtifactDescription} from "../pages/compare/types";
+import {CompileTestCase} from "../pages/compare/compile/common";
+import {catapultUrl} from "../self-profile";
+import {ref} from "vue";
+
+const props = defineProps<{
+  testCase: CompileTestCase;
+  artifact: ArtifactDescription;
+}>();
+
+const loading = ref(true);
+
+const onIframeLoad = () => {
+  loading.value = false;
+};
+</script>
+
+<template>
+  <div v-if="loading">Loading...</div>
+  <iframe
+    v-show="!loading"
+    width="100%"
+    style="aspect-ratio: 16/9"
+    :src="catapultUrl(props.artifact, props.testCase)"
+    @load="onIframeLoad"
+  />
+</template>

--- a/site/frontend/src/pages/compare/compile/table/benchmark-detail.vue
+++ b/site/frontend/src/pages/compare/compile/table/benchmark-detail.vue
@@ -443,8 +443,10 @@ onMounted(() => {
       </div>
     </div>
     <div class="columns">
-      <p>Catapult</p>
-      <CatapultIframe :artifact="props.artifact" :testCase="props.testCase" />
+      <div class="rows center-items grow">
+        <div class="title bold">Catapult</div>
+        <CatapultIframe :artifact="props.artifact" :testCase="props.testCase" />
+      </div>
     </div>
     <div class="columns" v-if="props.metric !== BINARY_SIZE_METRIC">
       <div class="rows center-items grow">

--- a/site/frontend/src/pages/compare/compile/table/benchmark-detail.vue
+++ b/site/frontend/src/pages/compare/compile/table/benchmark-detail.vue
@@ -29,6 +29,8 @@ import CompileSectionsChart from "./sections-chart.vue";
 import PerfettoLink from "../../../../components/perfetto-link.vue";
 import ProfileShortcut from "./shortcuts/profile-shortcut.vue";
 import BinarySizeShortcut from "./shortcuts/binary-size-shortcut.vue";
+import {catapultUrl} from "../../../../self-profile";
+import CatapultIframe from "../../../../components/catapult-iframe.vue";
 
 const props = defineProps<{
   testCase: CompileTestCase;
@@ -309,13 +311,6 @@ onMounted(() => {
     sectionsDetail.value = d;
   });
 });
-
-const catapultUrl = (artifact: ArtifactDescription) =>
-  computed(() => {
-    const {commit} = artifact;
-    const {benchmark, profile, scenario} = props.testCase;
-    return `/perf/self-profile-viewer?commit=${commit}&benchmark=${benchmark}-${profile.toLowerCase()}&scenario=${scenario}&type=crox`;
-  });
 </script>
 
 <template>
@@ -388,7 +383,9 @@ const catapultUrl = (artifact: ArtifactDescription) =>
               :test-case="props.testCase"
               >query trace </PerfettoLink
             >,
-            <a :href="catapultUrl(props.baseArtifact).value">catapult</a>
+            <a :href="catapultUrl(props.baseArtifact, props.testCase)"
+              >catapult</a
+            >
           </li>
           <li>
             After:
@@ -398,7 +395,7 @@ const catapultUrl = (artifact: ArtifactDescription) =>
             <PerfettoLink :artifact="props.artifact" :test-case="props.testCase"
               >query trace </PerfettoLink
             >,
-            <a :href="catapultUrl(props.artifact).value">catapult</a>
+            <a :href="catapultUrl(props.artifact, props.testCase)">catapult</a>
           </li>
           <li>
             <a
@@ -444,6 +441,10 @@ const catapultUrl = (artifact: ArtifactDescription) =>
         </div>
         <div ref="relativeToPreviousChartElement"></div>
       </div>
+    </div>
+    <div class="columns">
+      <p>Catapult</p>
+      <CatapultIframe :artifact="props.artifact" :testCase="props.testCase" />
     </div>
     <div class="columns" v-if="props.metric !== BINARY_SIZE_METRIC">
       <div class="rows center-items grow">

--- a/site/frontend/src/pages/compare/compile/table/benchmark-detail.vue
+++ b/site/frontend/src/pages/compare/compile/table/benchmark-detail.vue
@@ -309,6 +309,13 @@ onMounted(() => {
     sectionsDetail.value = d;
   });
 });
+
+const catapultUrl = (artifact: ArtifactDescription) =>
+  computed(() => {
+    const {commit} = artifact;
+    const {benchmark, profile, scenario} = props.testCase;
+    return `/perf/self-profile-viewer?commit=${commit}&benchmark=${benchmark}-${profile.toLowerCase()}&scenario=${scenario}&type=crox`;
+  });
 </script>
 
 <template>
@@ -379,8 +386,9 @@ onMounted(() => {
             <PerfettoLink
               :artifact="props.baseArtifact"
               :test-case="props.testCase"
-              >query trace
-            </PerfettoLink>
+              >query trace </PerfettoLink
+            >,
+            <a :href="catapultUrl(props.baseArtifact).value">catapult</a>
           </li>
           <li>
             After:
@@ -388,8 +396,9 @@ onMounted(() => {
               >self-profile</a
             >,
             <PerfettoLink :artifact="props.artifact" :test-case="props.testCase"
-              >query trace
-            </PerfettoLink>
+              >query trace </PerfettoLink
+            >,
+            <a :href="catapultUrl(props.artifact).value">catapult</a>
           </li>
           <li>
             <a

--- a/site/frontend/src/pages/compare/compile/table/benchmark-detail.vue
+++ b/site/frontend/src/pages/compare/compile/table/benchmark-detail.vue
@@ -445,6 +445,10 @@ onMounted(() => {
     <div class="columns">
       <div class="rows center-items grow">
         <div class="title bold">Catapult</div>
+        <CatapultIframe
+          :artifact="props.baseArtifact"
+          :testCase="props.testCase"
+        />
         <CatapultIframe :artifact="props.artifact" :testCase="props.testCase" />
       </div>
     </div>

--- a/site/frontend/src/self-profile.ts
+++ b/site/frontend/src/self-profile.ts
@@ -1,4 +1,8 @@
 // Returns the URL to a measureme self-profile data, processed into the
+
+import {CompileTestCase} from "./pages/compare/compile/common";
+import {ArtifactDescription} from "./pages/compare/types";
+
 // Chrome profiler format.
 export function chromeProfileUrl(
   commit: string,
@@ -22,3 +26,12 @@ export function processedSelfProfileRelativeUrl(
 ): string {
   return `/perf/processed-self-profile?commit=${commit}&benchmark=${benchmarkAndProfile}&scenario=${scenario}&type=${type}`;
 }
+
+export const catapultUrl = (
+  artifact: ArtifactDescription,
+  testCase: CompileTestCase
+) => {
+  const {commit} = artifact;
+  const {benchmark, profile, scenario} = testCase;
+  return `/perf/self-profile-viewer?commit=${commit}&benchmark=${benchmark}-${profile.toLowerCase()}&scenario=${scenario}&type=crox`;
+};

--- a/site/src/request_handlers.rs
+++ b/site/src/request_handlers.rs
@@ -13,7 +13,7 @@ pub use graph::{handle_compile_detail_graphs, handle_compile_detail_sections, ha
 pub use next_artifact::handle_next_artifact;
 pub use self_profile::{
     handle_self_profile, handle_self_profile_processed_download, handle_self_profile_raw,
-    handle_self_profile_raw_download,
+    handle_self_profile_raw_download, handle_self_profile_viewer,
 };
 pub use status_page::handle_status_page;
 

--- a/site/src/request_handlers/self_profile.rs
+++ b/site/src/request_handlers/self_profile.rs
@@ -47,6 +47,7 @@ pub async fn handle_self_profile_viewer(
         .expect("failed to run trace2html");
 
     cmd.wait().await.unwrap();
+    json.close().unwrap();
 
     let mut builder = http::Response::builder()
         .header_typed(ContentType::html())
@@ -60,6 +61,7 @@ pub async fn handle_self_profile_viewer(
 
     let mut html_buf = Vec::new();
     html.read_to_end(&mut html_buf).unwrap();
+    html.close().unwrap();
 
     builder.body(hyper::Body::from(html_buf)).unwrap()
 }

--- a/site/src/request_handlers/self_profile.rs
+++ b/site/src/request_handlers/self_profile.rs
@@ -44,9 +44,15 @@ pub async fn handle_self_profile_viewer(
 
     cmd.wait().await.unwrap();
 
-    let builder = http::Response::builder()
+    let mut builder = http::Response::builder()
         .header_typed(ContentType::html())
         .status(StatusCode::OK);
+
+    builder.headers_mut().unwrap().insert(
+        hyper::header::CONTENT_SECURITY_POLICY,
+        hyper::header::HeaderValue::from_maybe_shared("frame-ancestors 'self'")
+            .expect("valid header"),
+    );
 
     let mut html_buf = Vec::new();
     let mut html = File::open("trace.html").await.unwrap();

--- a/site/src/server.rs
+++ b/site/src/server.rs
@@ -434,6 +434,11 @@ async fn serve_req(server: Server, req: Request) -> Result<Response, ServerError
             let req = check!(parse_query_string(req.uri()));
             return Ok(request_handlers::handle_self_profile_processed_download(req, &ctxt).await);
         }
+        "/perf/self-profile-viewer" => {
+            let ctxt: Arc<SiteCtxt> = server.ctxt.read().as_ref().unwrap().clone();
+            let req = check!(parse_query_string(req.uri()));
+            return Ok(request_handlers::handle_self_profile_viewer(req, &ctxt).await);
+        }
         _ if req.method() == http::Method::GET => return Ok(not_found()),
         _ => {}
     }


### PR DESCRIPTION
closes #1857

We are currently using [Perfetto](https://perfetto.dev/) as our query trace visualizer. However, it would be beneficial to have a visualizer integrated directly into rust-lang.org.

In this PR, I have added the following:

- An endpoint that returns standalone visualizer HTML generated by [Catapult](https://chromium.googlesource.com/catapult/+/HEAD/tracing/README.md)'s trace2html.
  - It's just using `tokio::process::Command` to call `python3 trace2html (tempfile).json -o (tempfile).html`.
- A component that displays the visualizer, which has been added to the compare details page.
- A link to the Catapult's HTML next to the current query tracer.