### PR TITLE
remove interpolated points of dashboard's runtime bench and fix graph unit

### DIFF
--- a/site/frontend/src/pages/dashboard.ts
+++ b/site/frontend/src/pages/dashboard.ts
@@ -80,6 +80,13 @@ function render(
 }
 
 function renderRuntime(element: string, data: [number], versions: [string]) {
+  // Remove null and convert nanoseconds to miliseconds
+  // The null values, which indicate that the runtime data is missing, are only present at the beginning of the array.
+  const formattedData = data
+    .filter((data) => data != null)
+    .map((data) => data / 1_000_000);
+  const nullCount = data.length - formattedData.length;
+
   Highcharts.chart({
     chart: {
       renderTo: element,
@@ -92,11 +99,11 @@ function renderRuntime(element: string, data: [number], versions: [string]) {
       text: `Average time for a runtime benchmark`,
     },
     yAxis: {
-      title: {text: "Seconds"},
+      title: {text: "Miliseconds"},
       min: 0,
     },
     xAxis: {
-      categories: versions,
+      categories: versions.slice(nullCount),
       title: {text: "Version"},
     },
     series: [
@@ -104,7 +111,7 @@ function renderRuntime(element: string, data: [number], versions: [string]) {
         showInLegend: false,
         type: "line",
         animation: false,
-        data,
+        data: formattedData,
       },
     ],
   });

--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -75,7 +75,7 @@ pub mod dashboard {
         pub debug: Cases,
         pub opt: Cases,
         pub doc: Cases,
-        pub runtime: Vec<f64>,
+        pub runtime: Vec<Option<f64>>,
     }
 }
 


### PR DESCRIPTION
I fixed the graph unit from seconds to nanoseconds and removed interpolated points from when runtime benchmarks hadn't been implemented yet.