### PR TITLE
Use `--exact-match` instead of `--include` on the website

### DIFF
--- a/site/frontend/src/pages/compare/compile/table/shortcuts/binary-size-shortcut.vue
+++ b/site/frontend/src/pages/compare/compile/table/shortcuts/binary-size-shortcut.vue
@@ -39,7 +39,7 @@ function normalizeBackend(backend: string): string {
   <pre><code>./target/release/collector binary_stats compile \
     +{{ props.baseArtifact.commit }} \
     --rustc2 +{{ props.artifact.commit }} \
-    --include {{ testCase.benchmark }} \
+    --exact-match {{ testCase.benchmark }} \
     --profile {{ normalizeProfile(testCase.profile) }} \
     --backend {{ normalizeBackend(testCase.backend) }}</code></pre>
 </template>

--- a/site/frontend/src/pages/compare/compile/table/shortcuts/cachegrind-cmd.vue
+++ b/site/frontend/src/pages/compare/compile/table/shortcuts/cachegrind-cmd.vue
@@ -39,7 +39,7 @@ function normalizeScenario(scenario: string): string {
   <pre><code>./target/release/collector profile_local cachegrind \
     +{{ firstCommit }} \<template v-if="props.baselineCommit !== undefined">
     --rustc2 +{{ props.commit }} \</template>
-    --include {{ testCase.benchmark }} \
+    --exact-match {{ testCase.benchmark }} \
     --profiles {{ normalizeProfile(testCase.profile) }} \
     --scenarios {{ normalizeScenario(testCase.scenario) }}</code></pre>
 </template>

--- a/site/frontend/src/pages/detailed-query.ts
+++ b/site/frontend/src/pages/detailed-query.ts
@@ -198,7 +198,7 @@ function populate_data(data, state: Selector) {
     txt +=
       "<br>Local profile (base): <code>" +
       `./target/release/collector profile_local cachegrind
-                    +${state.base_commit} --include ${bench_name(
+                    +${state.base_commit} --exact-match ${bench_name(
         state.benchmark
       )} --profiles
                 ${profile(state.benchmark)} --scenarios ${scenario_filter(
@@ -208,7 +208,7 @@ function populate_data(data, state: Selector) {
   txt +=
     "<br>Local profile (new): <code>" +
     `./target/release/collector profile_local cachegrind
-                +${state.commit} --include ${bench_name(
+                +${state.commit} --exact-match ${bench_name(
       state.benchmark
     )} --profiles
                 ${profile(state.benchmark)} --scenarios ${scenario_filter(
@@ -220,7 +220,7 @@ function populate_data(data, state: Selector) {
       `./target/release/collector profile_local cachegrind
                 +${state.base_commit} --rustc2 +${
         state.commit
-      } --include ${bench_name(state.benchmark)} --profiles
+      } --exact-match ${bench_name(state.benchmark)} --profiles
                 ${profile(state.benchmark)} --scenarios ${scenario_filter(
         state.scenario
       )}</code>`;


### PR DESCRIPTION
The example commands always execute a single benchmark, so they should match its name exactly. Found in [#t-compiler/performance > prefix matching name](https://rust-lang.zulipchat.com/#narrow/channel/247081-t-compiler.2Fperformance/topic/prefix.20matching.20name/with/521560453).