### PR TITLE
Run DB tests against SQLite too

### DIFF
--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -28,4 +28,4 @@ x509-cert = { version = "0.2.5", features = ["pem"] }
 intern = { path = "../intern" }
 
 [dev-dependencies]
-uuid = "1.16.0"
+uuid = { version = "1.16.0", features = ["v4"] }


### PR DESCRIPTION
Modifies the end-to-end DB tests to run against both Postgres and SQLite.