### PR TITLE
Fix styling of benchmark detail graphs

### DIFF
--- a/site/frontend/src/pages/compare/benchmark-detail.scss
+++ b/site/frontend/src/pages/compare/benchmark-detail.scss
@@ -1,0 +1,39 @@
+.columns {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 15px;
+  margin: 10px 0;
+
+  .grow {
+    flex-grow: 1;
+  }
+
+  &.graphs {
+    flex-wrap: nowrap;
+  }
+}
+
+.graphs {
+  margin-top: 15px;
+}
+
+.rows {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+
+  &.center-items {
+    align-items: center;
+  }
+}
+
+.title {
+  &.bold,
+  .bold {
+    font-weight: bold;
+  }
+
+  &.info {
+    margin-bottom: 15px;
+  }
+}

--- a/site/frontend/src/pages/compare/compile/table/benchmark-detail-graph.vue
+++ b/site/frontend/src/pages/compare/compile/table/benchmark-detail-graph.vue
@@ -266,3 +266,7 @@ onMounted(() => {
     </div>
   </div>
 </template>
+
+<style scoped lang="scss">
+@import "../../benchmark-detail.scss";
+</style>

--- a/site/frontend/src/pages/compare/compile/table/benchmark-detail.vue
+++ b/site/frontend/src/pages/compare/compile/table/benchmark-detail.vue
@@ -250,49 +250,11 @@ onMounted(() => {
 </template>
 
 <style scoped lang="scss">
-.columns {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 15px;
-  margin: 10px 0;
-
-  .grow {
-    flex-grow: 1;
-  }
-
-  &.graphs {
-    flex-wrap: nowrap;
-  }
-}
-
-.graphs {
-  margin-top: 15px;
-}
-
-.rows {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-
-  &.center-items {
-    align-items: center;
-  }
-}
+@import "../../benchmark-detail.scss";
 
 .shortcut {
   margin-top: 15px;
   text-align: left;
-}
-
-.title {
-  &.bold,
-  .bold {
-    font-weight: bold;
-  }
-
-  &.info {
-    margin-bottom: 15px;
-  }
 }
 
 table {

--- a/site/frontend/src/pages/compare/runtime/benchmark-detail-graph.vue
+++ b/site/frontend/src/pages/compare/runtime/benchmark-detail-graph.vue
@@ -256,3 +256,7 @@ onMounted(() => {
     </div>
   </div>
 </template>
+
+<style scoped lang="scss">
+@import "../benchmark-detail.scss";
+</style>


### PR DESCRIPTION
Not sure if there was a way to fix this without duplicating the styles, but this works (see https://tealquaternion.camdvr.org/compare.html for an example)
This broke in https://github.com/rust-lang/rustc-perf/pull/1922.