### PR TITLE
Update libc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,9 +1241,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libm"


### PR DESCRIPTION
So that it works with `-Ccheck-cfg`. Required for `rustc-perf` bootstrap integration that I'm working on.