### PR TITLE
Fix touch() failing on Windows

### DIFF
--- a/collector/src/utils/fs.rs
+++ b/collector/src/utils/fs.rs
@@ -45,7 +45,7 @@ pub fn rename<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> anyhow::Result<
 
 /// Touch a file, resetting its modification time.
 pub fn touch(path: &Path) -> anyhow::Result<()> {
-    let file = File::options().read(true).open(path)?;
+    let file = File::options().read(true).write(true).open(path)?;
     file.set_modified(SystemTime::now())
         .with_context(|| format!("touching file {:?}", path))?;
 


### PR DESCRIPTION
It seems like 79faa3e5554c9bd515dbddcf4b9f53c1ecba53f4 introduced an issue on Windows. In order to modify file modification time there it needs to be opened in write mode, otherwise it fails with an "Access is denied" OS error. This PR fixes that.