### PR TITLE
refactor: hard-code v1 API response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1109,7 +1109,6 @@ checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
  "hashbrown",
- "serde",
 ]
 
 [[package]]
@@ -2088,15 +2087,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust_team_data"
-version = "1.0.0"
-source = "git+https://github.com/rust-lang/team#89bb40d3dca1bd9a6c6dbc1b8cb2ddc1fcc932ad"
-dependencies = [
- "indexmap",
- "serde",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2346,7 +2336,6 @@ dependencies = [
  "ring",
  "rmp-serde",
  "rust-embed",
- "rust_team_data",
  "ruzstd 0.6.0",
  "semver",
  "serde",

--- a/site/Cargo.toml
+++ b/site/Cargo.toml
@@ -27,7 +27,6 @@ regex = "1"
 lazy_static = "1"
 reqwest = { version = "0.11", features = ["json", "blocking"] }
 toml = "0.7"
-rust_team_data = { git = "https://github.com/rust-lang/team" }
 parking_lot = "0.12"
 snap = "1"
 itertools = "0.10"


### PR DESCRIPTION
Another step toward making rustc-perf self-contained.
See <https://github.com/rust-lang/rust/pull/125465>.

It makes no different between depending on an arbitrary Git commit
of rust-lang/team and inlining the responded JSON structure.