### PR TITLE
Fix bootstrap rustc benchmark

### DIFF
--- a/collector/src/compile/execute/rustc.rs
+++ b/collector/src/compile/execute/rustc.rs
@@ -117,7 +117,7 @@ async fn record(
             .env("BOOTSTRAP_SKIP_TARGET_SANITY", "1")
             .arg("build")
             .arg("--stage")
-            .arg("0")
+            .arg("1")
             // We want bootstrap and the Cargos it spawns to have no parallelism --
             // if multiple rustcs are competing for jobserver tokens, we introduce
             // quite a bit of variance.


### PR DESCRIPTION
This was broken by the change done in https://github.com/rust-lang/rust/pull/137882.