### PR TITLE
Use async closures in collector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           rustup default $RUST_TOOLCHAIN_VERSION
           rustup component add --toolchain $RUST_TOOLCHAIN_VERSION rustfmt clippy
         env:
-          RUST_TOOLCHAIN_VERSION: 1.81.0
+          RUST_TOOLCHAIN_VERSION: 1.85.0
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -4,7 +4,7 @@ name = "collector"
 version = "0.1.0"
 edition = "2021"
 description = "Collects Rust performance data"
-rust-version = "1.81.0"
+rust-version = "1.85.0"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/site/src/load.rs
+++ b/site/src/load.rs
@@ -452,7 +452,7 @@ fn sort_queue(
         // are ready to be benchmarked (i.e., those with parent in done or no
         // parent).
         let level_len = partition_in_place(unordered_queue[finished..].iter_mut(), |(_, mr)| {
-            mr.parent_sha().map_or(true, |parent| done.contains(parent))
+            mr.parent_sha().is_none_or(|parent| done.contains(parent))
         });
 
         // No commit is ready for benchmarking. This can happen e.g. when a try parent commit


### PR DESCRIPTION
Finally we can get rid of the cursed passing of Tokio runtime. I tried to do this once some time ago, but it was ~impossible without async closures.