### PR TITLE
Restore leading spaces on empty context lines in patch files

### DIFF
--- a/collector/compile-benchmarks/coercions/0-println.patch
+++ b/collector/compile-benchmarks/coercions/0-println.patch
@@ -5,6 +5,6 @@ index 3fb7c5f..63e7f0f 100644
 @@ -65574,4 +65574,4 @@ pub static MAPPING: [&'static str; 0xffff] = [
      "",
  ];
-
+ 
 -fn main() { }
 +fn main() { println!("test"); }

--- a/collector/compile-benchmarks/inflate/0-println.patch
+++ b/collector/compile-benchmarks/inflate/0-println.patch
@@ -4,7 +4,7 @@ index b5f3996..8d7766d 100644
 +++ b/src/lib.rs
 @@ -184,6 +184,7 @@ impl<'a> BitStream<'a> {
      }
-
+ 
      fn fill(&mut self) -> BitState {
 +        println!("testing");
          while self.state.n + 8 <= 32 && self.use_byte() {}

--- a/collector/compile-benchmarks/issue-46449/0-io-error-6144.patch
+++ b/collector/compile-benchmarks/issue-46449/0-io-error-6144.patch
@@ -3,11 +3,11 @@ index 4b9db94..c44dea6 100644
 --- a/src/lib.rs
 +++ b/src/lib.rs
 @@ -2,7 +2,7 @@ extern crate futures;
-
+ 
  use futures::{Future, Poll};
-
+ 
 -const BUFFER_SIZE: usize = 1;
 +const BUFFER_SIZE: usize = 6144;
  pub struct Error(::std::io::Error);
-
+ 
  struct Dummy<T>(T);

--- a/collector/compile-benchmarks/issue-46449/1-u32-3072.patch
+++ b/collector/compile-benchmarks/issue-46449/1-u32-3072.patch
@@ -3,13 +3,13 @@ index c44dea6..b555f05 100644
 --- a/src/lib.rs
 +++ b/src/lib.rs
 @@ -2,8 +2,8 @@ extern crate futures;
-
+ 
  use futures::{Future, Poll};
-
+ 
 -const BUFFER_SIZE: usize = 6144;
 -pub struct Error(::std::io::Error);
 +const BUFFER_SIZE: usize = 3072;
 +pub struct Error(u32);
-
+ 
  struct Dummy<T>(T);
  impl<T> Future for Dummy<T> {

--- a/collector/compile-benchmarks/issue-46449/2-u8-3072.patch
+++ b/collector/compile-benchmarks/issue-46449/2-u8-3072.patch
@@ -4,10 +4,10 @@ index f8f91d6..b555f05 100644
 +++ b/src/lib.rs
 @@ -3,7 +3,7 @@ extern crate futures;
  use futures::{Future, Poll};
-
+ 
  const BUFFER_SIZE: usize = 3072;
 -pub struct Error(u32);
 +pub struct Error(u8);
-
+ 
  struct Dummy<T>(T);
  impl<T> Future for Dummy<T> {

--- a/collector/compile-benchmarks/issue-46449/3-empty-3072.patch
+++ b/collector/compile-benchmarks/issue-46449/3-empty-3072.patch
@@ -4,10 +4,10 @@ index f8f91d6..72382a0 100644
 +++ b/src/lib.rs
 @@ -3,7 +3,7 @@ extern crate futures;
  use futures::{Future, Poll};
-
+ 
  const BUFFER_SIZE: usize = 3072;
 -pub struct Error(u8);
 +pub struct Error;
-
+ 
  struct Dummy<T>(T);
  impl<T> Future for Dummy<T> {

--- a/collector/compile-benchmarks/issue-46449/4-static-str-6144.patch
+++ b/collector/compile-benchmarks/issue-46449/4-static-str-6144.patch
@@ -3,13 +3,13 @@ index 72382a0..5d8fc67 100644
 --- a/src/lib.rs
 +++ b/src/lib.rs
 @@ -2,8 +2,8 @@ extern crate futures;
-
+ 
  use futures::{Future, Poll};
-
+ 
 -const BUFFER_SIZE: usize = 3072;
 -pub struct Error;
 +const BUFFER_SIZE: usize = 6144;
 +pub struct Error(&'static str);
-
+ 
  struct Dummy<T>(T);
  impl<T> Future for Dummy<T> {

--- a/collector/compile-benchmarks/regex-1.5.5/0-compile-one.patch
+++ b/collector/compile-benchmarks/regex-1.5.5/0-compile-one.patch
@@ -4,7 +4,7 @@ index 9db743f..ef1948e 100644
 +++ b/src/compile.rs
 @@ -137,6 +137,8 @@ impl Compiler {
      }
-
+ 
      fn compile_one(mut self, expr: &Hir) -> result::Result<Program, Error> {
 +        {} // @030
 +

--- a/collector/compile-benchmarks/regex-1.5.5/1-is-valid-cap-letter.patch
+++ b/collector/compile-benchmarks/regex-1.5.5/1-is-valid-cap-letter.patch
@@ -4,7 +4,7 @@ index 9bea703..3b6ae94 100644
 +++ b/src/expand.rs
 @@ -128,6 +128,7 @@ fn find_cap_ref(replacement: &[u8]) -> Option<CaptureRef<'_>> {
  }
-
+ 
  /// Returns true if and only if the given byte is allowed in a capture name.
  fn is_valid_cap_letter(b: &u8) -> bool {
 +    { }

--- a/collector/compile-benchmarks/regex-1.5.5/4-byte-frequencies.patch
+++ b/collector/compile-benchmarks/regex-1.5.5/4-byte-frequencies.patch
@@ -4,7 +4,7 @@ index 92bafc1..6eb5799 100644
 +++ b/src/freqs.rs
 @@ -2,7 +2,7 @@
  // edit directly
-
+ 
  pub const BYTE_FREQUENCIES: [u8; 256] = [
 -    55,  // '\x00'
 +    54+1,  // '\x00'

--- a/collector/compile-benchmarks/regex-1.5.5/5-Job.patch
+++ b/collector/compile-benchmarks/regex-1.5.5/5-Job.patch
@@ -10,5 +10,5 @@ index 3c06254..4b72fd4 100644
      SaveRestore { slot: usize, old_pos: Option<usize> },
 +    Inst { ip: InstPtr, at: InputAt },
  }
-
+ 
  impl<'a, 'm, 'r, 's, I: Input> Bounded<'a, 'm, 'r, 's, I> {

--- a/collector/compile-benchmarks/regex/0-compile-one.patch
+++ b/collector/compile-benchmarks/regex/0-compile-one.patch
@@ -4,7 +4,7 @@ index 9db743f..ef1948e 100644
 +++ b/src/compile.rs
 @@ -137,6 +137,8 @@ impl Compiler {
      }
-
+ 
      fn compile_one(mut self, expr: &Expr) -> result::Result<Program, Error> {
 +        {} // @030
 +

--- a/collector/compile-benchmarks/regex/1-is-valid-cap-letter.patch
+++ b/collector/compile-benchmarks/regex/1-is-valid-cap-letter.patch
@@ -4,7 +4,7 @@ index 9bea703..3b6ae94 100644
 +++ b/src/expand.rs
 @@ -84,6 +84,7 @@ fn find_cap_ref(mut replacement: &[u8]) -> Option<CaptureRef> {
  }
-
+ 
  fn is_valid_cap_letter(b: &u8) -> bool {
 +    { }
      match *b {

--- a/collector/compile-benchmarks/regex/2-expand.patch
+++ b/collector/compile-benchmarks/regex/2-expand.patch
@@ -4,7 +4,7 @@ index 9bea703..a28b82d 100644
 +++ b/src/expand.rs
 @@ -5,6 +5,7 @@ use memchr::memchr;
  use bytes::Captures;
-
+ 
  pub fn expand(caps: &Captures, mut replacement: &[u8], dst: &mut Vec<u8>) {
 +    { }
      while !replacement.is_empty() {

--- a/collector/compile-benchmarks/regex/5-byte-frequencies.patch
+++ b/collector/compile-benchmarks/regex/5-byte-frequencies.patch
@@ -4,7 +4,7 @@ index 92bafc1..6eb5799 100644
 +++ b/src/freqs.rs
 @@ -12,7 +12,7 @@
  // edit directly
-
+ 
  pub const BYTE_FREQUENCIES: [u8; 256] = [
 -     55, // '\x00'
 +     54+1, // '\x00'

--- a/collector/compile-benchmarks/regex/6-sparse-set.patch
+++ b/collector/compile-benchmarks/regex/6-sparse-set.patch
@@ -16,5 +16,5 @@ index 34c05e7..ef5188e 100644
 -    /// The number of elements in the set.
 -    size: usize,
  }
-
+ 
  impl SparseSet {

--- a/collector/compile-benchmarks/regex/7-Job.patch
+++ b/collector/compile-benchmarks/regex/7-Job.patch
@@ -10,5 +10,5 @@ index 3c06254..4b72fd4 100644
      SaveRestore { slot: usize, old_pos: Option<usize> },
 +    Inst { ip: InstPtr, at: InputAt },
  }
-
+ 
  impl<'a, 'm, 'r, 's, I: Input> Bounded<'a, 'm, 'r, 's, I> {

--- a/collector/compile-benchmarks/serde-1.0.136/0-println.patch
+++ b/collector/compile-benchmarks/serde-1.0.136/0-println.patch
@@ -3,7 +3,7 @@ index 576fd03c..a825007a 100644
 --- a/src/de/utf8.rs
 +++ b/src/de/utf8.rs
 @@ -41,6 +41,7 @@ pub struct Encode {
-
+ 
  impl Encode {
      pub fn as_str(&self) -> &str {
 +        println!();

--- a/collector/compile-benchmarks/style-servo/0-println.patch
+++ b/collector/compile-benchmarks/style-servo/0-println.patch
@@ -7,5 +7,5 @@ diff --git a/components/style/matching.rs b/components/style/matching.rs
          if replacements.intersects(RestyleHint::for_animations()) {
 +            println!("{:?}", context.shared.traversal_flags.for_animation_only());
              debug_assert!(context.shared.traversal_flags.for_animation_only());
-
+ 
              if replacements.contains(RESTYLE_SMIL) {

--- a/collector/compile-benchmarks/style-servo/components/script/dom/bindings/codegen/parser/callback-location.patch
+++ b/collector/compile-benchmarks/style-servo/components/script/dom/bindings/codegen/parser/callback-location.patch
@@ -8,7 +8,7 @@ index da32340..81c52b7 100644
              assert self.name.name == obj.identifier.name
 -            return IDLCallbackType(self.location, obj)
 +            return IDLCallbackType(obj.location, obj)
-
+ 
          if self._promiseInnerType and not self._promiseInnerType.isComplete():
              self._promiseInnerType = self._promiseInnerType.complete(scope)
 @@ -6521,7 +6521,7 @@ class Parser(Tokenizer):


### PR DESCRIPTION
Usually `git apply` does not care about these. However, if the repository is checked out with CRLF line endings, an empty line in the patch context without a leading space results in a "corrupt patch" error.  In other cases this change should have no effect.