### PR TITLE
drop protobuf and derive_more from deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.70.0
+          toolchain: 1.73.0
           override: true
           components: rustfmt, clippy
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,17 +567,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_more"
-version = "0.99.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1473,13 +1462,13 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.2"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
 dependencies = [
  "flate2",
  "memchr",
- "ruzstd 0.5.0",
+ "ruzstd",
 ]
 
 [[package]]
@@ -2063,23 +2052,11 @@ dependencies = [
 
 [[package]]
 name = "ruzstd"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58c4eb8a81997cf040a091d1f7e1938aeab6749d3a0dfa73af43cdc32393483d"
+checksum = "5022b253619b1ba797f243056276bed8ed1a73b0f5a7ce7225d524067644bf8f"
 dependencies = [
  "byteorder",
- "derive_more",
- "twox-hash",
-]
-
-[[package]]
-name = "ruzstd"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5174a470eeb535a721ae9fdd6e291c2411a906b96592182d05217591d5c5cf7b"
-dependencies = [
- "byteorder",
- "derive_more",
  "twox-hash",
 ]
 
@@ -2286,7 +2263,7 @@ dependencies = [
  "rmp-serde",
  "rust-embed",
  "rust_team_data",
- "ruzstd 0.6.0",
+ "ruzstd",
  "semver",
  "serde",
  "serde_derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1785,15 +1785,8 @@ dependencies = [
  "lazy_static",
  "memchr",
  "parking_lot",
- "protobuf",
  "thiserror",
 ]
-
-[[package]]
-name = "protobuf"
-version = "2.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "quick-xml"

--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -37,7 +37,7 @@ thousands = "0.2.0"
 rustc-demangle = { version = "0.1", features = ["std"] }
 similar = "2.2"
 console = "0.15"
-object = "0.32.1"
+object = "0.36.0"
 tabled = { version = "0.14.0", features = ["ansi-str"] }
 humansize = "2.1.3"
 regex = "1.7.1"

--- a/collector/src/artifact_stats.rs
+++ b/collector/src/artifact_stats.rs
@@ -108,7 +108,7 @@ static RUSTC_HASH_REGEX: OnceLock<Regex> = OnceLock::new();
 /// Demangle the symbol and remove rustc mangling hashes.
 fn normalize_symbol_name(symbol: &str) -> String {
     let regex =
-        RUSTC_HASH_REGEX.get_or_init(|| Regex::new(r#"(::)?\b[a-z0-9]{15,17}\b(\.\d+)?"#).unwrap());
+        RUSTC_HASH_REGEX.get_or_init(|| Regex::new(r"(::)?\b[a-z0-9]{15,17}\b(\.\d+)?").unwrap());
 
     let symbol = rustc_demangle::demangle(symbol).to_string();
     regex.replace_all(&symbol, "").to_string()

--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -1371,7 +1371,7 @@ fn print_binary_stats(
     // Fill in items from the second artifact that are not present in the first one
     if use_diff {
         for (section, size) in items2 {
-            if items.get(&section).is_none() {
+            if !items.contains_key(&section) {
                 rows.push(Row {
                     name: section,
                     before: 0,

--- a/collector/src/runtime/mod.rs
+++ b/collector/src/runtime/mod.rs
@@ -209,7 +209,7 @@ fn execute_runtime_benchmark_binary(
     let mut command = prepare_command(binary);
     command.arg("run");
     command.arg("--iterations");
-    command.arg(&iterations.to_string());
+    command.arg(iterations.to_string());
 
     if !filter.exclude.is_empty() {
         command.args(["--exclude", &filter.exclude.join(",")]);

--- a/collector/src/utils/fs.rs
+++ b/collector/src/utils/fs.rs
@@ -13,7 +13,7 @@ pub fn rename<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> anyhow::Result<
     let ctx = format!("renaming file {:?} to {:?}", from, to);
 
     if fs::metadata(from)?.is_file() {
-        return Ok(fs::rename(from, to).with_context(|| ctx.clone())?);
+        return fs::rename(from, to).with_context(|| ctx.clone());
     }
 
     robocopy(from, to, &[&"/move"]).with_context(|| ctx.clone())

--- a/collector/src/utils/read2.rs
+++ b/collector/src/utils/read2.rs
@@ -158,7 +158,7 @@ mod imp {
     impl<'a> Pipe<'a> {
         unsafe fn new<P: IntoRawHandle>(p: P, dst: &'a mut Vec<u8>) -> Pipe<'a> {
             Pipe {
-                dst: dst,
+                dst,
                 pipe: NamedPipe::from_raw_handle(p.into_raw_handle()),
                 overlapped: Overlapped::zero(),
                 done: false,
@@ -196,9 +196,6 @@ mod imp {
         if v.capacity() == v.len() {
             v.reserve(1);
         }
-        slice::from_raw_parts_mut(
-            v.as_mut_ptr().offset(v.len() as isize),
-            v.capacity() - v.len(),
-        )
+        slice::from_raw_parts_mut(v.as_mut_ptr().add(v.len()), v.capacity() - v.len())
     }
 }

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -717,6 +717,8 @@ impl Connection for SqliteConnection {
         _profile: Profile,
         _scenario: crate::Scenario,
     ) {
+        #![allow(clippy::diverging_sub_expression)]
+
         // FIXME: this is left for the future, if we ever need to support it. It
         // shouldn't be too hard, but we may also want to just intern the raw
         // self profile files into sqlite database or something like that, not

--- a/site/Cargo.toml
+++ b/site/Cargo.toml
@@ -39,7 +39,8 @@ url = "2"
 analyzeme = "12.0.0"
 inferno = { version = "0.11", default-features = false }
 mime = "0.3"
-prometheus = "0.13"
+# prometheus currently uses plain text, so disable protobuf
+prometheus = { version = "0.13", default-features = false }
 uuid = { version = "1.3.0", features = ["v4"] }
 tera = { version = "1.19", default-features = false }
 rust-embed = { version = "6.6.0", features = ["include-exclude", "interpolate-folder-path"] }

--- a/site/Cargo.toml
+++ b/site/Cargo.toml
@@ -46,7 +46,7 @@ tera = { version = "1.19", default-features = false }
 rust-embed = { version = "6.6.0", features = ["include-exclude", "interpolate-folder-path"] }
 humansize = "2"
 lru = "0.12.0"
-ruzstd = "0.6.0"
+ruzstd = "0.7.0"
 
 [target.'cfg(unix)'.dependencies]
 jemallocator = "0.5"

--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -197,9 +197,9 @@ pub struct UnrolledCommit<'a> {
 
 lazy_static::lazy_static! {
     static ref ROLLUP_PR_NUMBER: regex::Regex =
-        regex::Regex::new(r#"^Auto merge of #(\d+)"#).unwrap();
+        regex::Regex::new(r"^Auto merge of #(\d+)").unwrap();
     static ref ROLLEDUP_PR_NUMBER: regex::Regex =
-        regex::Regex::new(r#"^Rollup merge of #(\d+)"#).unwrap();
+        regex::Regex::new(r"^Rollup merge of #(\d+)").unwrap();
 }
 
 // Gets the pr number for the associated rollup PR message. Returns None if this is not a rollup PR

--- a/site/src/request_handlers/github.rs
+++ b/site/src/request_handlers/github.rs
@@ -11,9 +11,9 @@ use regex::Regex;
 
 lazy_static::lazy_static! {
     static ref BODY_TIMER_BUILD: Regex =
-        Regex::new(r#"(?:\W|^)@rust-timer\s+build\s+(\w+)(?:\W|$)(?:include=(\S+))?\s*(?:exclude=(\S+))?\s*(?:runs=(\d+))?"#).unwrap();
+        Regex::new(r"(?:\W|^)@rust-timer\s+build\s+(\w+)(?:\W|$)(?:include=(\S+))?\s*(?:exclude=(\S+))?\s*(?:runs=(\d+))?").unwrap();
     static ref BODY_TIMER_QUEUE: Regex =
-        Regex::new(r#"(?:\W|^)@rust-timer\s+queue(?:\W|$)(?:include=(\S+))?\s*(?:exclude=(\S+))?\s*(?:runs=(\d+))?"#).unwrap();
+        Regex::new(r"(?:\W|^)@rust-timer\s+queue(?:\W|$)(?:include=(\S+))?\s*(?:exclude=(\S+))?\s*(?:runs=(\d+))?").unwrap();
 }
 
 pub async fn handle_github(


### PR DESCRIPTION
First commit: `prometheus` currently uses plain text, so disable `protobuf`; this reduces `site` bin by ~ 1mb;
Second: drops `derive_more`

Bumped stable rust version from 1.70 to 1.73 for CI.