### PR TITLE
fix alert display when build fails

### DIFF
--- a/site/src/github/comparison_summary.rs
+++ b/site/src/github/comparison_summary.rs
@@ -185,8 +185,9 @@ async fn summarize_run(
             .collect::<Vec<_>>()
             .join("\n");
         let alert_row = ":exclamation: ".repeat(5);
+        // second \n before `alert_row` needed or markdown will render this as appended to last li
         format!(
-            "\n{alert_row}\n**Warning :warning:**: The following benchmark(s) failed to build:\n{benchmarks}\n{alert_row}\n"
+            "\n{alert_row}\n**Warning :warning:**: The following benchmark(s) failed to build:\n{benchmarks}\n\n{alert_row}\n"
         )
     } else {
         String::new()


### PR DESCRIPTION
cc #1935

See https://github.com/rust-lang/rust/pull/127473#issuecomment-2213091171, second alert signs right shifted, while instead they should be aligned with previous alert signs.

second \n before `alert_row` needed or markdown will render this as appended to last list item.