### PR TITLE
Revert "Do not panic on S3 file upload failures"

### DIFF
--- a/collector/src/compile/execute/bencher.rs
+++ b/collector/src/compile/execute/bencher.rs
@@ -338,9 +338,9 @@ impl SelfProfileS3Upload {
         let start = std::time::Instant::now();
         let status = self.0.wait().expect("waiting for child");
         if !status.success() {
-            log::error!("S3 upload failed: {status:?}");
-        } else {
-            log::trace!("uploaded to S3, additional wait: {:?}", start.elapsed());
+            panic!("S3 upload failed: {:?}", status);
         }
+
+        log::trace!("uploaded to S3, additional wait: {:?}", start.elapsed());
     }
 }


### PR DESCRIPTION
Reverts rust-lang/rustc-perf#2188. The S3 errors have stopped, so let's revert to have more visibility into potential future failures.