### PR TITLE
use "bootstrap" instead of "rustbuild"

### DIFF
--- a/collector/compile-benchmarks/cargo-0.60.0/src/cargo/core/compiler/build_context/target_info.rs
+++ b/collector/compile-benchmarks/cargo-0.60.0/src/cargo/core/compiler/build_context/target_info.rs
@@ -866,7 +866,7 @@ impl RustDocFingerprint {
             Ok(rustdoc_data) => rustdoc_data,
             // If the fingerprint does not exist, do not clear out the doc
             // directories. Otherwise this ran into problems where projects
-            // like rustbuild were creating the doc directory before running
+            // like bootstrap were creating the doc directory before running
             // `cargo doc` in a way that deleting it would break it.
             Err(_) => return write_fingerprint(),
         };

--- a/collector/compile-benchmarks/cargo-0.60.0/src/cargo/core/compiler/fingerprint.rs
+++ b/collector/compile-benchmarks/cargo-0.60.0/src/cargo/core/compiler/fingerprint.rs
@@ -80,7 +80,7 @@
 //!
 //! [^3]: See below for details on mtime tracking.
 //!
-//! [^4]: `__CARGO_DEFAULT_LIB_METADATA` is set by rustbuild to embed the
+//! [^4]: `__CARGO_DEFAULT_LIB_METADATA` is set by bootstrap to embed the
 //!        release channel (bootstrap/stable/beta/nightly) in libstd.
 //!
 //! [^5]: Config settings that are not otherwise captured anywhere else.

--- a/collector/compile-benchmarks/cargo-0.60.0/src/cargo/version.rs
+++ b/collector/compile-benchmarks/cargo-0.60.0/src/cargo/version.rs
@@ -9,7 +9,7 @@ pub struct CommitInfo {
     pub commit_date: String,
 }
 
-/// Information provided by the outer build system (rustbuild aka bootstrap).
+/// Information provided by the outer build system (bootstrap).
 pub struct CfgInfo {
     /// Information about the Git repository we may have been built from.
     pub commit_info: Option<CommitInfo>,
@@ -22,7 +22,7 @@ pub struct VersionInfo {
     /// Cargo's version, such as "1.57.0", "1.58.0-beta.1", "1.59.0-nightly", etc.
     pub version: String,
     /// Information that's only available when we were built with
-    /// rustbuild, rather than Cargo itself.
+    /// bootstrap, rather than Cargo itself.
     pub cfg_info: Option<CfgInfo>,
 }
 
@@ -47,9 +47,9 @@ pub fn version() -> VersionInfo {
         };
     }
 
-    // This is the version set in rustbuild, which we use to match rustc.
+    // This is the version set in bootstrap, which we use to match rustc.
     let version = option_env_str!("CFG_RELEASE").unwrap_or_else(|| {
-        // If cargo is not being built by rustbuild, then we just use the
+        // If cargo is not being built by bootstrap, then we just use the
         // version from cargo's own `Cargo.toml`.
         //
         // There are two versions at play here:


### PR DESCRIPTION
Let's stick with the single name "bootstrap" to refer to the bootstrap project to avoid confusion.

cc https://github.com/rust-lang/rust/pull/127434