### PR TITLE
Add UI for comparing backend results

### DIFF
--- a/site/frontend/src/pages/compare/compile/benchmarks.vue
+++ b/site/frontend/src/pages/compare/compile/benchmarks.vue
@@ -16,6 +16,7 @@ export interface BenchmarkProps {
   benchmarkMap: CompileBenchmarkMap;
   filter: CompileBenchmarkFilter;
   stat: string;
+  showBackend: boolean;
 }
 
 const props = defineProps<BenchmarkProps>();
@@ -77,6 +78,7 @@ const secondaryHasNonRelevant = computed(
       :commit-b="data.b"
       :stat="stat"
       :benchmark-map="benchmarkMap"
+      :show-backend="showBackend"
     >
       <template #header>
         <Section title="Primary" link="secondary" :linkUp="false"></Section>
@@ -92,6 +94,7 @@ const secondaryHasNonRelevant = computed(
       :commit-b="data.b"
       :stat="stat"
       :benchmark-map="benchmarkMap"
+      :show-backend="showBackend"
     >
       <template #header>
         <Section title="Secondary" link="primary" :linkUp="true"></Section>

--- a/site/frontend/src/pages/compare/compile/common.ts
+++ b/site/frontend/src/pages/compare/compile/common.ts
@@ -245,13 +245,12 @@ export function transformDataForBackendComparison(
     }
   }
 
-  const transformed = [];
-  benchmarkMap.forEach((entry) => {
+  return Array.from(benchmarkMap, ([_, entry]) => {
     const comparison: CompileBenchmarkComparison = {
       benchmark: entry.benchmark,
       profile: entry.profile,
       scenario: entry.scenario,
-      // Treat the backend as LLVM
+      // Treat LLVM as the baseline
       backend: "llvm",
       comparison: {
         statistics: [entry.llvm, entry.cranelift],
@@ -260,8 +259,6 @@ export function transformDataForBackendComparison(
         significance_threshold: 1.0,
       },
     };
-    transformed.push(comparison);
+    return comparison;
   });
-
-  return transformed;
 }

--- a/site/frontend/src/pages/compare/compile/common.ts
+++ b/site/frontend/src/pages/compare/compile/common.ts
@@ -206,5 +206,5 @@ export function createCompileBenchmarkMap(
 }
 
 export function testCaseKey(testCase: CompileTestCase): string {
-  return `${testCase.benchmark};${testCase.profile};${testCase.scenario};${testCase.category}`;
+  return `${testCase.benchmark};${testCase.profile};${testCase.scenario};${testCase.backend};${testCase.category}`;
 }

--- a/site/frontend/src/pages/compare/compile/common.ts
+++ b/site/frontend/src/pages/compare/compile/common.ts
@@ -27,6 +27,7 @@ export type CompileBenchmarkFilter = {
     binary: boolean;
     library: boolean;
   };
+  selfCompareBackend: boolean;
 } & BenchmarkFilter;
 
 export const defaultCompileFilter: CompileBenchmarkFilter = {
@@ -57,6 +58,7 @@ export const defaultCompileFilter: CompileBenchmarkFilter = {
     binary: true,
     library: true,
   },
+  selfCompareBackend: false,
 };
 
 export type Profile = "check" | "debug" | "opt" | "doc";

--- a/site/frontend/src/pages/compare/compile/common.ts
+++ b/site/frontend/src/pages/compare/compile/common.ts
@@ -208,3 +208,58 @@ export function createCompileBenchmarkMap(
 export function testCaseKey(testCase: CompileTestCase): string {
   return `${testCase.benchmark};${testCase.profile};${testCase.scenario};${testCase.backend};${testCase.category}`;
 }
+
+// Transform compile comparisons to compare LLVM vs Cranelift, instead of
+// before/after. Assumes that the data comes from the same commit.
+export function transformDataForBackendComparison(
+  comparisons: CompileBenchmarkComparison[]
+): CompileBenchmarkComparison[] {
+  const benchmarkMap: Map<
+    string,
+    {
+      llvm: number | null;
+      cranelift: number | null;
+      benchmark: string;
+      profile: Profile;
+      scenario: string;
+    }
+  > = new Map();
+  for (const comparison of comparisons) {
+    const key = `${comparison.benchmark};${comparison.profile};${comparison.scenario}`;
+    if (!benchmarkMap.has(key)) {
+      benchmarkMap.set(key, {
+        llvm: null,
+        cranelift: null,
+        benchmark: comparison.benchmark,
+        profile: comparison.profile,
+        scenario: comparison.scenario,
+      });
+    }
+    const record = benchmarkMap.get(key);
+    if (comparison.backend === "llvm") {
+      record.llvm = comparison.comparison.statistics[0];
+    } else if (comparison.backend === "cranelift") {
+      record.cranelift = comparison.comparison.statistics[0];
+    }
+  }
+
+  const transformed = [];
+  benchmarkMap.forEach((entry) => {
+    const comparison: CompileBenchmarkComparison = {
+      benchmark: entry.benchmark,
+      profile: entry.profile,
+      scenario: entry.scenario,
+      // Treat the backend as LLVM
+      backend: "llvm",
+      comparison: {
+        statistics: [entry.llvm, entry.cranelift],
+        is_relevant: true,
+        significance_factor: 1.0,
+        significance_threshold: 1.0,
+      },
+    };
+    transformed.push(comparison);
+  });
+
+  return transformed;
+}

--- a/site/frontend/src/pages/compare/compile/compile-page.vue
+++ b/site/frontend/src/pages/compare/compile/compile-page.vue
@@ -272,7 +272,7 @@ const filteredSummary = computed(() => computeSummary(comparisons.value));
   <OverallSummary :summary="filteredSummary" />
   <Aggregations :cases="comparisons" />
   <div class="warning" v-if="selfCompareBackend">
-    Comparing LLVM against Cranelift!
+    Comparing Cranelift against LLVM baseline!
   </div>
   <Benchmarks
     :data="data"

--- a/site/frontend/src/pages/compare/compile/compile-page.vue
+++ b/site/frontend/src/pages/compare/compile/compile-page.vue
@@ -217,23 +217,20 @@ const filter = ref(loadFilterFromUrl(urlParams, defaultCompileFilter));
 
 // Should we use the backend as the source of before/after data?
 const selfCompareBackend = computed(() => {
+  return canCompareBackends.value && filter.value.selfCompareBackend;
+});
+const canCompareBackends = computed(() => {
   const hasMultipleBackends =
     new Set(props.data.compile_comparisons.map((c) => c.backend)).size > 1;
-  return (
-    comparesIdenticalCommits.value &&
-    filter.value.selfCompareBackend &&
-    hasMultipleBackends
-  );
+  // Are we currently comparing the same commit in the before/after toolchains?
+  const comparesSameCommit = props.data.a.commit === props.data.b.commit;
+  return hasMultipleBackends && comparesSameCommit;
 });
 
 function exportData() {
   exportToMarkdown(comparisons.value, filter.value.showRawData);
 }
 
-// Are we currently comparing the same commit in the before/after toolchains?
-const comparesIdenticalCommits = computed(() => {
-  return props.data.a.commit === props.data.b.commit;
-});
 const benchmarkMap = createCompileBenchmarkMap(props.data);
 
 const compileComparisons = computed(() => {
@@ -265,7 +262,7 @@ const filteredSummary = computed(() => computeSummary(comparisons.value));
     :metrics="benchmarkInfo.compile_metrics"
   />
   <div
-    v-if="comparesIdenticalCommits"
+    v-if="canCompareBackends"
     :title="`Compare codegen backends for commit '${props.data.a.commit}'`"
   >
     Compare codegen backends for this commit:

--- a/site/frontend/src/pages/compare/compile/compile-page.vue
+++ b/site/frontend/src/pages/compare/compile/compile-page.vue
@@ -260,6 +260,7 @@ const filteredSummary = computed(() => computeSummary(comparisons.value));
     :filter="filter"
     :stat="selector.stat"
     :benchmark-map="benchmarkMap"
+    :show-backend="!selfCompareBackend"
   ></Benchmarks>
 </template>
 <style lang="scss" scoped>

--- a/site/frontend/src/pages/compare/compile/compile-page.vue
+++ b/site/frontend/src/pages/compare/compile/compile-page.vue
@@ -102,6 +102,11 @@ function loadFilterFromUrl(
         defaultFilter.artifact.library
       ),
     },
+    selfCompareBackend: getBoolOrDefault(
+      urlParams,
+      "selfCompareBackend",
+      defaultFilter.selfCompareBackend
+    ),
   };
 }
 
@@ -173,6 +178,11 @@ function storeFilterToUrl(
     filter.artifact.library,
     defaultFilter.artifact.library
   );
+  storeOrReset(
+    "selfCompareBackend",
+    filter.selfCompareBackend,
+    defaultFilter.selfCompareBackend
+  );
 
   changeUrl(urlParams);
 }
@@ -181,6 +191,10 @@ function updateFilter(newFilter: CompileBenchmarkFilter) {
   storeFilterToUrl(newFilter, defaultCompileFilter, getUrlParams());
   filter.value = newFilter;
   refreshQuickLinks();
+}
+
+function updateSelfCompareBackend(value: boolean) {
+  updateFilter({...filter.value, selfCompareBackend: value});
 }
 
 /**
@@ -199,7 +213,9 @@ const quickLinksKey = ref(0);
 const filter = ref(loadFilterFromUrl(urlParams, defaultCompileFilter));
 
 // Should we use the backend as the source of before/after data?
-const selfCompareBackend = ref(false);
+const selfCompareBackend = computed(
+  () => comparesIdenticalCommits.value && filter.value.selfCompareBackend
+);
 
 function exportData() {
   exportToMarkdown(comparisons.value, filter.value.showRawData);
@@ -240,7 +256,12 @@ const filteredSummary = computed(() => computeSummary(comparisons.value));
     :metrics="benchmarkInfo.compile_metrics"
   />
   <div v-if="comparesIdenticalCommits">
-    Self-compare backend: <input type="checkbox" v-model="selfCompareBackend" />
+    Self-compare backend:
+    <input
+      type="checkbox"
+      :checked="selfCompareBackend"
+      @change="(e) => updateSelfCompareBackend(e.target.checked)"
+    />
   </div>
   <Filters
     :defaultFilter="defaultCompileFilter"

--- a/site/frontend/src/pages/compare/compile/compile-page.vue
+++ b/site/frontend/src/pages/compare/compile/compile-page.vue
@@ -193,8 +193,11 @@ function updateFilter(newFilter: CompileBenchmarkFilter) {
   refreshQuickLinks();
 }
 
-function updateSelfCompareBackend(value: boolean) {
-  updateFilter({...filter.value, selfCompareBackend: value});
+// We pass the event target here, because Parcel cannot handle the `as`
+// cast directly in the template.
+function updateSelfCompareBackend(target: EventTarget) {
+  const element = target as HTMLInputElement;
+  updateFilter({...filter.value, selfCompareBackend: element.checked});
 }
 
 /**
@@ -260,7 +263,7 @@ const filteredSummary = computed(() => computeSummary(comparisons.value));
     <input
       type="checkbox"
       :checked="selfCompareBackend"
-      @change="(e) => updateSelfCompareBackend(e.target.checked)"
+      @change="(e) => updateSelfCompareBackend(e.target)"
     />
   </div>
   <Filters

--- a/site/frontend/src/pages/compare/compile/table/comparisons-table.vue
+++ b/site/frontend/src/pages/compare/compile/table/comparisons-table.vue
@@ -18,6 +18,7 @@ const props = defineProps<{
   commitA: ArtifactDescription;
   commitB: ArtifactDescription;
   stat: string;
+  showBackend: boolean;
 }>();
 
 function prettifyRawNumber(number: number): string {
@@ -56,7 +57,7 @@ const unit = computed(() => {
           <th>Benchmark</th>
           <th>Profile</th>
           <th>Scenario</th>
-          <th>Backend</th>
+          <th v-if="showBackend">Backend</th>
           <th>% Change</th>
           <th class="narrow">
             Significance Threshold
@@ -95,7 +96,7 @@ const unit = computed(() => {
                 {{ comparison.testCase.profile }}
               </td>
               <td>{{ comparison.testCase.scenario }}</td>
-              <td>{{ comparison.testCase.backend }}</td>
+              <td v-if="showBackend">{{ comparison.testCase.backend }}</td>
               <td>
                 <div class="numeric-aligned">
                   <span v-bind:class="percentClass(comparison.percent)">


### PR DESCRIPTION
This PR adds a new comparison mode to the compile result compare page. This mode allows users to compare the results between the LLVM and Cranelift backends if you are comparing the same commit against each other.

![llvm-vs-cranelift](https://github.com/user-attachments/assets/c1e157c3-a89b-4608-82b7-f5d3ac07ddf8)

This was IMO the easiest way how to introduce this comparison mode. It would require non-trivial changes to get this working on the backend, and while this is arguably a bit of a hack, I think that it should work fine for the use-case that we need it for. In the future, this could be easily generalized to multiple backends, but for now it was not worth the hassle.

How to test:
1. Get results
```bash
$ rustup component add rustc-codegen-cranelift-preview --toolchain nightly
$ cargo run --bin collector -- bench_local `rustup +nightly which rustc` --include serde --profiles Debug --backends Llvm,Cranelift
```
2. Start the website (if you only have the data from the above run in the local DB, it should open the single commit compared against itself)
3. Click on "Self-compare backend"