### PR TITLE
Use a manual parser for `@rust-timer` commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1258,6 +1258,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6593a41c7a73841868772495db7dc1e8ecab43bb5c0b6da2059246c4b506ab60"
+dependencies = [
+ "console",
+ "lazy_static",
+ "linked-hash-map",
+ "similar",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1399,6 +1411,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2430,6 +2448,7 @@ dependencies = [
  "humansize",
  "hyper",
  "inferno",
+ "insta",
  "itertools",
  "jemalloc-ctl",
  "jemallocator",

--- a/site/Cargo.toml
+++ b/site/Cargo.toml
@@ -57,3 +57,6 @@ jemalloc-ctl = "0.5"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 toml = "0.7"
+
+[dev-dependencies]
+insta = "1.40.0"

--- a/site/README.md
+++ b/site/README.md
@@ -46,3 +46,8 @@ the `PORT` environment variable.
 ```console
 $ ./target/release/site <database>
 ```
+
+## Development
+We use [insta](https://github.com/mitsuhiko/insta) for snapshot testing. If any tests that use the
+`insta` macros fail, you should `cargo install cargo-insta` and then run `cargo insta review` to review
+the snapshot changes.


### PR DESCRIPTION
Instead of a regex. This allows the user to pass the arguments in an arbitrary order.