### PR TITLE
Switch self profile to use HW counters instead of walltime (attempt 2)

### DIFF
--- a/collector/src/bin/rustc-fake.rs
+++ b/collector/src/bin/rustc-fake.rs
@@ -119,6 +119,7 @@ fn main() {
                 let prof_out_dir = create_self_profile_dir();
                 if wrapper == "PerfStatSelfProfile" {
                     cmd.arg(format!("-Zself-profile={}", prof_out_dir.to_str().unwrap()));
+                    cmd.arg("-Zself-profile-counter=instructions:u");
                     let _ = fs::remove_dir_all(&prof_out_dir);
                     let _ = fs::create_dir_all(&prof_out_dir);
                 }

--- a/site/frontend/src/pages/detailed-query/page.vue
+++ b/site/frontend/src/pages/detailed-query/page.vue
@@ -391,8 +391,18 @@ loadData();
       </table>
 
       <p>
-        'Time (%)' is the percentage of the cpu-clock time spent on this query
-        (we do not use wall-time as we want to account for parallelism).
+        'Instructions (%)' is the percentage of instructions executed on this
+        query (we do not use wall-time as we want to account for parallelism).
+      </p>
+      <p>
+        <b
+          >Note: self-profile measurements have been
+          <a href="https://github.com/rust-lang/rustc-perf/pull/1984"
+            >recently switched</a
+          >
+          from wall-time to HW counters (instruction count). If comparing with
+          an older artifact, the timings might not be directly comparable.</b
+        >
       </p>
       <p>Executions do not include cached executions.</p>
 
@@ -408,21 +418,21 @@ loadData();
               <a
                 href="#"
                 @click.prevent="changeSortParameters('timePercent', 'desc')"
-                >Time (%)</a
+                >Instructions (%)</a
               >
             </th>
             <th :class="getHeaderClass('timeSeconds')">
               <a
                 href="#"
                 @click.prevent="changeSortParameters('timeSeconds', 'desc')"
-                >Time (s)</a
+                >Instructions</a
               >
             </th>
             <th v-if="showDelta" :class="getHeaderClass('timeDelta')">
               <a
                 href="#"
                 @click.prevent="changeSortParameters('timeDelta', 'desc')"
-                >Time delta</a
+                >Instructions delta</a
               >
             </th>
             <th :class="getHeaderClass('executions')">
@@ -442,14 +452,14 @@ loadData();
             <th
               v-if="showIncr"
               :class="getHeaderClass('incrementalLoading')"
-              title="Incremental loading time"
+              title="Incremental loading instructions"
             >
               <a
                 href="#"
                 @click.prevent="
                   changeSortParameters('incrementalLoading', 'desc')
                 "
-                >Incremental loading (s)</a
+                >Incremental loading (icounts)</a
               >
             </th>
             <th

--- a/site/frontend/src/pages/detailed-query/utils.ts
+++ b/site/frontend/src/pages/detailed-query/utils.ts
@@ -37,8 +37,8 @@ export interface SelfProfileResponse {
   base_profile_delta?: ProfileData;
 }
 
-export function toSeconds(time: number): number {
-  return time / 1000000000;
+export function normalizeValue(icounts: number): number {
+  return icounts;
 }
 
 export function createDelta(
@@ -259,24 +259,24 @@ export function createTableData(
             formatted: totals.percent_total_time.toFixed(2) + "%*",
             title: "% of cpu-time stat",
           },
-    timeSeconds: toSeconds(totals.self_time),
+    timeSeconds: normalizeValue(totals.self_time),
     timeDelta: totalsDelta
       ? createDelta(
-          toSeconds(totals.self_time),
-          toSeconds(totalsDelta.self_time),
-          false
+          normalizeValue(totals.self_time),
+          normalizeValue(totalsDelta.self_time),
+          true
         )
       : null,
     executions: totals.invocation_count,
     executionsDelta: totalsDelta
       ? createDelta(totals.invocation_count, totalsDelta.invocation_count, true)
       : null,
-    incrementalLoading: toSeconds(totals.incremental_load_time),
+    incrementalLoading: normalizeValue(totals.incremental_load_time),
     incrementalLoadingDelta: totalsDelta
       ? createDelta(
-          toSeconds(totals.incremental_load_time),
-          toSeconds(totalsDelta.incremental_load_time),
-          false
+          normalizeValue(totals.incremental_load_time),
+          normalizeValue(totalsDelta.incremental_load_time),
+          true
         )
       : null,
   });
@@ -299,24 +299,24 @@ export function createTableData(
               formatted: query.percent_total_time.toFixed(2) + "%",
               title: "",
             },
-      timeSeconds: toSeconds(query.self_time),
+      timeSeconds: normalizeValue(query.self_time),
       timeDelta: queryDelta
         ? createDelta(
-            toSeconds(query.self_time),
-            toSeconds(queryDelta.self_time),
-            false
+            normalizeValue(query.self_time),
+            normalizeValue(queryDelta.self_time),
+            true
           )
         : null,
       executions: query.invocation_count,
       executionsDelta: queryDelta
         ? createDelta(query.invocation_count, queryDelta.invocation_count, true)
         : null,
-      incrementalLoading: toSeconds(query.incremental_load_time),
+      incrementalLoading: normalizeValue(query.incremental_load_time),
       incrementalLoadingDelta: queryDelta
         ? createDelta(
-            toSeconds(query.incremental_load_time),
-            toSeconds(queryDelta.incremental_load_time),
-            false
+            normalizeValue(query.incremental_load_time),
+            normalizeValue(queryDelta.incremental_load_time),
+            true
           )
         : null,
     });

