### PR TITLE
Revert "Increase the number of finished runs shown in the status page"

### DIFF
--- a/site/src/request_handlers/status_page.rs
+++ b/site/src/request_handlers/status_page.rs
@@ -8,7 +8,7 @@ use crate::load::SiteCtxt;
 use database::{ArtifactId, Lookup};
 
 // How many historical (finished) runs should be returned from the status API.
-const FINISHED_RUN_COUNT: u64 = 25;
+const FINISHED_RUN_COUNT: u64 = 5;
 
 pub async fn handle_status_page(ctxt: Arc<SiteCtxt>) -> status::Response {
     let missing = ctxt.missing_commits().await;


### PR DESCRIPTION
Reverts rust-lang/rustc-perf#2055. It seems that it was too much for the DB. I'll rewrite the query to avoid the N+1 queries  problem instead.