### PR TITLE
apply showRawData option for markdown export

### DIFF
--- a/site/frontend/src/pages/compare/compile/compile-page.vue
+++ b/site/frontend/src/pages/compare/compile/compile-page.vue
@@ -192,14 +192,14 @@ function refreshQuickLinks() {
   quickLinksKey.value += 1;
 }
 
-function exportData() {
-  exportToMarkdown(comparisons.value);
-}
-
 const urlParams = getUrlParams();
 
 const quickLinksKey = ref(0);
 const filter = ref(loadFilterFromUrl(urlParams, defaultCompileFilter));
+
+function exportData() {
+  exportToMarkdown(comparisons.value, filter.value.showRawData);
+}
 
 const benchmarkMap = createCompileBenchmarkMap(props.data);
 const allComparisons = computed(() =>

--- a/site/frontend/src/pages/compare/compile/export.ts
+++ b/site/frontend/src/pages/compare/compile/export.ts
@@ -2,18 +2,44 @@ import {computeSummary, TestCaseComparison} from "../data";
 import {CompileTestCase} from "./common";
 
 export function exportToMarkdown(
-  comparisons: TestCaseComparison<CompileTestCase>[]
+  comparisons: TestCaseComparison<CompileTestCase>[],
+  showRawData: boolean = false
 ) {
   function changesTable(comparisons: TestCaseComparison<CompileTestCase>[]) {
-    let data =
-      "| Benchmark | Profile | Scenario | % Change | Significance Factor |\n";
-    data += "|:---:|:---:|:---:|:---:|:---:|\n";
+    let columns = [
+      "Benchmark",
+      "Profile",
+      "Scenario",
+      "% Change",
+      "Significance Factor",
+    ];
+    if (showRawData) {
+      columns.push("Before", "After");
+    }
+
+    const toMarkdownRow = (cells: string[]) => {
+      return `| ${cells.join(" | ")} |\n`;
+    };
+
+    let data = toMarkdownRow(columns);
+    data += toMarkdownRow(Array(columns.length).fill(":---:")).replace(
+      / /g,
+      ""
+    );
 
     for (const comparison of comparisons) {
-      data += `| ${comparison.testCase.benchmark} | ${comparison.testCase.profile} | ${comparison.testCase.scenario} `;
-      data += `| ${comparison.percent.toFixed(
-        2
-      )}% | ${comparison.significanceFactor.toFixed(2)}x\n`;
+      let cells = [
+        comparison.testCase.benchmark,
+        comparison.testCase.profile,
+        comparison.testCase.scenario,
+        `${comparison.percent.toFixed(2)}%`,
+        `${comparison.significanceFactor.toFixed(2)}x`,
+      ];
+      if (showRawData) {
+        cells.push(comparison.datumA.toString(), comparison.datumB.toString());
+      }
+
+      data += toMarkdownRow(cells);
     }
 
     return data;


### PR DESCRIPTION
On Zulip, I saw [some people have expressed interest in adding a showRawData option for Markdown export](https://rust-lang.zulipchat.com/#narrow/stream/247081-t-compiler.2Fperformance/topic/Accumulating.20multiple.20reports.20into.20one/near/459515623), so this PR propose to add it.
I also created a `toMarkdownRow` function to reduce the chances of generating invalid Markdown, as the current implementation is missing the final `|` at the end of each row.