--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -470,19 +470,23 @@ pub mod self_profile {
         pub artifact_sizes: Option<Vec<ArtifactSize>>,
     }
 
+    // Due to backwards compatibility, self profile event timing data is represented as durations,
+    // however since https://github.com/rust-lang/rustc-perf/pull/1647 it actually represents
+    // HW counter data (instruction counts).
     #[derive(Serialize, Deserialize, Clone, Debug)]
     pub struct QueryData {
         pub label: QueryLabel,
-        // Nanoseconds
+        // Instruction count
         pub time: u64,
+        // Instruction count
         pub self_time: u64,
         pub percent_total_time: f32,
         pub number_of_cache_misses: u32,
         pub number_of_cache_hits: u32,
         pub invocation_count: u32,
-        // Nanoseconds
+        // Instruction count
         pub blocked_time: u64,
-        // Nanoseconds
+        // Instruction count
         pub incremental_load_time: u64,
     }
 

--- a/site/src/request_handlers/self_profile.rs
+++ b/site/src/request_handlers/self_profile.rs
@@ -460,7 +460,7 @@ pub async fn handle_self_profile(
         .benchmark(selector::Selector::One(bench_name.to_string()))
         .profile(selector::Selector::One(profile.parse().unwrap()))
         .scenario(selector::Selector::One(scenario))
-        .metric(selector::Selector::One(Metric::CpuClock));
+        .metric(selector::Selector::One(Metric::InstructionsUser));
 
     // Helper for finding an `ArtifactId` based on a commit sha
     let find_aid = |commit: &str| {

--- a/site/src/request_handlers/self_profile.rs
+++ b/site/src/request_handlers/self_profile.rs
@@ -475,9 +475,9 @@ pub async fn handle_self_profile(
     }
     let commits = Arc::new(commits);
 
-    let mut cpu_responses = ctxt.statistic_series(query, commits.clone()).await?;
-    assert_eq!(cpu_responses.len(), 1, "all selectors are exact");
-    let mut cpu_response = cpu_responses.remove(0).series;
+    let mut instructions_responses = ctxt.statistic_series(query, commits.clone()).await?;
+    assert_eq!(instructions_responses.len(), 1, "all selectors are exact");
+    let mut instructions_response = instructions_responses.remove(0).series;
 
     let mut self_profile = get_or_download_self_profile(
         ctxt,
@@ -485,7 +485,7 @@ pub async fn handle_self_profile(
         bench_name,
         profile,
         scenario,
-        cpu_response.next().unwrap().1,
+        instructions_response.next().unwrap().1,
     )
     .await?;
     let base_self_profile = match commits.get(1) {
@@ -496,7 +496,7 @@ pub async fn handle_self_profile(
                 bench_name,
                 profile,
                 scenario,
-                cpu_response.next().unwrap().1,
+                instructions_response.next().unwrap().1,
             )
             .await?,
         ),

--- a/site/src/self_profile.rs
+++ b/site/src/self_profile.rs
@@ -318,7 +318,7 @@ pub(crate) async fn get_or_download_self_profile(
 }
 
 fn get_self_profile_data(
-    cpu_clock: Option<f64>,
+    total_instructions: Option<f64>,
     profile: &analyzeme::AnalysisResults,
 ) -> ServerResult<self_profile::SelfProfile> {
     let total_self_time: Duration = profile.query_data.iter().map(|qd| qd.self_time).sum();
@@ -345,7 +345,7 @@ fn get_self_profile_data(
         time: profile.total_time.as_nanos() as u64,
         self_time: total_self_time.as_nanos() as u64,
         // TODO: check against wall-time from perf stats
-        percent_total_time: cpu_clock
+        percent_total_time: total_instructions
             .map(|w| ((total_self_time.as_secs_f64() / w) * 100.0) as f32)
             // sentinel "we couldn't compute this time"
             .unwrap_or(-100.0),


### PR DESCRIPTION
This is a second attempt to land https://github.com/rust-lang/rustc-perf/pull/1647, which was later reverted in https://github.com/rust-lang/rustc-perf/pull/1700.

I tried to manually SSH into the collector server and run the whole benchmark suite with `--self-profile` using icounts. It went through. I'd like to try this on the live server to see what happens. If it fails again, we'll know more to see where we should investigate the failure.