### PR TITLE
Give full path of binary in example `download` command.

### DIFF
--- a/collector/compile-benchmarks/README.md
+++ b/collector/compile-benchmarks/README.md
@@ -176,9 +176,10 @@ Rust code being written today.
     anything we should be aware of when using this crate as a compile-time
     benchmark.
   - Look at [crates.io](https://crates.io) to find the latest (non-prerelease) version.
-  - Download it with `collector download -c $CATEGORY -a $ARTIFACT crate $NAME $VERSION`.
-    The `$CATEGORY` is probably `Primary`. `$ARTIFACT` is either `library` or `binary`, depending
-    on what kind of artifact does the benchmark build.
+  - Download it with `target/release/collector download -c $CATEGORY -a
+    $ARTIFACT crate $NAME $VERSION`. The `$CATEGORY` is probably `Primary`.
+    `$ARTIFACT` is either `library` or `binary`, depending on what kind of
+    artifact does the benchmark build.
 - It makes it easier for reviewers if you split things into two commits.
 - In the first commit, just add the code for the entire benchmark.
   - Do this by doing `git add` on the new directory.


### PR DESCRIPTION
So it's easier to copy and paste.