### PR TITLE
Fix error handling when looking for toolchain components

### DIFF
--- a/collector/src/toolchain.rs
+++ b/collector/src/toolchain.rs
@@ -589,13 +589,15 @@ pub fn create_toolchain_from_published_version(
 }
 
 fn get_lib_dir_from_rustc(rustc: &Path) -> anyhow::Result<PathBuf> {
-    let sysroot = Command::new(rustc)
-        .arg("--print")
-        .arg("sysroot")
-        .output()?
-        .stdout;
-    let sysroot_path = String::from_utf8_lossy(&sysroot);
-
+    let output = Command::new(rustc).arg("--print").arg("sysroot").output()?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "rustc failed to provide sysroot, exit status: {}\nstderr: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    let sysroot_path = String::from_utf8_lossy(&output.stdout);
     Ok(Path::new(sysroot_path.as_ref().trim()).join("lib"))
 }
 

--- a/collector/src/toolchain.rs
+++ b/collector/src/toolchain.rs
@@ -278,7 +278,7 @@ impl ToolchainComponents {
     /// Finds known library components in the given `dir` and stores them in `self`.
     fn fill_libraries(&mut self, dir: &Path) -> anyhow::Result<()> {
         let files: Vec<(PathBuf, String)> = fs::read_dir(dir)
-            .context("Cannot read lib dir to find components")?
+            .with_context(|| format!("Cannot read lib dir `{}` to find components", dir.display()))?
             .map(|entry| Ok(entry?))
             .collect::<anyhow::Result<Vec<_>>>()?
             .into_iter()

--- a/collector/src/toolchain.rs
+++ b/collector/src/toolchain.rs
@@ -598,7 +598,14 @@ fn get_lib_dir_from_rustc(rustc: &Path) -> anyhow::Result<PathBuf> {
         );
     }
     let sysroot_path = String::from_utf8_lossy(&output.stdout);
-    Ok(Path::new(sysroot_path.as_ref().trim()).join("lib"))
+    let lib_dir = Path::new(sysroot_path.as_ref().trim()).join("lib");
+    if !lib_dir.exists() {
+        anyhow::bail!(
+            "rustc returned non-existent sysroot: `{}`",
+            lib_dir.display()
+        );
+    }
+    Ok(lib_dir)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The perf collector failed weirdly in https://github.com/rust-lang/rust/pull/134297#issuecomment-2542820868. It failed when the collector was trying to gather PGO data, with a very terse error: `collector error: Cannot read lib dir to find components`. 

So this PR:
- adds some context on which directory was being read if an error happens in `fill_libraries`
- fixes the error handling in `get_lib_dir_from_rustc` which didn't check that `rustc --print sysroot` successfully returned the sysroot, it'll print the exit status and stderr.
- adds a check that the returned sysroot also exists, just in case

With these we can see that the error was a cute one, the stage2 rustc panicked when asked to print the sysroot. So the error in the CI logs would now look like:

```
Running with 1 job(s)
collector error: Cannot find libdir for rustc

Caused by:
    rustc failed to provide sysroot, exit status: exit status: 101
    stderr: thread 'main' panicked at compiler/rustc_driver_impl/src/lib.rs:1587:6:
    Unable to install ctrlc handler: System(Custom { kind: Other, error: EBADF })
    stack backtrace:
       0: rust_begin_unwind
       1: core::panicking::panic_fmt
       2: core::result::unwrap_failed
       3: rustc_driver_impl::install_ctrlc_handler
       4: rustc_driver_impl::main
       5: rustc_main::main
    note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

    error: the compiler unexpectedly panicked. this is a bug.

    note: we would appreciate a bug report: https://github.com/rust-lang/rust/issues/new?labels=C-bug%2C+I-ICE%2C+T-compiler&template=ice.md

    note: please make sure that you have updated to the latest nightly

    note: please attach the file at `/tmp/tmp-multistage/opt-artifacts/rustc-perf/rustc-ice-2024-12-15T18_31_39-82730.txt` to your bug report

    query stack during panic:
    end of query stack

[2024-12-15T18:31:39.841Z INFO  opt_dist::timer] Section `Stage 1 (Rustc PGO) > Gather profiles` ended: FAIL (0.30s)`
```

Once this lands, I'll bump the submodule in the rust repo so that CI has the new error handling, in case it happens again in the PRs trying to land the same changes that may currently cause a miscompile 😓.