### PR TITLE
Make compare page slightly less misleading when there are no relevant results

### DIFF
--- a/site/frontend/src/pages/compare/compile/table/comparisons-table.vue
+++ b/site/frontend/src/pages/compare/compile/table/comparisons-table.vue
@@ -48,7 +48,11 @@ const unit = computed(() => {
   <div class="bench-table" :id="id">
     <slot name="header"></slot>
     <div v-if="comparisons.length === 0" style="text-align: center">
-      {{ hasNonRelevant ? "No relevant results" : "No results" }}
+      {{
+        hasNonRelevant
+          ? "No relevant results (enable Filters -> Show non-relevant results to see all)"
+          : "No results"
+      }}
     </div>
     <table v-else class="benches compare">
       <thead>

--- a/site/frontend/src/pages/compare/summary/overall-summary.vue
+++ b/site/frontend/src/pages/compare/summary/overall-summary.vue
@@ -11,7 +11,7 @@ const summary = computed(() => props.summary);
 </script>
 
 <template>
-  <div class="main-summary">
+  <div class="main-summary" v-if="summary.all.count > 0">
     <SummaryTable :summary="summary"></SummaryTable>
     <div style="position: absolute; right: 5px; top: 5px">
       <Tooltip style="margin-right: 1em">


### PR DESCRIPTION
I talked to @FractalFir about his experiences with rustc-perf, and he was rightly confused about this.

Before:
![image](https://github.com/user-attachments/assets/86241ec5-4e97-4368-9ecc-d5c5c0457f6c)

After:
![image](https://github.com/user-attachments/assets/4fe68890-629e-45fa-8b16-39e2d6cb32c0)
