### PR TITLE
Use inline script instead actions-rs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,12 @@ jobs:
           fetch-depth: 1
 
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.75.0
-          override: true
-          components: rustfmt, clippy
+        run: |
+          rustup install $RUST_TOOLCHAIN_VERSION
+          rustup default $RUST_TOOLCHAIN_VERSION
+          rustup component add --toolchain $RUST_TOOLCHAIN_VERSION rustfmt clippy
+        env:
+          RUST_TOOLCHAIN_VERSION: 1.75.0
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -77,11 +78,14 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Install latest beta
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: beta
-          override: true
+      - name: Install latest beta toolchain
+        run: |
+          rustup install %RUST_TOOLCHAIN_VERSION%
+          rustup default %RUST_TOOLCHAIN_VERSION%
+          rustup component add --toolchain %RUST_TOOLCHAIN_VERSION% rustfmt clippy
+        env:
+          RUST_TOOLCHAIN_VERSION: beta
+        shell: cmd
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -90,7 +94,7 @@ jobs:
       - name: cargo check
         run: cargo check
         env:
-            RUSTFLAGS: -Dwarnings
+          RUSTFLAGS: -Dwarnings
 
       - name: Run unit tests
         run: cargo test --all
@@ -125,11 +129,13 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Install latest beta
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: beta
-          override: true
+      - name: Install latest beta toolchain
+        run: |
+          rustup install $RUST_TOOLCHAIN_VERSION
+          rustup default $RUST_TOOLCHAIN_VERSION
+          rustup component add --toolchain $RUST_TOOLCHAIN_VERSION rustfmt clippy
+        env:
+          RUST_TOOLCHAIN_VERSION: beta
 
       - name: Configure environment
         run: |
@@ -162,11 +168,13 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Install latest beta
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: beta
-          override: true
+      - name: Install latest beta toolchain
+        run: |
+          rustup install $RUST_TOOLCHAIN_VERSION
+          rustup default $RUST_TOOLCHAIN_VERSION
+          rustup component add --toolchain $RUST_TOOLCHAIN_VERSION rustfmt clippy
+        env:
+          RUST_TOOLCHAIN_VERSION: beta
 
       - name: Configure environment
         run: |
@@ -196,11 +204,13 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Install latest beta
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: beta
-          override: true
+      - name: Install latest beta toolchain
+        run: |
+          rustup install $RUST_TOOLCHAIN_VERSION
+          rustup default $RUST_TOOLCHAIN_VERSION
+          rustup component add --toolchain $RUST_TOOLCHAIN_VERSION rustfmt clippy
+        env:
+          RUST_TOOLCHAIN_VERSION: beta
 
       - name: Configure environment
         run: |
@@ -227,11 +237,13 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Install latest beta
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: beta
-          override: true
+      - name: Install latest beta toolchain
+        run: |
+          rustup install $RUST_TOOLCHAIN_VERSION
+          rustup default $RUST_TOOLCHAIN_VERSION
+          rustup component add --toolchain $RUST_TOOLCHAIN_VERSION rustfmt clippy
+        env:
+          RUST_TOOLCHAIN_VERSION: beta
 
       # We build a specific version of Valgrind because the one from the Ubuntu 22.04 repositories
       # has problems with Rust debuginfo.
@@ -294,10 +306,13 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v2
 
-      - name: Install stable
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - name: Install latest toolchain
+        run: |
+          rustup install $RUST_TOOLCHAIN_VERSION
+          rustup default $RUST_TOOLCHAIN_VERSION
+          rustup component add --toolchain $RUST_TOOLCHAIN_VERSION rustfmt clippy
+        env:
+          RUST_TOOLCHAIN_VERSION: stable
 
       - uses: Swatinem/rust-cache@v2
 
@@ -344,10 +359,13 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v2
 
-      - name: Install stable
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - name: Install latest stable toolchain
+        run: |
+          rustup install $RUST_TOOLCHAIN_VERSION
+          rustup default $RUST_TOOLCHAIN_VERSION
+          rustup component add --toolchain $RUST_TOOLCHAIN_VERSION rustfmt clippy
+        env:
+          RUST_TOOLCHAIN_VERSION: stable
 
       - name: Install nightly
         run: rustup install nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
@@ -74,7 +74,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout the source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
@@ -125,7 +125,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
@@ -164,7 +164,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
@@ -200,7 +200,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
@@ -233,7 +233,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout the source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
@@ -304,7 +304,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install latest toolchain
         run: |
@@ -357,7 +357,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install latest stable toolchain
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,7 +14,7 @@ jobs:
           echo "RUSTC_PERF_VERSION=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
       - name: Checkout the source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
@@ -26,7 +26,7 @@ jobs:
         env:
           RUST_TOOLCHAIN_VERSION: stable
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,11 +19,12 @@ jobs:
           fetch-depth: 1
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+        run: |
+          rustup install $RUST_TOOLCHAIN_VERSION --profile minimal
+          rustup default $RUST_TOOLCHAIN_VERSION
+          rustup component add --toolchain $RUST_TOOLCHAIN_VERSION rustfmt clippy
+        env:
+          RUST_TOOLCHAIN_VERSION: stable
 
       - uses: Swatinem/rust-cache@v1
 


### PR DESCRIPTION
The repository for [`actions-rs/toolchain`](https://github.com/actions-rs/toolchain) has been archived and is no longer maintained. Instead, this PR uses an inline script like:

```yaml
      - name: Install stable toolchain
        run: |
          rustup install $RUST_TOOLCHAIN_VERSION --profile minimal
          rustup default $RUST_TOOLCHAIN_VERSION
          rustup component add --toolchain $RUST_TOOLCHAIN_VERSION rustfmt clippy
        env:
          RUST_TOOLCHAIN_VERSION: stable
```

Additionally, I've updated the versions for `actions/checkout`, `actions/setup-node`, and `Swatinem/rust-cache`. 