### PR TITLE
Feat - implement queue

### DIFF
--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -845,31 +845,13 @@ pub struct CommitJob {
     pub started_at: Option<Date>,
     pub finished_at: Option<Date>,
     pub status: CommitJobStatus,
+    pub include: Option<String>,
+    pub exclude: Option<String>,
+    pub runs: Option<i32>,
+    pub backends: Option<String>,
 }
 
 impl CommitJob {
-    /// Create a new commit job
-    pub fn new(
-        sha: String,
-        parent_sha: Option<String>,
-        pr: u32,
-        commit_type: CommitType,
-        commit_time: Date,
-    ) -> Self {
-        Self {
-            sha,
-            parent_sha,
-            commit_type,
-            pr,
-            commit_time,
-            status: CommitJobStatus::Queued,
-            target: Target::X86_64UnknownLinuxGnu,
-            machine_id: None,
-            started_at: None,
-            finished_at: None,
-        }
-    }
-
     pub fn from_db(
         sha: String,
         parent_sha: Option<String>,
@@ -881,6 +863,10 @@ impl CommitJob {
         started_at: Option<Date>,
         finished_at: Option<Date>,
         status: CommitJobStatus,
+        include: Option<String>,
+        exclude: Option<String>,
+        runs: Option<i32>,
+        backends: Option<String>,
     ) -> Self {
         Self {
             sha,
@@ -893,6 +879,10 @@ impl CommitJob {
             started_at,
             finished_at,
             status,
+            include,
+            exclude,
+            runs,
+            backends,
         }
     }
 
@@ -905,6 +895,10 @@ impl CommitJob {
             String::from("commit_time"),
             String::from("status"),
             String::from("target"),
+            String::from("include"),
+            String::from("exclude"),
+            String::from("runs"),
+            String::from("backends"),
         ]
     }
 }

--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -1,5 +1,6 @@
 use crate::{
-    ArtifactCollection, ArtifactId, ArtifactIdNumber, CodegenBackend, CommitJob, CompileBenchmark, Target
+    ArtifactCollection, ArtifactId, ArtifactIdNumber, CodegenBackend, CommitJob, CompileBenchmark,
+    Target,
 };
 use crate::{CollectionId, Index, Profile, QueuedCommit, Scenario, Step};
 use chrono::{DateTime, Utc};
@@ -179,13 +180,14 @@ pub trait Connection: Send + Sync {
     /// Removes all data associated with the given artifact.
     async fn purge_artifact(&self, aid: &ArtifactId);
 
-    /* @Queue - Adds a job - we want to "double up" by adding one per `Target` */
-    /// Add a job to the queue
+    /// Add a jobs to the queue
     async fn enqueue_commit_job(&self, target: Target, jobs: &[CommitJob]);
 
-    /* @Queue - currently extracts everything out of the queue as a SELECT */
     /// Dequeue jobs
-    async fn dequeue_commit_job(&self, machine_id: String, target: Target) -> Option<String>;
+    async fn dequeue_commit_job(&self, machine_id: String, target: Target) -> Option<CommitJob>;
+
+    /// Mark the job as finished
+    async fn finish_commit_job(&self, machine_id: String, target: Target, sha: String) -> bool;
 }
 
 #[async_trait::async_trait]

--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -184,10 +184,10 @@ pub trait Connection: Send + Sync {
     async fn enqueue_commit_job(&self, target: Target, jobs: &[CommitJob]);
 
     /// Dequeue jobs
-    async fn dequeue_commit_job(&self, machine_id: String, target: Target) -> Option<CommitJob>;
+    async fn dequeue_commit_job(&self, machine_id: &str, target: Target) -> Option<CommitJob>;
 
     /// Mark the job as finished
-    async fn finish_commit_job(&self, machine_id: String, target: Target, sha: String) -> bool;
+    async fn finish_commit_job(&self, machine_id: &str, target: Target, sha: String) -> bool;
 }
 
 #[async_trait::async_trait]

--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ArtifactCollection, ArtifactId, ArtifactIdNumber, CodegenBackend, CompileBenchmark, Target,
+    ArtifactCollection, ArtifactId, ArtifactIdNumber, CodegenBackend, CommitJob, CompileBenchmark, Target
 };
 use crate::{CollectionId, Index, Profile, QueuedCommit, Scenario, Step};
 use chrono::{DateTime, Utc};
