### PR TITLE
perf record with --call-graph=fp --freq=max

### DIFF
--- a/collector/src/bin/rustc-fake.rs
+++ b/collector/src/bin/rustc-fake.rs
@@ -234,9 +234,9 @@ fn main() {
                 let has_perf = cmd.output().is_ok();
                 assert!(has_perf);
                 cmd.arg("record")
-                    .arg("--call-graph=dwarf")
+                    .arg("--call-graph=fp")
                     .arg("--output=perf")
-                    .arg("--freq=299")
+                    .arg("--freq=max")
                     .arg("--event=cycles:u,instructions:u")
                     .arg(&tool)
                     .args(&args);


### PR DESCRIPTION
I've been carrying this patch locally for months/years; @Noratrieb asked me to make this PR.

I only find `profile_local perf-record` useful with this patch applied, because otherwise the profile doesn't have enough samples to make anything of the profile data. And since we're sampling as fast as possible to get a reasonable signal-to-noise ratio on a microbenchmark, we need to use frame pointers. Which are now enabled by default in the compiler profile, (and are enabled in the distributed standard library too!).