### PR TITLE
Add runtime chart to dashboard

### DIFF
--- a/site/frontend/src/pages/dashboard.ts
+++ b/site/frontend/src/pages/dashboard.ts
@@ -3,7 +3,7 @@ import {DASHBOARD_DATA_URL} from "../urls";
 
 import {getJson} from "../utils/requests";
 
-interface DashboardCases {
+interface DashboardCompileBenchmarkCases {
   clean_averages: [number];
   base_incr_averages: [number];
   clean_incr_averages: [number];
@@ -13,10 +13,11 @@ interface DashboardCases {
 interface DashboardResponse {
   Ok: {
     versions: [string];
-    check: DashboardCases;
-    debug: DashboardCases;
-    opt: DashboardCases;
-    doc: DashboardCases;
+    check: DashboardCompileBenchmarkCases;
+    debug: DashboardCompileBenchmarkCases;
+    opt: DashboardCompileBenchmarkCases;
+    doc: DashboardCompileBenchmarkCases;
+    runtime: [number];
   };
 }
 
@@ -25,7 +26,7 @@ type Profile = "check" | "debug" | "opt" | "doc";
 function render(
   element: string,
   name: Profile,
-  data: DashboardCases,
+  data: DashboardCompileBenchmarkCases,
   versions: [string]
 ) {
   let articles = {check: "a", debug: "a", opt: "an", doc: "a"};
@@ -78,12 +79,44 @@ function render(
   });
 }
 
+function renderRuntime(element: string, data: [number], versions: [string]) {
+  Highcharts.chart({
+    chart: {
+      renderTo: element,
+      zooming: {
+        type: "xy",
+      },
+      type: "line",
+    },
+    title: {
+      text: `Average time for a run`,
+    },
+    yAxis: {
+      title: {text: "Seconds"},
+      min: 0,
+    },
+    xAxis: {
+      categories: versions,
+      title: {text: "Version"},
+    },
+    series: [
+      {
+        showInLegend: false,
+        type: "line",
+        animation: false,
+        data,
+      },
+    ],
+  });
+}
+
 function populate_data(response: DashboardResponse) {
   const data = response.Ok;
   render("check-average-times", "check", data.check, data.versions);
   render("debug-average-times", "debug", data.debug, data.versions);
   render("opt-average-times", "opt", data.opt, data.versions);
   render("doc-average-times", "doc", data.doc, data.versions);
+  renderRuntime("runtime-average-times", data.runtime, data.versions);
 }
 
 async function make_data() {

--- a/site/frontend/src/pages/dashboard.ts
+++ b/site/frontend/src/pages/dashboard.ts
@@ -89,7 +89,7 @@ function renderRuntime(element: string, data: [number], versions: [string]) {
       type: "line",
     },
     title: {
-      text: `Average time for a run`,
+      text: `Average time for a runtime benchmark`,
     },
     yAxis: {
       title: {text: "Seconds"},

--- a/site/frontend/templates/pages/dashboard.html
+++ b/site/frontend/templates/pages/dashboard.html
@@ -19,7 +19,9 @@
     <code>1.28.0</code>, along with the latest <code>beta</code> release. The displayed
     duration is an arithmetic mean amongst all
     <a href="https://github.com/rust-lang/rustc-perf/tree/master/collector/compile-benchmarks#stable">stable</a>
-    benchmarks.
+    benchmarks. The dashboard also shows the average duration of runtime benchmarks, which measure the performance of
+    Rust programs
+    compiled by a given version of the Rust compiler.
 </details>
 
 <div class="graphs">

--- a/site/frontend/templates/pages/dashboard.html
+++ b/site/frontend/templates/pages/dashboard.html
@@ -1,19 +1,34 @@
 {% extends "layout.html" %}
+{% block head %}
+<style>
+    .graphs {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+
+        @media screen and (max-width: 768px) {
+            grid-template-columns: 1fr;
+        }
+    }
+</style>
+{% endblock %}
 {% block content %}
 <details style="margin-top: 10px;">
-<summary>What data is in the dashboard?</summary>
+    <summary>What data is in the dashboard?</summary>
 
-The dashboard shows performance results for all stable Rust releases going back to
-<code>1.28.0</code>, along with the latest <code>beta</code> release. The displayed
-duration is an arithmetic mean amongst all
-<a href="https://github.com/rust-lang/rustc-perf/tree/master/collector/compile-benchmarks#stable">stable</a>
-benchmarks.
+    The dashboard shows performance results for all stable Rust releases going back to
+    <code>1.28.0</code>, along with the latest <code>beta</code> release. The displayed
+    duration is an arithmetic mean amongst all
+    <a href="https://github.com/rust-lang/rustc-perf/tree/master/collector/compile-benchmarks#stable">stable</a>
+    benchmarks.
 </details>
 
-<div id="check-average-times"></div>
-<div id="debug-average-times"></div>
-<div id="opt-average-times"></div>
-<div id="doc-average-times"></div>
+<div class="graphs">
+    <div id="check-average-times"></div>
+    <div id="debug-average-times"></div>
+    <div id="opt-average-times"></div>
+    <div id="doc-average-times"></div>
+    <div id="runtime-average-times"></div>
+</div>
 <div id="as-of"></div>
 {% endblock %}
 {% block script %}

--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -75,6 +75,7 @@ pub mod dashboard {
         pub debug: Cases,
         pub opt: Cases,
         pub doc: Cases,
+        pub runtime: Vec<f64>,
     }
 }
 

--- a/site/src/request_handlers/dashboard.rs
+++ b/site/src/request_handlers/dashboard.rs
@@ -85,9 +85,6 @@ pub async fn handle_dashboard(ctxt: Arc<SiteCtxt>) -> ServerResult<dashboard::Re
     let compile_benchmark_query = selector::CompileBenchmarkQuery::default()
         .benchmark(selector::Selector::Subset(STABLE_BENCHMARKS.clone()))
         .metric(selector::Selector::One(Metric::WallTime));
-    let runtime_benchmark_query = selector::RuntimeBenchmarkQuery::default()
-        .benchmark(selector::Selector::Subset(STABLE_BENCHMARKS.clone()))
-        .metric(selector::Selector::One(Metric::WallTime));
 
     let summary_scenarios = ctxt.summary_scenarios();
     let aids = &artifact_ids;
@@ -133,7 +130,10 @@ pub async fn handle_dashboard(ctxt: Arc<SiteCtxt>) -> ServerResult<dashboard::Re
     .await
     .unwrap();
 
-    let runtime_benchmark_query = &runtime_benchmark_query;
+    let runtime_benchmark_query = selector::RuntimeBenchmarkQuery::default()
+        .benchmark(selector::Selector::All)
+        .metric(selector::Selector::One(Metric::WallTime));
+
     let responses = ctxt
         .statistic_series(runtime_benchmark_query.clone(), aids.clone())
         .await?;

--- a/site/src/selector.rs
+++ b/site/src/selector.rs
@@ -86,6 +86,7 @@ pub fn range_subset(data: Vec<Commit>, range: RangeInclusive<Bound>) -> Vec<Comm
     }
 }
 
+#[derive(Debug)]
 struct ArtifactIdIter {
     ids: Arc<Vec<ArtifactId>>,
     idx: usize,
@@ -424,6 +425,7 @@ impl SiteCtxt {
     }
 }
 
+#[derive(Debug)]
 pub struct StatisticSeries {
     artifact_ids: ArtifactIdIter,
     points: std::vec::IntoIter<Option<f64>>,


### PR DESCRIPTION
fix #1816 

There isn't a perf-config.json for the runtime benchmarks, so I averaged all the runtime benchmarks. However, it would be somewhat useful to add one.