### PR TITLE
Handle measureme panics, and don't crash the collector on self-profile data errors

### DIFF
--- a/collector/src/compile/execute/mod.rs
+++ b/collector/src/compile/execute/mod.rs
@@ -636,12 +636,27 @@ fn parse_self_profile(
     let (profile, files) = if let Some(profile_path) = full_path {
         // measureme 0.8+ uses a single file
         let data = fs::read(&profile_path)?;
-        let results = analyzeme::ProfilingData::from_paged_buffer(data, None)
-            .map_err(|error| {
-                eprintln!("Cannot read self-profile data: {error:?}");
-                std::io::Error::new(ErrorKind::InvalidData, error)
-            })?
-            .perform_analysis();
+
+        // HACK: `decodeme` can unexpectedly panic on invalid data produced by rustc. We catch this
+        // here until it's fixed and emits a proper error.
+        let res =
+            std::panic::catch_unwind(|| analyzeme::ProfilingData::from_paged_buffer(data, None));
+        let results = match res {
+            Ok(Ok(profiling_data)) => profiling_data.perform_analysis(),
+            Ok(Err(error)) => {
+                // A "regular" error in measureme.
+                log::error!("Cannot read self-profile data: {error:?}");
+                return Err(std::io::Error::new(ErrorKind::InvalidData, error));
+            }
+            Err(error) => {
+                // An unexpected panic in measureme: it sometimes happens when encountering some
+                // cases of invalid mm_profdata files.
+                let error = format!("Unexpected measureme error with self-profile data: {error:?}");
+                log::error!("{error}");
+                return Err(std::io::Error::new(ErrorKind::InvalidData, error));
+            }
+        };
+
         let profile = SelfProfile {
             artifact_sizes: results.artifact_sizes,
         };


### PR DESCRIPTION
Situation: rustc creates invalid `-Zself-profile` data, the collector tries to read it and measureme crashes or returns an error => the collector panics (likely after 5 tries). On panics, the perf run is incomplete and the collector will try to complete it, which will still crash. This happened today in [this run](https://github.com/rust-lang/rust/pull/133502#issuecomment-2505184315).

This PR:
- wraps measureme's panics (until I fix it there to remove the unwraps/expects) so that the collector in turn doesn't crash on randomly invalid self-profile data, and returns an error
- if any errors happen with the self-profile data, instead of the collector panicking [here](https://github.com/rust-lang/rustc-perf/blob/2cdeaa113a643445a5b84df61baeaa9e181495cf/collector/src/compile/execute/bencher.rs#L220-L226), we consider this case as self-profile data missing. This is already handled by the self-profile page as far as I can tell so it should not be catastrophic (compared to infinite looping on a benchmark crash).

In the future we'll need to do another pass at error-handling and tightening up these cases. We'd ideally record any such issue as a benchmark failure, and move on to the other benchmarks.

This should do until then, I think.