### PR TITLE
use gzip to compress self profile json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,10 @@
 version = 3
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "ahash"
@@ -768,9 +768,9 @@ checksum = "b3ea1ec5f8307826a5b71094dd91fc04d4ae75d5709b20ad351c7fb4815c86ec"
 
 [[package]]
 name = "flate2"
-version = "1.0.25"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+checksum = "9c0596c1eac1f9e04ed902702e9878208b336edc9d6fddc8a48387349bab3666"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1485,11 +1485,11 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.6.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
- "adler",
+ "adler2",
 ]
 
 [[package]]
@@ -2388,6 +2388,7 @@ dependencies = [
  "collector",
  "database",
  "env_logger",
+ "flate2",
  "futures",
  "hashbrown",
  "headers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ members = ["collector", "collector/benchlib", "site", "database", "intern"]
 exclude = ["rust/src"]
 resolver = "2"
 
+[workspace.dependencies]
+flate2 = "1.0.32"
+
 [profile.release.package.site]
 debug = 1
 

--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -30,7 +30,7 @@ jobserver = "0.1.21"
 snap = "1"
 filetime = "0.2.14"
 walkdir = "2"
-flate2 = { version = "1.0.22", features = ["rust_backend"] }
+flate2 = { workspace = true, features = ["rust_backend"] }
 rayon = "1.5.2"
 cargo_metadata = "0.15.0"
 thousands = "0.2.0"

--- a/site/Cargo.toml
+++ b/site/Cargo.toml
@@ -1,5 +1,9 @@
 [package]
-authors = ["Mark-Simulacrum <mark.simulacrum@gmail.com>", "Nicholas Cameron <ncameron@mozilla.com>", "The rustc-perf contributors"]
+authors = [
+    "Mark-Simulacrum <mark.simulacrum@gmail.com>",
+    "Nicholas Cameron <ncameron@mozilla.com>",
+    "The rustc-perf contributors",
+]
 name = "site"
 version = "0.1.0"
 edition = "2021"
@@ -42,10 +46,14 @@ mime = "0.3"
 prometheus = { version = "0.13", default-features = false }
 uuid = { version = "1.3.0", features = ["v4"] }
 tera = { version = "1.19", default-features = false }
-rust-embed = { version = "6.6.0", features = ["include-exclude", "interpolate-folder-path"] }
+rust-embed = { version = "6.6.0", features = [
+    "include-exclude",
+    "interpolate-folder-path",
+] }
 humansize = "2"
 lru = "0.12.0"
 ruzstd = "0.7.0"
+flate2 = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 jemallocator = "0.5"

--- a/site/src/request_handlers/self_profile.rs
+++ b/site/src/request_handlers/self_profile.rs
@@ -127,6 +127,8 @@ pub async fn handle_self_profile_processed_download(
             ContentType::from("image/svg+xml".parse::<mime::Mime>().unwrap())
         } else if output.filename.ends_with("html") {
             ContentType::html()
+        } else if output.filename.ends_with("gz") {
+            headers::ContentType::from("application/gzip".parse::<mime::Mime>().unwrap())
         } else {
             unreachable!()
         })


### PR DESCRIPTION
We're currently not compressing the results from the /perf/processed-self-profile endpoint, which sometimes leads to downloading files over 800MB. To reduce load times, this PR proposes adding gzip compression, which is supported by Perfetto. Compressing an 850MB JSON file takes about 4.4 seconds, but the size of compressed data is about 30 MB so this should somewhat improve performance.

Also, I'm using `headers::ContentType::from("application/gzip".parse::<mime::Mime>().unwrap())` because the mime crate doesn't support `application/gzip` and it seems to be unmaintained. 
https://github.com/hyperium/mime/pull/136