### PR TITLE
Add more visible warning when a benchmark fails to compile in a PR

### DIFF
--- a/site/src/github/comparison_summary.rs
+++ b/site/src/github/comparison_summary.rs
@@ -183,7 +183,10 @@ async fn summarize_run(
             .map(|benchmark| format!("- {benchmark}"))
             .collect::<Vec<_>>()
             .join("\n");
-        format!("\n**Warning ⚠**: The following benchmark(s) failed to build:\n{benchmarks}\n")
+        let alert_row = ":exclamation: ".repeat(5);
+        format!(
+            "\n{alert_row}\n**Warning :warning:**: The following benchmark(s) failed to build:\n{benchmarks}\n{alert_row}\n"
+        )
     } else {
         String::new()
     };

--- a/site/src/github/comparison_summary.rs
+++ b/site/src/github/comparison_summary.rs
@@ -176,7 +176,8 @@ async fn summarize_run(
     let inst_comparison =
         calculate_metric_comparison(ctxt, &commit, Metric::InstructionsUser).await?;
 
-    let errors = if !inst_comparison.newly_failed_benchmarks.is_empty() {
+    let has_broken_benchmarks = !inst_comparison.newly_failed_benchmarks.is_empty();
+    let errors = if has_broken_benchmarks {
         let benchmarks = inst_comparison
             .newly_failed_benchmarks
             .keys()
@@ -209,7 +210,9 @@ async fn summarize_run(
         &mut message,
         "### Overall result: {}{}\n",
         overall_result,
-        if is_regression {
+        if has_broken_benchmarks {
+            " - BENCHMARK(S) FAILED"
+        } else if is_regression {
             " - ACTION NEEDED"
         } else {
             " - no action needed"


### PR DESCRIPTION
This should make the warning more visible, to avoid situations where we overlook it (e.g. https://github.com/rust-lang/rust/pull/125507). This is how it should look like:
![image](https://github.com/rust-lang/rustc-perf/assets/4539057/59941cfb-74a5-4e0b-97b6-36db0f0cacac)