### PR TITLE
Do not compile extended tools in bootstrap benchmark

### DIFF
--- a/collector/src/compile/execute/rustc.rs
+++ b/collector/src/compile/execute/rustc.rs
@@ -98,6 +98,9 @@ async fn record(
         "build.cargo={}",
         toolchain.components.cargo.to_str().unwrap()
     ))
+    // Do not compile all default tools
+    .arg("--set")
+    .arg("build.extended=false")
     .status()
     .context("configuring")?;
     assert!(status.success(), "configure successful");


### PR DESCRIPTION
I really don't think that we have to compile things like `llvm-bitcode-linker` and `wasm-component-ld` in the bootstrap benchmark. Especially the compilation is performed with `-j1`, so compiling tens of dependencies that these crates have is quite painful.

This should speed up the bootstrap build by a couple of minutes, I think.