### PR TITLE
html5ever: explicitly enable nightly rustc_encodable_decodable feature

### DIFF
--- a/collector/compile-benchmarks/html5ever/build.rs
+++ b/collector/compile-benchmarks/html5ever/build.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(soft_unstable)]
+#![feature(rustc_encodable_decodable)]
 
 extern crate phf_codegen;
 extern crate rustc_serialize;


### PR DESCRIPTION
Needed to keep the benchmark working with https://github.com/rust-lang/rust/pull/134272.

Other benchmarks also seem to use nightly features so I hope this is fine?