@@ -178,6 +178,14 @@ pub trait Connection: Send + Sync {
 
     /// Removes all data associated with the given artifact.
     async fn purge_artifact(&self, aid: &ArtifactId);
+
+    /* @Queue - Adds a job - we want to "double up" by adding one per `Target` */
+    /// Add a job to the queue
+    async fn enqueue_commit_job(&self, target: Target, jobs: &[CommitJob]);
+
+    /* @Queue - currently extracts everything out of the queue as a SELECT */
+    /// Dequeue jobs
+    async fn dequeue_commit_job(&self, machine_id: String, target: Target) -> Option<String>;
 }
 
 #[async_trait::async_trait]

--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -1441,7 +1441,7 @@ where
         self.conn().execute(&sql, &params).await.unwrap();
     }
 
-    async fn dequeue_commit_job(&self, machine_id: String, target: Target) -> Option<CommitJob> {
+    async fn dequeue_commit_job(&self, machine_id: &str, target: Target) -> Option<CommitJob> {
         /* Check to see if this machine possibly went offline while doing
          * a previous job - if it did we'll take that job */
         let maybe_previous_job = self
@@ -1559,7 +1559,7 @@ where
     }
 
     /// Mark a job in the database as done
-    async fn finish_commit_job(&self, machine_id: String, target: Target, sha: String) -> bool {
+    async fn finish_commit_job(&self, machine_id: &str, target: Target, sha: String) -> bool {
         let jobs = self
             .conn()
             .query_opt(

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -1323,7 +1323,7 @@ impl Connection for SqliteConnection {
             .unwrap();
     }
 
-    async fn dequeue_commit_job(&self, machine_id: String, target: Target) -> Option<CommitJob> {
+    async fn dequeue_commit_job(&self, machine_id: &str, target: Target) -> Option<CommitJob> {
         /* Check to see if this machine possibly went offline while doing
          * a previous job - if it did we'll take that job */
         let maybe_previous_job = self
@@ -1349,7 +1349,7 @@ impl Connection for SqliteConnection {
                 ",
             )
             .unwrap()
-            .query_map(params![&machine_id, &target, &machine_id, &target], |row| {
+            .query_map(params![machine_id, &target, machine_id, &target], |row| {
                 Ok(commit_queue_row_to_commit_job(row))
             })
             .unwrap()
@@ -1392,7 +1392,7 @@ impl Connection for SqliteConnection {
                 ",
             )
             .unwrap()
-            .query_map(params![&target, &target, &machine_id, &target], |row| {
+            .query_map(params![&target, &target, machine_id, &target], |row| {
                 Ok(commit_queue_row_to_commit_job(row))
             })
             .unwrap()
@@ -1430,7 +1430,7 @@ impl Connection for SqliteConnection {
                 ",
             )
             .unwrap()
-            .query_map(params![&target, &machine_id, &target], |row| {
+            .query_map(params![&target, machine_id, &target], |row| {
                 Ok(commit_queue_row_to_commit_job(row))
             })
             .unwrap()
@@ -1447,7 +1447,7 @@ impl Connection for SqliteConnection {
     }
 
     /// Mark a job in the database as done
-    async fn finish_commit_job(&self, machine_id: String, target: Target, sha: String) -> bool {
+    async fn finish_commit_job(&self, machine_id: &str, target: Target, sha: String) -> bool {
         let jobs = self
             .raw_ref()
             .execute(
@@ -1460,7 +1460,7 @@ impl Connection for SqliteConnection {
                     AND machine_id = ?
                     AND target = ?;
                 ",
-                params![&sha, &machine_id, &target],
+                params![&sha, machine_id, &target],
             )
             .unwrap();
         return jobs == 1;

--- a/site/src/lib.rs
+++ b/site/src/lib.rs
@@ -5,6 +5,7 @@ pub mod api;
 pub mod github;
 pub mod load;
 pub mod server;
+pub mod queue_jobs;
 
 mod average;
 mod benchmark_metadata;

--- a/site/src/lib.rs
+++ b/site/src/lib.rs
@@ -4,8 +4,8 @@ extern crate itertools;
 pub mod api;
 pub mod github;
 pub mod load;
-pub mod server;
 pub mod queue_jobs;
+pub mod server;
 
 mod average;
 mod benchmark_metadata;

--- a/site/src/queue_jobs.rs
+++ b/site/src/queue_jobs.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
+use crate::load::SiteCtxt;
 use parking_lot::RwLock;
 use tokio::time::{self, Duration};
-use crate::load::SiteCtxt;
 
 /// Inserts into the queue at `seconds` interval
 pub async fn cron_enqueue_jobs(site_ctxt: Arc<RwLock<Option<Arc<SiteCtxt>>>>, seconds: u64) {

--- a/site/src/queue_jobs.rs
+++ b/site/src/queue_jobs.rs
@@ -1,0 +1,20 @@
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+use tokio::time::{self, Duration};
+use crate::load::SiteCtxt;
+
+/// Inserts into the queue at `seconds` interval
+pub async fn cron_enqueue_jobs(site_ctxt: Arc<RwLock<Option<Arc<SiteCtxt>>>>, seconds: u64) {
+    let mut interval = time::interval(Duration::from_secs(seconds));
+
+    loop {
+        let ctxt = site_ctxt.clone();
+        let ctxt = ctxt.read();
+        if let Some(ctxt) = ctxt.as_ref() {
+            ctxt.enqueue_commit_jobs().await;
+        }
+        interval.tick().await;
+        println!("Cron job executed at: {:?}", std::time::SystemTime::now());
+    }
+}

--- a/site/src/request_handlers.rs
+++ b/site/src/request_handlers.rs
@@ -13,7 +13,7 @@ pub use graph::{
     handle_compile_detail_graphs, handle_compile_detail_sections, handle_graphs,
     handle_runtime_detail_graphs,
 };
-pub use next_artifact::handle_next_artifact;
+pub use next_artifact::{handle_next_artifact, handle_released_artifact};
 pub use self_profile::{
     handle_self_profile, handle_self_profile_processed_download, handle_self_profile_raw,
     handle_self_profile_raw_download,

--- a/site/src/request_handlers/next_artifact.rs
+++ b/site/src/request_handlers/next_artifact.rs
@@ -82,3 +82,23 @@ pub async fn handle_next_artifact(ctxt: Arc<SiteCtxt>) -> next_artifact::Respons
         artifact: next_commit,
     }
 }
+
+/// Retrieve the next release artifact or return NULL
+pub async fn handle_released_artifact(ctxt: Arc<SiteCtxt>) -> next_artifact::Response {
+    match ctxt.missing_published_artifacts().await {
+        Ok(next_artifact) => {
+            if let Some(next_artifact) = next_artifact.into_iter().next() {
+                log::debug!("next_artifact: {next_artifact}");
+                next_artifact::Response {
+                    artifact: Some(next_artifact::NextArtifact::Release(next_artifact)),
+                }
+            } else {
+                next_artifact::Response { artifact: None }
+            }
+        }
+        Err(error) => {
+            log::error!("Failed to fetch missing artifacts: {error:?}");
+            next_artifact::Response { artifact: None }
+        }
+    }
+}

--- a/site/src/server.rs
+++ b/site/src/server.rs
@@ -387,6 +387,11 @@ async fn serve_req(server: Server, req: Request) -> Result<Response, ServerError
                 .handle_get_async(&req, request_handlers::handle_next_artifact)
                 .await;
         }
+        "/perf/released_artifact" => {
+            return server
+                .handle_get_async(&req, request_handlers::handle_released_artifact)
+                .await;
+        }
         "/perf/triage" if *req.method() == http::Method::GET => {
             let ctxt: Arc<SiteCtxt> = server.ctxt.read().as_ref().unwrap().clone();
             let input: triage::Request = check!(parse_query_string(req.uri()));


### PR DESCRIPTION
This is a bit prototype-y at the moment however I thought it wise to get some early feedback as the main ideas are here.

I do have some the some questions that I though of while implementing the queue namely;

- Do we want to add a `retry` column? As it is theoretically possible for a machine to keep picking up a job that it failed to do
- How to handle a "release" build which I've hacked together and endpoint for
- How to allocate a machine uuid
- How to let a machine know what architecture it is on (could do a shell `uname -a` or something similar)?

I don't think the SQLite implementation would work at all as there is an assumption that there is a centralised database or database cluster that the whole system speaks to. I could be wrong but with the SQLite implementation it would create a version of the database local to the machine (presently 2) thus would not work. With that in mind I've not implemented anything to handle concurrent access to SQLite. The implementation, presently, is only useful for local development and perhaps tests?