### PR TITLE
Log duration of self-profile parsing

### DIFF
--- a/collector/src/compile/execute/mod.rs
+++ b/collector/src/compile/execute/mod.rs
@@ -22,6 +22,7 @@ use std::pin::Pin;
 use std::process::{self, Command};
 use std::str;
 use std::sync::LazyLock;
+use std::time::Instant;
 
 pub mod bencher;
 mod etw_parser;
@@ -758,6 +759,7 @@ fn parse_self_profile(
     }
     let (profile, files) = if let Some(profile_path) = full_path {
         // measureme 0.8+ uses a single file
+        let start = Instant::now();
         let data = fs::read(&profile_path)?;
 
         // HACK: `decodeme` can unexpectedly panic on invalid data produced by rustc. We catch this
@@ -779,6 +781,10 @@ fn parse_self_profile(
                 return Err(std::io::Error::new(ErrorKind::InvalidData, error));
             }
         };
+        log::trace!(
+            "Self profile analyze duration: {}",
+            start.elapsed().as_secs_f64()
+        );
 
         let profile = SelfProfile {
             artifact_sizes: results.artifact_sizes,


### PR DESCRIPTION
I profiled rustc-perf locally, and it seems like we spent a bunch of time on parsing the self-profile files. This is quite wasteful, because they can be quite large, and we iterate through the whole file, load and allocate all the event labels, and then only take the artifact numbers from it, which is like 6 numbers.

I have code locally that optimizes this so that the loading is 2x faster, but I want to first see how much time we actually spend on this in production. My estimate is around 1 minute per benchmark run.