### PR TITLE
Remove artifact from PR queue when purging it

### DIFF
--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -1344,6 +1344,13 @@ where
             .execute("delete from artifact where name = $1", &[&info.name])
             .await
             .unwrap();
+        self.conn()
+            .execute(
+                "delete from pull_request_build where bors_sha = $1",
+                &[&info.name],
+            )
+            .await
+            .unwrap();
     }
 }
 

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -1216,6 +1216,12 @@ impl Connection for SqliteConnection {
         self.raw_ref()
             .execute("delete from artifact where name = ?1", [info.name])
             .unwrap();
+        self.raw_ref()
+            .execute(
+                "delete from pull_request_build where bors_sha = ?1",
+                [info.name],
+            )
+            .unwrap();
     }
 }
 


### PR DESCRIPTION
This should make the `purge_artifact` command more universal, and really purge the given artifact from all places in DB.