### PR TITLE
Move typenum-1.18.0 patch file to the correct directory

### DIFF
--- a/collector/compile-benchmarks/typenum-1.18.0/0-add-fn.patch
+++ b/collector/compile-benchmarks/typenum-1.18.0/0-add-fn.patch
@@ -1,7 +1,7 @@
-diff --git a/typenum-1.18.0/src/lib.rs b/typenum-1.18.0/src/lib.rs
+diff --git a/src/lib.rs b/src/lib.rs
 index f7a1241a..13582037 100644
---- a/typenum-1.18.0/src/lib.rs
-+++ b/typenum-1.18.0/src/lib.rs
+--- a/src/lib.rs
++++ b/src/lib.rs
 @@ -173,3 +173,4 @@ mod sealed {
      impl Sealed for ATerm {}
      impl<V, A> Sealed for TArr<V, A> {}


### PR DESCRIPTION
Missed this while reviewing https://github.com/rust-lang/rustc-perf/pull/2088.