### PR TITLE
Add optional `backends` parameter to benchmarking requests

### DIFF
--- a/collector/src/api.rs
+++ b/collector/src/api.rs
@@ -9,6 +9,7 @@ pub mod next_artifact {
             include: Option<String>,
             exclude: Option<String>,
             runs: Option<i32>,
+            backends: Option<String>,
         },
     }
 

--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -968,10 +968,11 @@ fn main_result() -> anyhow::Result<i32> {
                         // majority of cases.
                         let mut backends = vec![];
                         if let Some(requested_backends) = requested_backends {
-                            if requested_backends.contains("Llvm") {
+                            let requested_backends = requested_backends.to_lowercase();
+                            if requested_backends.contains("llvm") {
                                 backends.push(CodegenBackend::Llvm);
                             }
-                            if requested_backends.contains("Cranelift") {
+                            if requested_backends.contains("cranelift") {
                                 backends.push(CodegenBackend::Cranelift);
                             }
                         }

--- a/collector/src/toolchain.rs
+++ b/collector/src/toolchain.rs
@@ -20,11 +20,7 @@ pub struct Sysroot {
 }
 
 impl Sysroot {
-    pub fn install(
-        sha: String,
-        triple: &str,
-        backends: Vec<CodegenBackend>,
-    ) -> anyhow::Result<Self> {
+    pub fn install(sha: String, triple: &str, backends: &[CodegenBackend]) -> anyhow::Result<Self> {
         let unpack_into = "cache";
 
         fs::create_dir_all(unpack_into)?;

--- a/database/schema.md
+++ b/database/schema.md
@@ -238,11 +238,12 @@ is attached to the entry in this table, it can be benchmarked.
 * exclude: which benchmarks should be excluded (corresponds to the `--exclude` benchmark parameter)
 * runs: how many iterations should be used by default for the benchmark run
 * commit_date: when was the commit created
+* backends: the codegen backends to use for the benchmarks (corresponds to the `--backends` benchmark parameter)
 
 ```
 sqlite> select * from pull_request_build limit 1;
-bors_sha    pr  parent_sha  complete  requested    include  exclude  runs  commit_date
-----------  --  ----------  --------  ---------    -------  -------  ----  -----------
+bors_sha    pr  parent_sha  complete  requested    include  exclude  runs  commit_date  backends
+----------  --  ----------  --------  ---------    -------  -------  ----  -----------  --------
 1w0p83...   42  fq24xq...   true      <timestamp>                    3     <timestamp>
 ```
 

--- a/database/src/bin/postgres-to-sqlite.rs
+++ b/database/src/bin/postgres-to-sqlite.rs
@@ -275,13 +275,13 @@ impl Table for PullRequestBuild {
     }
 
     fn postgres_select_statement(&self, _since_weeks_ago: Option<u32>) -> String {
-        "select bors_sha, pr, parent_sha, complete, requested, include, exclude, runs from "
+        "select bors_sha, pr, parent_sha, complete, requested, include, exclude, runs, backends from "
             .to_string()
             + self.name()
     }
 
     fn sqlite_insert_statement(&self) -> &'static str {
-        "insert into pull_request_build (bors_sha, pr, parent_sha, complete, requested, include, exclude, runs) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+        "insert into pull_request_build (bors_sha, pr, parent_sha, complete, requested, include, exclude, runs, backends) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
     }
 
     fn sqlite_execute_insert(&self, statement: &mut rusqlite::Statement, row: tokio_postgres::Row) {
@@ -296,6 +296,7 @@ impl Table for PullRequestBuild {
                 row.get::<_, Option<&str>>(5),
                 row.get::<_, Option<&str>>(6),
                 row.get::<_, Option<i32>>(7),
+                row.get::<_, Option<&str>>(8),
             ])
             .unwrap();
     }

--- a/database/src/bin/sqlite-to-postgres.rs
+++ b/database/src/bin/sqlite-to-postgres.rs
@@ -369,6 +369,7 @@ struct PullRequestBuildRow<'a> {
     exclude: Nullable<&'a str>,
     runs: Nullable<i32>,
     commit_date: Nullable<DateTime<Utc>>,
+    backends: Nullable<&'a str>,
 }
 
 impl Table for PullRequestBuild {
@@ -377,11 +378,11 @@ impl Table for PullRequestBuild {
     }
 
     fn sqlite_attributes() -> &'static str {
-        "bors_sha, pr, parent_sha, complete, requested, include, exclude, runs, commit_date"
+        "bors_sha, pr, parent_sha, complete, requested, include, exclude, runs, commit_date, backends"
     }
 
     fn postgres_attributes() -> &'static str {
-        "bors_sha, pr, parent_sha, complete, requested, include, exclude, runs, commit_date"
+        "bors_sha, pr, parent_sha, complete, requested, include, exclude, runs, commit_date, backends"
     }
 
     fn postgres_generated_id_attribute() -> Option<&'static str> {
@@ -407,6 +408,7 @@ impl Table for PullRequestBuild {
                 commit_date: Nullable(
                     commit_date.map(|seconds| Utc.timestamp_opt(seconds, 0).unwrap()),
                 ),
+                backends: row.get_ref(9).unwrap().try_into().unwrap(),
             })
             .unwrap();
     }

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -28,6 +28,7 @@ pub struct QueuedCommit {
     pub exclude: Option<String>,
     pub runs: Option<i32>,
     pub commit_date: Option<Date>,
+    pub backends: Option<String>,
 }
 
 #[derive(Debug, Hash, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -121,6 +121,7 @@ pub trait Connection: Send + Sync {
         include: Option<&str>,
         exclude: Option<&str>,
         runs: Option<i32>,
