### PR TITLE
Triage 2025 06 17

### DIFF
--- a/triage/2025/2025-06-17.md
+++ b/triage/2025/2025-06-17.md
@@ -1,0 +1,196 @@
+# 2025-06-17 Triage Log
+
+Relatively quiet week, with a few improvements to benchmarks leveraging the new
+trait solver.
+
+Triage done by **@kobzol**.
+Revision range: [c31cccb7..45acf54e](https://perf.rust-lang.org/?start=c31cccb7b5cc098b1a8c1794ed38d7fdbec0ccb0&end=45acf54eea118ed27927282b5e0bfdcd80b7987c&absolute=false&stat=instructions%3Au)
+
+**Summary**:
+
+| (instructions:u)                   | mean  | range           | count |
+|:----------------------------------:|:-----:|:---------------:|:-----:|
+| Regressions ❌ <br /> (primary)    | 0.3%  | [0.1%, 0.5%]    | 14    |
+| Regressions ❌ <br /> (secondary)  | 0.3%  | [0.1%, 0.5%]    | 52    |
+| Improvements ✅ <br /> (primary)   | -0.5% | [-4.8%, -0.1%]  | 68    |
+| Improvements ✅ <br /> (secondary) | -4.3% | [-56.5%, -0.1%] | 85    |
+| All ❌✅ (primary)                 | -0.4% | [-4.8%, 0.5%]   | 82    |
+
+
+3 Regressions, 7 Improvements, 4 Mixed; 4 of them in rollups
+51 artifact comparisons made in total
+
+#### Regressions
+
+Rollup of 16 pull requests [#142299](https://github.com/rust-lang/rust/pull/142299) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=c6a955468b025dbe3d1de3e8f3e30496d1fb7f40&end=8ce228758651aa58c4d34e3bd65bf70a251da27e&stat=instructions:u)
+
+| (instructions:u)                   | mean  | range          | count |
+|:----------------------------------:|:-----:|:--------------:|:-----:|
+| Regressions ❌ <br /> (primary)    | 0.5%  | [0.1%, 0.7%]   | 8     |
+| Regressions ❌ <br /> (secondary)  | 0.4%  | [0.2%, 1.1%]   | 37    |
+| Improvements ✅ <br /> (primary)   | -0.2% | [-0.2%, -0.2%] | 1     |
+| Improvements ✅ <br /> (secondary) | -     | -              | 0     |
+| All ❌✅ (primary)                 | 0.4%  | [-0.2%, 0.7%]  | 9     |
+
+- Regression caused by [#142240](https://github.com/rust-lang/rust/pull/142240).
+- Regression fixed in [#142398](https://github.com/rust-lang/rust/pull/142398).
+- Marked as triaged.
+
+Infrastructure for lints during attribute parsing, specifically duplicate usages of attributes [#138164](https://github.com/rust-lang/rust/pull/138164) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=6c8138de8f1c96b2f66adbbc0e37c73525444750&end=573a01569000d395498a5f98f916d6e5305ac81a&stat=instructions:u)
+
+| (instructions:u)                   | mean | range        | count |
+|:----------------------------------:|:----:|:------------:|:-----:|
+| Regressions ❌ <br /> (primary)    | 0.5% | [0.1%, 1.0%] | 107   |
+| Regressions ❌ <br /> (secondary)  | 1.0% | [0.1%, 3.1%] | 56    |
+| Improvements ✅ <br /> (primary)   | -    | -            | 0     |
+| Improvements ✅ <br /> (secondary) | -    | -            | 0     |
+| All ❌✅ (primary)                 | 0.5% | [0.1%, 1.0%] | 107   |
+
+- Regression was fixed in [#142455](https://github.com/rust-lang/rust/pull/142455).
+- Marked as triaged.
+
+Rollup of 9 pull requests [#142443](https://github.com/rust-lang/rust/pull/142443) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=0d6ab209c525e276cbe7544cbd39a3c3619b6b18&end=8da623945f83933dd38644d5745532ee032e855b&stat=instructions:u)
+
+| (instructions:u)                   | mean | range        | count |
+|:----------------------------------:|:----:|:------------:|:-----:|
+| Regressions ❌ <br /> (primary)    | 0.2% | [0.1%, 0.3%] | 7     |
+| Regressions ❌ <br /> (secondary)  | 0.3% | [0.2%, 0.5%] | 22    |
+| Improvements ✅ <br /> (primary)   | -    | -            | 0     |
+| Improvements ✅ <br /> (secondary) | -    | -            | 0     |
+| All ❌✅ (primary)                 | 0.2% | [0.1%, 0.3%] | 7     |
+
+- Most of the (small) regressions seem to be caused by [#142308](https://github.com/rust-lang/rust/pull/142308),
+  which only updates dependencies.
+- Marked as triaged.
+
+#### Improvements
+
+Rollup of 10 pull requests [#142392](https://github.com/rust-lang/rust/pull/142392) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=14346303d760027e53214e705109a62c0f00b214&end=fe5c95d4ae33ec9d7831921e448e2daf8264ea42&stat=instructions:u)
+
+| (instructions:u)                   | mean  | range          | count |
+|:----------------------------------:|:-----:|:--------------:|:-----:|
+| Regressions ❌ <br /> (primary)    | -     | -              | 0     |
+| Regressions ❌ <br /> (secondary)  | -     | -              | 0     |
+| Improvements ✅ <br /> (primary)   | -0.8% | [-4.9%, -0.1%] | 37    |
+| Improvements ✅ <br /> (secondary) | -1.4% | [-7.7%, -0.2%] | 72    |
+| All ❌✅ (primary)                 | -0.8% | [-4.9%, -0.1%] | 37    |
+
+
+[perf] `GenericArgs`-related: Change asserts to debug asserts & use more slice interning over iterable interning [#142289](https://github.com/rust-lang/rust/pull/142289) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=cc87afd8c0f9992d29581a0c26075be0962be8c4&end=49a8ba06848fa8f282fe9055b4178350970bb0ce&stat=instructions:u)
+
+| (instructions:u)                   | mean  | range          | count |
+|:----------------------------------:|:-----:|:--------------:|:-----:|
+| Regressions ❌ <br /> (primary)    | -     | -              | 0     |
+| Regressions ❌ <br /> (secondary)  | -     | -              | 0     |
+| Improvements ✅ <br /> (primary)   | -0.2% | [-0.3%, -0.1%] | 15    |
+| Improvements ✅ <br /> (secondary) | -1.2% | [-4.7%, -0.1%] | 13    |
+| All ❌✅ (primary)                 | -0.2% | [-0.3%, -0.1%] | 15    |
+
+
+move fast reject into inner [#142355](https://github.com/rust-lang/rust/pull/142355) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=38c41d0f926d77985fc17087c21eeb7896dfe61e&end=32b51523f81a5f916c4bb3fee5a749721f19e01d&stat=instructions:u)
+
+| (instructions:u)                   | mean  | range          | count |
+|:----------------------------------:|:-----:|:--------------:|:-----:|
+| Regressions ❌ <br /> (primary)    | -     | -              | 0     |
+| Regressions ❌ <br /> (secondary)  | -     | -              | 0     |
+| Improvements ✅ <br /> (primary)   | -0.4% | [-0.5%, -0.1%] | 15    |
+| Improvements ✅ <br /> (secondary) | -     | -              | 0     |
+| All ❌✅ (primary)                 | -0.4% | [-0.5%, -0.1%] | 15    |
+
+
+early linting: avoid redundant calls to `check_id` [#142398](https://github.com/rust-lang/rust/pull/142398) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=0cbc0764380630780a275c437260e4d4d5f28c92&end=75e7cf5f85aad82331a38deff24845b63eaf30f3&stat=instructions:u)
+
+| (instructions:u)                   | mean  | range          | count |
+|:----------------------------------:|:-----:|:--------------:|:-----:|
+| Regressions ❌ <br /> (primary)    | -     | -              | 0     |
+| Regressions ❌ <br /> (secondary)  | 0.2%  | [0.2%, 0.2%]   | 1     |
+| Improvements ✅ <br /> (primary)   | -0.3% | [-0.6%, -0.1%] | 29    |
+| Improvements ✅ <br /> (secondary) | -0.4% | [-1.0%, -0.2%] | 31    |
+| All ❌✅ (primary)                 | -0.3% | [-0.6%, -0.1%] | 29    |
+
+
+Don't fold `ExternalConstraintsData` when it's empty [#142430](https://github.com/rust-lang/rust/pull/142430) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=75e7cf5f85aad82331a38deff24845b63eaf30f3&end=7827d55852783e8d85932a938d70fff64e9b9f07&stat=instructions:u)
+
+| (instructions:u)                   | mean  | range          | count |
+|:----------------------------------:|:-----:|:--------------:|:-----:|
+| Regressions ❌ <br /> (primary)    | -     | -              | 0     |
+| Regressions ❌ <br /> (secondary)  | -     | -              | 0     |
+| Improvements ✅ <br /> (primary)   | -     | -              | 0     |
+| Improvements ✅ <br /> (secondary) | -0.5% | [-0.7%, -0.2%] | 11    |
+| All ❌✅ (primary)                 | -     | -              | 0     |
+
+
+collect delayed lints in hir_crate_items [#142455](https://github.com/rust-lang/rust/pull/142455) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=7827d55852783e8d85932a938d70fff64e9b9f07&end=586ad391f5ee4519acc7cae340e34673bae762b1&stat=instructions:u)
+
+| (instructions:u)                   | mean  | range          | count |
+|:----------------------------------:|:-----:|:--------------:|:-----:|
+| Regressions ❌ <br /> (primary)    | -     | -              | 0     |
+| Regressions ❌ <br /> (secondary)  | 0.2%  | [0.2%, 0.2%]   | 1     |
+| Improvements ✅ <br /> (primary)   | -0.4% | [-0.8%, -0.2%] | 87    |
+| Improvements ✅ <br /> (secondary) | -1.0% | [-2.5%, -0.1%] | 42    |
+| All ❌✅ (primary)                 | -0.4% | [-0.8%, -0.2%] | 87    |
+
+
+use `MixedBitSet` for borrows-in-scope dataflow analysis [#142471](https://github.com/rust-lang/rust/pull/142471) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=586ad391f5ee4519acc7cae340e34673bae762b1&end=f768dc01da9a681716724418ccf64ce55bd396c5&stat=instructions:u)
+
+| (instructions:u)                   | mean  | range          | count |
+|:----------------------------------:|:-----:|:--------------:|:-----:|
+| Regressions ❌ <br /> (primary)    | -     | -              | 0     |
+| Regressions ❌ <br /> (secondary)  | -     | -              | 0     |
+| Improvements ✅ <br /> (primary)   | -0.7% | [-0.7%, -0.6%] | 2     |
+| Improvements ✅ <br /> (secondary) | -0.6% | [-0.7%, -0.4%] | 5     |
+| All ❌✅ (primary)                 | -0.7% | [-0.7%, -0.6%] | 2     |
+
+
+#### Mixed
+
+cache `param_env` canonicalization [#141451](https://github.com/rust-lang/rust/pull/141451) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=40daf23eeb711dadf140b2536e67e3ff4c999196&end=100199c9aa50b0c47b37c9c86335d68b2a77b535&stat=instructions:u)
+
+| (instructions:u)                   | mean   | range           | count |
+|:----------------------------------:|:------:|:---------------:|:-----:|
+| Regressions ❌ <br /> (primary)    | 0.5%   | [0.5%, 0.5%]    | 1     |
+| Regressions ❌ <br /> (secondary)  | -      | -               | 0     |
+| Improvements ✅ <br /> (primary)   | -      | -               | 0     |
+| Improvements ✅ <br /> (secondary) | -18.3% | [-56.0%, -0.2%] | 13    |
+| All ❌✅ (primary)                 | 0.5%   | [0.5%, 0.5%]    | 1     |
+
+- The single regression was noise.
+- Marked as triaged.
+
+Remove check_mod_loops query and run the checks per-body instead [#141883](https://github.com/rust-lang/rust/pull/141883) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=1677d46cb128cc8f285dbd32b0dc4d7a46437050&end=1c047506f94cd2d05228eb992b0a6bbed1942349&stat=instructions:u)
+
+| (instructions:u)                   | mean  | range          | count |
+|:----------------------------------:|:-----:|:--------------:|:-----:|
+| Regressions ❌ <br /> (primary)    | -     | -              | 0     |
+| Regressions ❌ <br /> (secondary)  | 0.2%  | [0.2%, 0.3%]   | 3     |
+| Improvements ✅ <br /> (primary)   | -     | -              | 0     |
+| Improvements ✅ <br /> (secondary) | -0.3% | [-0.4%, -0.2%] | 8     |
+| All ❌✅ (primary)                 | -     | -              | 0     |
+
+- Tiny regressions and improvements in secondary benchmarks, it's a wash.
+- Marked as triaged.
+
+Make root vars more stable [#142090](https://github.com/rust-lang/rust/pull/142090) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=1c047506f94cd2d05228eb992b0a6bbed1942349&end=2b0274c71dba0e24370ebf65593da450e2e91868&stat=instructions:u)
+
+| (instructions:u)                   | mean  | range          | count |
+|:----------------------------------:|:-----:|:--------------:|:-----:|
+| Regressions ❌ <br /> (primary)    | 0.1%  | [0.1%, 0.1%]   | 1     |
+| Regressions ❌ <br /> (secondary)  | 0.3%  | [0.3%, 0.3%]   | 2     |
+| Improvements ✅ <br /> (primary)   | -     | -              | 0     |
+| Improvements ✅ <br /> (secondary) | -0.9% | [-1.2%, -0.4%] | 9     |
+| All ❌✅ (primary)                 | 0.1%  | [0.1%, 0.1%]   | 1     |
+
+- The single regression on a primary benchmark is a doc build and it's super tiny, the rest are tiny improvements.
+- Marked as triaged.
+
+Rollup of 10 pull requests [#142442](https://github.com/rust-lang/rust/pull/142442) [(Comparison Link)](https://perf.rust-lang.org/compare.html?start=015c7770ec0ffdba9ff03f1861144a827497f8ca&end=c35911781925bcbfdeb5e6e1adb305097af46801&stat=instructions:u)
+
+| (instructions:u)                   | mean  | range          | count |
+|:----------------------------------:|:-----:|:--------------:|:-----:|
+| Regressions ❌ <br /> (primary)    | 0.2%  | [0.1%, 0.3%]   | 9     |
+| Regressions ❌ <br /> (secondary)  | 0.2%  | [0.1%, 0.3%]   | 21    |
+| Improvements ✅ <br /> (primary)   | -     | -              | 0     |
+| Improvements ✅ <br /> (secondary) | -0.2% | [-0.2%, -0.1%] | 5     |
+| All ❌✅ (primary)                 | 0.2%  | [0.1%, 0.3%]   | 9     |
+
+- Several PRs were tried, but so far we haven't been able to figure out what caused the regression.


### PR DESCRIPTION
[Rendered](https://github.com/Kobzol/rustc-perf/blob/d40fd2e4bd715c7d350d23e0c894f97f915998b6/triage/2025/2025-06-17.md)

Note that I started putting the triage files into the `2025` directory, so that we have a better directory structure and the page with all the MD files doesn't take so long to load.