### PR TITLE
fix mono items profiler

### DIFF
--- a/collector/src/bin/rustc-fake.rs
+++ b/collector/src/bin/rustc-fake.rs
@@ -388,10 +388,8 @@ fn main() {
             }
 
             "MonoItems" => {
-                // Lazy item collection is the default (i.e., without this
-                // option)
                 let mut cmd = Command::new(tool);
-                cmd.arg("-Zprint-mono-items=lazy")
+                cmd.arg("-Zprint-mono-items")
                     .args(args)
                     .stdout(std::process::Stdio::from(
                         std::fs::File::create("mono-items").unwrap(),


### PR DESCRIPTION
Lazy/eager collection was removed in https://github.com/rust-lang/rust/pull/140842.

CI is currently [failing](https://github.com/rust-lang/rustc-perf/actions/runs/14982412373/job/42089368417#step:9:292) because of that.