### PR TITLE
Do not panic on S3 file upload failures

### DIFF
--- a/collector/src/compile/execute/bencher.rs
+++ b/collector/src/compile/execute/bencher.rs
@@ -345,9 +345,9 @@ impl SelfProfileS3Upload {
         let start = std::time::Instant::now();
         let status = self.0.wait().expect("waiting for child");
         if !status.success() {
-            panic!("S3 upload failed: {:?}", status);
+            log::error!("S3 upload failed: {status:?}");
+        } else {
+            log::trace!("uploaded to S3, additional wait: {:?}", start.elapsed());
         }
-
-        log::trace!("uploaded to S3, additional wait: {:?}", start.elapsed());
     }
 }


### PR DESCRIPTION
We have started hitting this a few times today when uploading the self-profile artifacts to S3:
```
upload failed: ../../../tmp/.tmp1aGYxm to s3://rustc-perf/self-profile/67394/derive/check/full/self-profile-32456021.mm_profdata.sz SSL validation failed for https://rustc-perf.s3.us-west-1.amazonaws.com/self-profile/67394/derive/check/full/self-profile-32456021.mm_profdata.sz EOF occurred in violation of protocol (_ssl.c:2406)
```
I don't think it's worth it to crash/interrupt the whole collection when a self-profile file can't be uploaded, we use them very sparsely anyway, and if the unlikely case happened that an important self-profile case was missing, we can just rerun locally.