### PR TITLE
chore: update to `analyzeme@12.0.0` and `rust_team_data@a5260e7`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2090,7 +2090,7 @@ dependencies = [
 [[package]]
 name = "rust_team_data"
 version = "1.0.0"
-source = "git+https://github.com/rust-lang/team#89bb40d3dca1bd9a6c6dbc1b8cb2ddc1fcc932ad"
+source = "git+https://github.com/rust-lang/team#a5260e76d3aa894c64c56e6ddc8545b9a98043ec"
 dependencies = [
  "indexmap",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "analyzeme"
+version = "12.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20feead6e1e9722cb326230127d5ca89fe5c4609cb0dd047c3b58c81a26cfd18"
+dependencies = [
+ "decodeme 10.1.3",
+ "decodeme 12.0.0",
+ "measureme 10.1.3",
+ "measureme 12.0.0",
+ "memchr",
+ "rustc-hash",
+ "serde",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,7 +371,7 @@ dependencies = [
 name = "collector"
 version = "0.1.0"
 dependencies = [
- "analyzeme 11.0.0",
+ "analyzeme 12.0.0",
  "anyhow",
  "benchlib",
  "cargo_metadata",
@@ -554,10 +569,36 @@ dependencies = [
 
 [[package]]
 name = "decodeme"
+version = "10.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8907b810935b1fc70e90f415d88e5e3fb1fc0d17058c7da49d5e294eab89decf"
+dependencies = [
+ "measureme 10.1.3",
+ "memchr",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "decodeme"
 version = "11.0.0"
 source = "git+https://github.com/rust-lang/measureme?branch=stable#f2914503011098feb1bc9205c75dfb53203f9d9c"
 dependencies = [
  "measureme 11.0.0",
+ "memchr",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "decodeme"
+version = "12.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad52c78335c03452cb0404e5ae32e9e291f15186091be8d2e22d942f417475e0"
+dependencies = [
+ "measureme 12.0.0",
  "memchr",
  "rustc-hash",
  "serde",
@@ -1355,8 +1396,36 @@ dependencies = [
 
 [[package]]
 name = "measureme"
+version = "10.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f0c6afa424b30bee598dc5e8116cd01359bc57919cb10ac38cf9e0914f16c0b"
+dependencies = [
+ "log",
+ "memmap2",
+ "parking_lot 0.12.1",
+ "perf-event-open-sys 3.0.0",
+ "rustc-hash",
+ "smallvec",
+]
+
+[[package]]
+name = "measureme"
 version = "11.0.0"
 source = "git+https://github.com/rust-lang/measureme?branch=stable#f2914503011098feb1bc9205c75dfb53203f9d9c"
+dependencies = [
+ "log",
+ "memmap2",
+ "parking_lot 0.12.1",
+ "perf-event-open-sys 3.0.0",
+ "rustc-hash",
+ "smallvec",
+]
+
+[[package]]
+name = "measureme"
+version = "12.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed2d26a61b68ba37bf203340b6b6addf4da2c2e7cfb0cff700792088d69ebc9"
 dependencies = [
  "log",
  "memmap2",

--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -41,7 +41,7 @@ object = "0.32.1"
 tabled = { version = "0.14.0", features = ["ansi-str"] }
 humansize = "2.1.3"
 regex = "1.7.1"
-analyzeme = { git = "https://github.com/rust-lang/measureme", branch = "stable" }
+analyzeme = "12.0.0"
 
 benchlib = { path = "benchlib" }
 

--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -507,7 +507,7 @@ pub mod github {
 
     #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
     pub struct User {
-        pub id: usize,
+        pub id: u64,
     }
 
     #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/site/src/request_handlers/github.rs
+++ b/site/src/request_handlers/github.rs
@@ -177,7 +177,7 @@ fn build_captures(comment_body: &str) -> impl Iterator<Item = (&str, regex::Capt
         })
 }
 
-pub async fn get_authorized_users() -> Result<Vec<usize>, String> {
+pub async fn get_authorized_users() -> Result<Vec<u64>, String> {
     let url = format!("{}/permissions/perf.json", ::rust_team_data::v1::BASE_URL);
     let client = reqwest::Client::new();
     client


### PR DESCRIPTION
Another step toward making rustc-perf self-contained for <https://github.com/rust-lang/rust/pull/125465>.

This update two dependencies:

* `analyzeme@12.0.0`. Previously we depend on Git repository directly. In this version the v7 profdata file format support is dropped.
* `rust_team_data@a5260e7`. This version includes the license issue fixed (<https://github.com/rust-lang/team/pull/1462>). Since rust_team_data is only used by the website, it should be fine just depending on Git. See <https://github.com/rust-lang/rustc-perf/pull/1914>.

r? @Kobzol 