### PR TITLE
Update & remove unused npm packages

### DIFF
--- a/site/frontend/package-lock.json
+++ b/site/frontend/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "date-fns": "^2.30.0",
-        "highcharts": "6.0.7",
+        "highcharts": "^11.4.1",
         "msgpack-lite": "^0.1.26",
         "parcel": "^2.8.3",
         "sass": "^1.59.3",
@@ -21,7 +21,6 @@
         "@babel/types": "^7.21.4",
         "@parcel/compressor-brotli": "^2.8.3",
         "@parcel/transformer-vue": "^2.8.3",
-        "@types/highcharts": "^7.0.0",
         "@types/msgpack-lite": "^0.1.8",
         "prettier": "2.8.8",
         "typescript": "^5.0.2",
@@ -2030,16 +2029,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/@types/highcharts": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@types/highcharts/-/highcharts-7.0.0.tgz",
-      "integrity": "sha512-YDevls0s9uqz6VEbchxp+NEaKssAPq5aDZgqEUpxOIUCQEncQtXxibp1w4lvgKyhM4qDejAcSZ+DKfA/kzqR0A==",
-      "deprecated": "This is a stub types definition. highcharts provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "highcharts": "*"
-      }
-    },
     "node_modules/@types/msgpack-lite": {
       "version": "0.1.11",
       "resolved": "https://registry.npmjs.org/@types/msgpack-lite/-/msgpack-lite-0.1.11.tgz",
@@ -2839,9 +2828,9 @@
       }
     },
     "node_modules/highcharts": {
-      "version": "6.0.7",
-      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-6.0.7.tgz",
-      "integrity": "sha512-LR1gArvVqegc0Gf1bAESm6scmCV5CuyIS0UZTqXKQs5mxMXYXES+xJl5htV3P2GqzleDrp1dsTqDdL9u4DF5Qw=="
+      "version": "11.4.1",
+      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-11.4.1.tgz",
+      "integrity": "sha512-t+BjB4hba5rNheczCrpyDz8BJrqGdgECHaaXQrgbf1mRdPMPemlOfo08/kTMgZ/Kp/Xfj015atdXpUFdwUU12Q=="
     },
     "node_modules/htmlnano": {
       "version": "2.1.1",

--- a/site/frontend/package.json
+++ b/site/frontend/package.json
@@ -14,7 +14,6 @@
     "@babel/types": "^7.21.4",
     "@parcel/compressor-brotli": "^2.8.3",
     "@parcel/transformer-vue": "^2.8.3",
-    "@types/highcharts": "^7.0.0",
     "@types/msgpack-lite": "^0.1.8",
     "prettier": "2.8.8",
     "typescript": "^5.0.2",
@@ -22,7 +21,7 @@
   },
   "dependencies": {
     "date-fns": "^2.30.0",
-    "highcharts": "6.0.7",
+    "highcharts": "^11.4.1",
     "msgpack-lite": "^0.1.26",
     "parcel": "^2.8.3",
     "sass": "^1.59.3",

--- a/site/frontend/src/pages/dashboard.ts
+++ b/site/frontend/src/pages/dashboard.ts
@@ -29,10 +29,13 @@ function render(
   versions: [string]
 ) {
   let articles = {check: "a", debug: "a", opt: "an", doc: "a"};
-  new Highcharts.chart(document.getElementById(element), {
+
+  Highcharts.chart({
     chart: {
-      zoomType: "xy",
-      renderTo: document.getElementById(element),
+      renderTo: element,
+      zooming: {
+        type: "xy",
+      },
       type: "line",
     },
     title: {
@@ -48,21 +51,25 @@ function render(
     },
     series: [
       {
+        type: "line",
         name: "full",
         animation: false,
         data: data.clean_averages,
       },
       {
+        type: "line",
         name: "incremental full",
         animation: false,
         data: data.base_incr_averages,
       },
       {
+        type: "line",
         name: "incremental unchanged",
         animation: false,
         data: data.clean_incr_averages,
       },
       {
+        type: "line",
         name: "incremental patched: println",
         animation: false,
         data: data.println_incr_averages,


### PR DESCRIPTION
I updated the packages to reduce npm warnings and removed some unused ones like "vite" and "@types/highcharts".
I'm a bit concerned about Highcharts because we can't test the dashboard page locally. One option might be to revert the last commit and stick with Highcharts 6.x.