### PR TITLE
Modify CI permissions to fix nightly releases

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: "0 23 * * *"
 
+permissions:
+  contents: write
+
 jobs:
   publish_release:
     name: Publish release


### PR DESCRIPTION
Seems like the permissions could have been broken by the GH enterprise migration.

Hoping that this fixes [this](https://github.com/rust-lang/rustc-perf/actions/runs/10950183578/job/30404938315).

Inspired by https://github.com/ncipollo/release-action/issues/208#issuecomment-1398625039.