### PR TITLE
Do not show patch release data in the dashboard

### DIFF
--- a/site/src/request_handlers/dashboard.rs
+++ b/site/src/request_handlers/dashboard.rs
@@ -14,7 +14,8 @@ pub async fn handle_dashboard(ctxt: Arc<SiteCtxt>) -> ServerResult<dashboard::Re
 
     let mut versions = index
         .artifacts()
-        .filter(|a| a.starts_with("1.") || a.starts_with("beta"))
+        // Do not consider patch releases, only consider 1.XYZ.0
+        .filter(|a| (a.starts_with("1.") && a.ends_with(".0")) || a.starts_with("beta"))
         .collect::<Vec<_>>();
     versions.sort_by(|a, b| {
         match (


### PR DESCRIPTION
To make the stable release gaps more evenly spaced. Suggested here: [#t-compiler/performance > Switching the default benchmark runner to AX-42 @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/247081-t-compiler.2Fperformance/topic/Switching.20the.20default.20benchmark.20runner.20to.20AX-42/near/526878416).