### PR TITLE
Use stable compiler for compiling the `collector`

### DIFF
--- a/collector/collect.sh
+++ b/collector/collect.sh
@@ -16,8 +16,8 @@ while : ; do
 
         # Make sure we have a recent build, so that we can successfully build
         # the collector.
-        rustup update 1.81.0
-        cargo +1.81.0 build --release -p collector
+        rustup update stable
+        cargo +stable build --release -p collector
 
         target/release/collector bench_next $SITE_URL --self-profile --bench-rustc --db $DATABASE
         STATUS=$?


### PR DESCRIPTION
I changed it from nightly to `1.81.0` in February, but since then we bumped MSRV of the collector, so we have been running with an old collector for quite some time :man_facepalming: I wonder if we should error out if the compilation fails?

```
HEAD is now at 88542ee4 Merge pull request #2158 from Kobzol/bootstrap-disable-extended
info: syncing channel updates for '1.81.0-x86_64-unknown-linux-gnu'
1.81.0-x86_64-unknown-linux-gnu unchanged - rustc 1.81.0 (eeb90cda1 2024-09-04)
info: checking for self-update
error: rustc 1.81.0 is not supported by the following packages:
collector@0.1.0 requires rustc 1.85.0
```