### PR TITLE
Fix warnings due to `mismatched_lifetime_syntaxes`

### DIFF
--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -452,7 +452,7 @@ struct ArtifactInfo<'a> {
 }
 
 impl ArtifactId {
-    fn info(&self) -> ArtifactInfo {
+    fn info(&self) -> ArtifactInfo<'_> {
         let (name, date, ty) = match self {
             Self::Commit(commit) => (
                 commit.sha.as_str(),

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -453,7 +453,7 @@ impl SqliteConnection {
     pub fn raw(&mut self) -> &mut rusqlite::Connection {
         self.conn.get_mut().unwrap_or_else(|e| e.into_inner())
     }
-    pub fn raw_ref(&self) -> std::sync::MutexGuard<rusqlite::Connection> {
+    pub fn raw_ref(&self) -> std::sync::MutexGuard<'_, rusqlite::Connection> {
         self.conn.lock().unwrap_or_else(|e| e.into_inner())
     }
 }

--- a/site/src/request_handlers/github.rs
+++ b/site/src/request_handlers/github.rs
@@ -161,7 +161,7 @@ async fn handle_rust_timer(
 
 /// Parses the first occurrence of a `@rust-timer queue <shared-args>` command
 /// in the input string.
-fn parse_queue_command(body: &str) -> Option<Result<QueueCommand, String>> {
+fn parse_queue_command(body: &str) -> Option<Result<QueueCommand<'_>, String>> {
     let args = get_command_lines(body, "queue").next()?;
     let args = match parse_command_arguments(args) {
         Ok(args) => args,
@@ -176,7 +176,7 @@ fn parse_queue_command(body: &str) -> Option<Result<QueueCommand, String>> {
 }
 
 /// Parses all occurrences of a `@rust-timer build <shared-args>` command in the input string.
-fn parse_build_commands(body: &str) -> impl Iterator<Item = Result<BuildCommand, String>> {
+fn parse_build_commands(body: &str) -> impl Iterator<Item = Result<BuildCommand<'_>, String>> {
     get_command_lines(body, "build").map(|line| {
         let mut iter = line.splitn(2, ' ');
         let Some(sha) = iter.next().filter(|s| !s.is_empty() && !s.contains('=')) else {


### PR DESCRIPTION
New warn-by-default lint on nightly.