### PR TITLE
Fix compilation of the stable cargo benchmark on latest beta

### DIFF
--- a/collector/compile-benchmarks/cargo/src/cargo/util/flock.rs
+++ b/collector/compile-benchmarks/cargo/src/cargo/util/flock.rs
@@ -222,9 +222,9 @@ impl Filesystem {
                         &|| f.lock_exclusive())?;
             }
             State::Shared => {
-                acquire(config, msg, &path,
-                        &|| f.try_lock_shared(),
-                        &|| f.lock_shared())?;
+                // acquire(config, msg, &path,
+                //         &|| f.try_lock_shared(),
+                //         &|| f.lock_shared())?;
             }
             State::Unlocked => {}
 


### PR DESCRIPTION
https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/Stable.20cargo.20benchmark.20broke.20with.20latest.20beta/with/527261893