+        backends: Option<&str>,
     );
     /// Returns true if this PR was queued waiting for a commit
     async fn pr_attach_commit(

--- a/site/frontend/src/pages/status/data.ts
+++ b/site/frontend/src/pages/status/data.ts
@@ -39,6 +39,7 @@ export type MissingReason =
         include: string | null;
         exclude: string | null;
         runs: number | null;
+        backends: string | null;
       };
     }
   | {

--- a/site/src/load.rs
+++ b/site/src/load.rs
@@ -33,6 +33,7 @@ pub enum MissingReason {
         include: Option<String>,
         exclude: Option<String>,
         runs: Option<i32>,
+        backends: Option<String>,
     },
     InProgress(Option<Box<MissingReason>>),
 }
@@ -382,6 +383,7 @@ fn calculate_missing_from(
         exclude,
         runs,
         commit_date,
+        backends,
     } in queued_pr_commits
         .into_iter()
         // filter out any queued PR master commits (leaving only try commits)
@@ -407,6 +409,7 @@ fn calculate_missing_from(
                 include,
                 exclude,
                 runs,
+                backends,
             },
         ));
     }
@@ -579,6 +582,7 @@ mod tests {
                 exclude: None,
                 runs: None,
                 commit_date: None,
+                backends: None,
             },
             QueuedCommit {
                 sha: "b".into(),
@@ -588,6 +592,7 @@ mod tests {
                 exclude: None,
                 runs: None,
                 commit_date: None,
+                backends: None,
             },
             QueuedCommit {
                 sha: "a".into(),
@@ -597,6 +602,7 @@ mod tests {
                 exclude: None,
                 runs: None,
                 commit_date: None,
+                backends: None,
             },
         ];
         let in_progress_artifacts = vec![];
@@ -640,6 +646,7 @@ mod tests {
                     include: None,
                     exclude: None,
                     runs: None,
+                    backends: None,
                 },
             ),
         ];
@@ -689,6 +696,7 @@ mod tests {
                 exclude: None,
                 runs: None,
                 commit_date: None,
+                backends: None,
             },
             // A try run
             QueuedCommit {
@@ -699,6 +707,7 @@ mod tests {
                 exclude: None,
                 runs: None,
                 commit_date: None,
+                backends: None,
             },
         ];
         let in_progress_artifacts = vec![];
@@ -746,6 +755,7 @@ mod tests {
                     include: None,
                     exclude: None,
                     runs: None,
+                    backends: None,
                 },
             ),
         ];

--- a/site/src/request_handlers/github.rs
+++ b/site/src/request_handlers/github.rs
@@ -325,7 +325,7 @@ mod tests {
     #[test]
     fn build_command() {
         insta::assert_compact_debug_snapshot!(get_build_commands("@rust-timer build 5832462aa1d9373b24ace96ad2c50b7a18af9952"),
-            @r###"[Ok(BuildCommand { sha: "5832462aa1d9373b24ace96ad2c50b7a18af9952", params: BenchmarkParameters { include: None, exclude: None, runs: None } })]"###);
+            @r#"[Ok(BuildCommand { sha: "5832462aa1d9373b24ace96ad2c50b7a18af9952", params: BenchmarkParameters { include: None, exclude: None, runs: None, backends: None } })]"#);
     }
 
     #[test]
@@ -334,7 +334,7 @@ mod tests {
 @rust-timer build 5832462aa1d9373b24ace96ad2c50b7a18af9952
 @rust-timer build 23936af287657fa4148aeab40cc2a780810fae52
 "#),
-            @r###"[Ok(BuildCommand { sha: "5832462aa1d9373b24ace96ad2c50b7a18af9952", params: BenchmarkParameters { include: None, exclude: None, runs: None } }), Ok(BuildCommand { sha: "23936af287657fa4148aeab40cc2a780810fae52", params: BenchmarkParameters { include: None, exclude: None, runs: None } })]"###);
+            @r#"[Ok(BuildCommand { sha: "5832462aa1d9373b24ace96ad2c50b7a18af9952", params: BenchmarkParameters { include: None, exclude: None, runs: None, backends: None } }), Ok(BuildCommand { sha: "23936af287657fa4148aeab40cc2a780810fae52", params: BenchmarkParameters { include: None, exclude: None, runs: None, backends: None } })]"#);
     }
 
     #[test]
@@ -346,14 +346,14 @@ mod tests {
     #[test]
     fn build_command_complex() {
         insta::assert_compact_debug_snapshot!(get_build_commands("  @rust-timer  build    sha123456  exclude=baz    include=foo,bar runs=4"),
-            @r###"[Ok(BuildCommand { sha: "sha123456", params: BenchmarkParameters { include: Some("foo,bar"), exclude: Some("baz"), runs: Some(4) } })]"###);
+            @r#"[Ok(BuildCommand { sha: "sha123456", params: BenchmarkParameters { include: Some("foo,bar"), exclude: Some("baz"), runs: Some(4), backends: None } })]"#);
     }
 
     #[test]
     fn build_command_link() {
         insta::assert_compact_debug_snapshot!(get_build_commands(r#"
 @rust-timer build https://github.com/rust-lang/rust/commit/323f521bc6d8f2b966ba7838a3f3ee364e760b7e"#),
-            @r###"[Ok(BuildCommand { sha: "323f521bc6d8f2b966ba7838a3f3ee364e760b7e", params: BenchmarkParameters { include: None, exclude: None, runs: None } })]"###);
+            @r#"[Ok(BuildCommand { sha: "323f521bc6d8f2b966ba7838a3f3ee364e760b7e", params: BenchmarkParameters { include: None, exclude: None, runs: None, backends: None } })]"#);
     }
 
     #[test]
@@ -369,7 +369,7 @@ mod tests {
     #[test]
     fn queue_command() {
         insta::assert_compact_debug_snapshot!(parse_queue_command("@rust-timer queue"),
-            @"Some(Ok(QueueCommand { params: BenchmarkParameters { include: None, exclude: None, runs: None } }))");
+            @"Some(Ok(QueueCommand { params: BenchmarkParameters { include: None, exclude: None, runs: None, backends: None } }))");
     }
 
     #[test]
@@ -387,19 +387,19 @@ mod tests {
     #[test]
     fn queue_command_include() {
         insta::assert_compact_debug_snapshot!(parse_queue_command("@rust-timer queue include=abcd,feih"),
-            @r###"Some(Ok(QueueCommand { params: BenchmarkParameters { include: Some("abcd,feih"), exclude: None, runs: None } }))"###);
+            @r#"Some(Ok(QueueCommand { params: BenchmarkParameters { include: Some("abcd,feih"), exclude: None, runs: None, backends: None } }))"#);
     }
 
     #[test]
     fn queue_command_exclude() {
         insta::assert_compact_debug_snapshot!(parse_queue_command("@rust-timer queue exclude=foo134,barzbaz41baf"),
-            @r###"Some(Ok(QueueCommand { params: BenchmarkParameters { include: None, exclude: Some("foo134,barzbaz41baf"), runs: None } }))"###);
+            @r#"Some(Ok(QueueCommand { params: BenchmarkParameters { include: None, exclude: Some("foo134,barzbaz41baf"), runs: None, backends: None } }))"#);
     }
 
     #[test]
     fn queue_command_runs() {
         insta::assert_compact_debug_snapshot!(parse_queue_command("@rust-timer queue runs=5"),
-            @"Some(Ok(QueueCommand { params: BenchmarkParameters { include: None, exclude: None, runs: Some(5) } }))");
+            @"Some(Ok(QueueCommand { params: BenchmarkParameters { include: None, exclude: None, runs: Some(5), backends: None } }))");
     }
 
     #[test]
@@ -411,7 +411,7 @@ mod tests {
     #[test]
     fn queue_command_combination() {
         insta::assert_compact_debug_snapshot!(parse_queue_command("@rust-timer queue include=acda,13asd exclude=c13,DA runs=5"),
-            @r###"Some(Ok(QueueCommand { params: BenchmarkParameters { include: Some("acda,13asd"), exclude: Some("c13,DA"), runs: Some(5) } }))"###);
+            @r#"Some(Ok(QueueCommand { params: BenchmarkParameters { include: Some("acda,13asd"), exclude: Some("c13,DA"), runs: Some(5), backends: None } }))"#);
     }
 
     #[test]
@@ -423,19 +423,19 @@ mod tests {
     #[test]
     fn queue_command_spaces() {
         insta::assert_compact_debug_snapshot!(parse_queue_command("@rust-timer     queue     include=abcd,das   "),
-            @r###"Some(Ok(QueueCommand { params: BenchmarkParameters { include: Some("abcd,das"), exclude: None, runs: None } }))"###);
+            @r#"Some(Ok(QueueCommand { params: BenchmarkParameters { include: Some("abcd,das"), exclude: None, runs: None, backends: None } }))"#);
     }
 
     #[test]
     fn queue_command_with_bors() {
         insta::assert_compact_debug_snapshot!(parse_queue_command("@bors try @rust-timer queue include=foo,bar"),
-            @r###"Some(Ok(QueueCommand { params: BenchmarkParameters { include: Some("foo,bar"), exclude: None, runs: None } }))"###);
+            @r#"Some(Ok(QueueCommand { params: BenchmarkParameters { include: Some("foo,bar"), exclude: None, runs: None, backends: None } }))"#);
     }
 
     #[test]
     fn queue_command_parameter_order() {
         insta::assert_compact_debug_snapshot!(parse_queue_command("@rust-timer queue runs=3 exclude=c,a include=b"),
-        @r###"Some(Ok(QueueCommand { params: BenchmarkParameters { include: Some("b"), exclude: Some("c,a"), runs: Some(3) } }))"###);
+            @r#"Some(Ok(QueueCommand { params: BenchmarkParameters { include: Some("b"), exclude: Some("c,a"), runs: Some(3), backends: None } }))"#);
     }
 
     #[test]
@@ -446,10 +446,42 @@ Let's do a perf run quickly and then we can merge it.
 @bors try @rust-timer queue include=foo,bar
 
 Otherwise LGTM."#),
-            @r###"Some(Ok(QueueCommand { params: BenchmarkParameters { include: Some("foo,bar"), exclude: None, runs: None } }))"###);
+            @r#"Some(Ok(QueueCommand { params: BenchmarkParameters { include: Some("foo,bar"), exclude: None, runs: None, backends: None } }))"#);
     }
 
     fn get_build_commands(body: &str) -> Vec<Result<BuildCommand, String>> {
         parse_build_commands(body).collect()
+    }
+
+    #[test]
+    fn build_command_with_backends() {
+        insta::assert_compact_debug_snapshot!(get_build_commands(r#"@rust-timer build 5832462aa1d9373b24ace96ad2c50b7a18af995G"#),
+            @r#"[Ok(BuildCommand { sha: "5832462aa1d9373b24ace96ad2c50b7a18af995G", params: BenchmarkParameters { include: None, exclude: None, runs: None, backends: None } })]"#);
+        insta::assert_compact_debug_snapshot!(get_build_commands(r#"@rust-timer build 5832462aa1d9373b24ace96ad2c50b7a18af995A backends=Llvm"#),
+            @r#"[Ok(BuildCommand { sha: "5832462aa1d9373b24ace96ad2c50b7a18af995A", params: BenchmarkParameters { include: None, exclude: None, runs: None, backends: Some("Llvm") } })]"#);
+        insta::assert_compact_debug_snapshot!(get_build_commands(r#"@rust-timer build 23936af287657fa4148aeab40cc2a780810fae5B backends=Cranelift"#),
+            @r#"[Ok(BuildCommand { sha: "23936af287657fa4148aeab40cc2a780810fae5B", params: BenchmarkParameters { include: None, exclude: None, runs: None, backends: Some("Cranelift") } })]"#);
+        insta::assert_compact_debug_snapshot!(get_build_commands(r#"@rust-timer build 23936af287657fa4148aeab40cc2a780810fae5C backends=Cranelift,Llvm"#),
+            @r#"[Ok(BuildCommand { sha: "23936af287657fa4148aeab40cc2a780810fae5C", params: BenchmarkParameters { include: None, exclude: None, runs: None, backends: Some("Cranelift,Llvm") } })]"#);
+        insta::assert_compact_debug_snapshot!(get_build_commands(r#"@rust-timer build 5832462aa1d9373b24ace96ad2c50b7a18af995D include=hello backends=Llvm"#),
+            @r#"[Ok(BuildCommand { sha: "5832462aa1d9373b24ace96ad2c50b7a18af995D", params: BenchmarkParameters { include: Some("hello"), exclude: None, runs: None, backends: Some("Llvm") } })]"#);
+        insta::assert_compact_debug_snapshot!(get_build_commands(r#"@rust-timer build 5832462aa1d9373b24ace96ad2c50b7a18af995E runs=10 backends=Llvm"#),
+            @r#"[Ok(BuildCommand { sha: "5832462aa1d9373b24ace96ad2c50b7a18af995E", params: BenchmarkParameters { include: None, exclude: None, runs: Some(10), backends: Some("Llvm") } })]"#);
+    }
+
+    #[test]
+    fn queue_command_with_backends() {
+        insta::assert_compact_debug_snapshot!(parse_queue_command("@rust-timer queue backends=Llvm"),
+            @r#"Some(Ok(QueueCommand { params: BenchmarkParameters { include: None, exclude: None, runs: None, backends: Some("Llvm") } }))"#);
+        insta::assert_compact_debug_snapshot!(parse_queue_command("@rust-timer queue backends=Cranelift"),
+            @r#"Some(Ok(QueueCommand { params: BenchmarkParameters { include: None, exclude: None, runs: None, backends: Some("Cranelift") } }))"#);
+        insta::assert_compact_debug_snapshot!(parse_queue_command("@rust-timer queue backends=Cranelift,Llvm"),
+            @r#"Some(Ok(QueueCommand { params: BenchmarkParameters { include: None, exclude: None, runs: None, backends: Some("Cranelift,Llvm") } }))"#);
+        insta::assert_compact_debug_snapshot!(parse_queue_command("@rust-timer queue"),
+            @"Some(Ok(QueueCommand { params: BenchmarkParameters { include: None, exclude: None, runs: None, backends: None } }))");
+        insta::assert_compact_debug_snapshot!(parse_queue_command("@rust-timer queue include=hello backends=Llvm"),
+            @r#"Some(Ok(QueueCommand { params: BenchmarkParameters { include: Some("hello"), exclude: None, runs: None, backends: Some("Llvm") } }))"#);
+        insta::assert_compact_debug_snapshot!(parse_queue_command("@rust-timer queue include=hello exclude=ripgrep runs=3 backends=Llvm"),
+            @r#"Some(Ok(QueueCommand { params: BenchmarkParameters { include: Some("hello"), exclude: Some("ripgrep"), runs: Some(3), backends: Some("Llvm") } }))"#);
     }
 }

--- a/site/src/request_handlers/github.rs
+++ b/site/src/request_handlers/github.rs
@@ -119,6 +119,7 @@ async fn handle_rust_timer(
                     cmd.params.include,
                     cmd.params.exclude,
                     cmd.params.runs,
+                    cmd.params.backends,
                 )
                 .await;
                 format!(
@@ -158,6 +159,7 @@ async fn handle_rust_timer(
                 command.params.include,
                 command.params.exclude,
                 command.params.runs,
+                command.params.backends,
             )
             .await;
         }
@@ -225,6 +227,7 @@ fn parse_benchmark_parameters<'a>(
         include: args.remove("include"),
         exclude: args.remove("exclude"),
         runs: None,
+        backends: args.remove("backends"),
     };
     if let Some(runs) = args.remove("runs") {
         let Ok(runs) = runs.parse::<u32>() else {
@@ -280,6 +283,7 @@ struct BenchmarkParameters<'a> {
     include: Option<&'a str>,
     exclude: Option<&'a str>,
     runs: Option<i32>,
+    backends: Option<&'a str>,
 }
 
 pub async fn get_authorized_users() -> Result<Vec<u64>, String> {


### PR DESCRIPTION
Opening as draft as I don't know how to test this: how do I simulate locally a request to benchmark a try build @Kobzol? Do I have to manually add rows to the database like in the 18th century?! :p.

This should 🤞  allow choosing which codegen backends we want to use for benchmarks, from the GH benchmarking requests. Hopefully. Maybe. I don't know how to test that it works, I don't know where is the documentation describing how to run these realistic workflows locally.

(Note that I chose to specifically not document the parameter in the help page, until we can test it out a bit in the real world, after this PR is completed)