### PR TITLE
Feat; job_queue table definition & mark a request as complete if all jobs are finished

### DIFF
--- a/database/schema.md
+++ b/database/schema.md
@@ -321,11 +321,28 @@ collector which benchmarks it should execute. The jobs will be kept in the
 table for ~30 days after being completed, so that we can quickly figure out
 what master parent jobs we need to backfill when handling try builds.
 
-```
-psql# SELECT * FROM job_queue limit 1;
+Columns:
 
-id   request_id   target    backend   benchmark_set  collector_id    created_at                   started_at                   completed_at                 status     retry   error 
----  -----------  --------  --------  -------------  --------------  ---------------------------  ---------------------------  ---------------------------  ---------  ------  --------
-23            7   AArch64   llvm      5              collector-1     2025-07-10 09:00:00.123+00   2025-07-10 09:05:02.456+00   2025-07-10 09:15:17.890+00   complete       0  
-```
->>>>>>> d0ed82ff (Feat; job_queue table definition & mark a request as complete if all jobs are finished)
+- **id** (`bigint` / `serial`): Primary-key identifier for the job row;
+  auto-increments with each new job.
+- **request_id** (`bigint`): References the parent benchmark request that
+  spawned this job.
+- **target** (`text NOT NULL`): Hardware/ISA the benchmarks must run on
+  (e.g. AArch64, x86_64).
+- **backend** (`text NOT NULL`): Code generation backend the collector should
+  test (e.g. llvm, cranelift).
+- **benchmark_set** (`int NOT NULL`): ID of the predefined benchmark suite to
+  execute.
+- **collector_id** (`text`): Id of the collector that claimed the job
+  (populated once the job is started).
+- **created_at** (`timestamptz NOT NULL`): Datetime when the job was queued.
+- **started_at** (`timestamptz`): Datetime when the collector actually began
+  running the benchmarks; NULL until the job is claimed.
+- **completed_at** (`timestampt`): Datetime when the collector finished
+  (successfully or otherwise); used to purge rows after ~30 days.
+- **status** (`text NOT NULL`): Current job state. `queued`, `in_progress`,
+  `success`, or `failure`.
+- **retry** (`int NOT NULL`): Number of times the job has been re-queued after
+  a failure; 0 on the first attempt.
+- **error** (`text`): Optional error message or stack trace from the last
+  failed run; NULL when the job succeeded.

--- a/database/schema.md
+++ b/database/schema.md
@@ -313,3 +313,19 @@ Columns:
   execute.
 * **is_active** (`boolean NOT NULL`): For controlling whether the collector is
   active for use. Useful for adding/removing collectors.
+
+### job_queue
+
+This table stores ephemeral benchmark jobs, which specifically tell the
+collector which benchmarks it should execute. The jobs will be kept in the
+table for ~30 days after being completed, so that we can quickly figure out
+what master parent jobs we need to backfill when handling try builds.
+
+```
+psql# SELECT * FROM job_queue limit 1;
+
+id   request_id   target    backend   benchmark_set  collector_id    created_at                   started_at                   completed_at                 status     retry   error 
+---  -----------  --------  --------  -------------  --------------  ---------------------------  ---------------------------  ---------------------------  ---------  ------  --------
+23            7   AArch64   llvm      5              collector-1     2025-07-10 09:00:00.123+00   2025-07-10 09:05:02.456+00   2025-07-10 09:15:17.890+00   complete       0  
+```
+>>>>>>> d0ed82ff (Feat; job_queue table definition & mark a request as complete if all jobs are finished)

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -1053,6 +1053,7 @@ impl BenchmarkRequestIndex {
     }
 
     pub fn add_tag(&mut self, tag: &str) {
+        self.all.insert(tag.to_string());
         self.completed.insert(tag.to_string());
     }
 }
@@ -1088,12 +1089,15 @@ impl fmt::Display for BenchmarkJobStatus {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct BenchmarkSet(u32);
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct BenchmarkJob {
     target: Target,
     backend: CodegenBackend,
-    benchmark_set: u32,
+    benchmark_set: BenchmarkSet,
     collector_id: String,
-    created_at: Option<DateTime<Utc>>,
+    created_at: DateTime<Utc>,
     started_at: Option<DateTime<Utc>>,
     completed_at: Option<DateTime<Utc>>,
     status: BenchmarkJobStatus,
@@ -1106,14 +1110,15 @@ impl BenchmarkJob {
         backend: CodegenBackend,
         benchmark_set: u32,
         collector_id: &str,
+        created_at: DateTime<Utc>,
         status: BenchmarkJobStatus,
     ) -> Self {
         BenchmarkJob {
             target,
             backend,
-            benchmark_set,
+            benchmark_set: BenchmarkSet(benchmark_set),
             collector_id: collector_id.to_string(),
-            created_at: None,
+            created_at,
             started_at: None,
             completed_at: None,
             status,

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -1065,13 +1065,18 @@ pub enum BenchmarkJobStatus {
     Failure,
 }
 
+const BENCHMARK_JOB_STATUS_QUEUED_STR: &str = "queued";
+const BENCHMARK_JOB_STATUS_IN_PROGRESS_STR: &str = "in_progress";
+const BENCHMARK_JOB_STATUS_SUCCESS_STR: &str = "success";
+const BENCHMARK_JOB_STATUS_FAILURE_STR: &str = "failure";
+
 impl BenchmarkJobStatus {
     pub fn as_str(&self) -> &str {
         match self {
-            BenchmarkJobStatus::Queued => "queued",
-            BenchmarkJobStatus::InProgress => "in_progress",
-            BenchmarkJobStatus::Success => "success",
-            BenchmarkJobStatus::Failure => "failure",
+            BenchmarkJobStatus::Queued => BENCHMARK_JOB_STATUS_QUEUED_STR,
+            BenchmarkJobStatus::InProgress => BENCHMARK_JOB_STATUS_IN_PROGRESS_STR,
+            BenchmarkJobStatus::Success => BENCHMARK_JOB_STATUS_SUCCESS_STR,
+            BenchmarkJobStatus::Failure => BENCHMARK_JOB_STATUS_FAILURE_STR,
         }
     }
 }
@@ -1084,15 +1089,15 @@ impl fmt::Display for BenchmarkJobStatus {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct BenchmarkJob {
-    pub target: Target,
-    pub backend: CodegenBackend,
-    pub benchmark_set: u32,
-    pub collector_id: String,
-    pub created_at: Option<DateTime<Utc>>,
-    pub started_at: Option<DateTime<Utc>>,
-    pub completed_at: Option<DateTime<Utc>>,
-    pub status: BenchmarkJobStatus,
-    pub retry: u32,
+    target: Target,
+    backend: CodegenBackend,
+    benchmark_set: u32,
+    collector_id: String,
+    created_at: Option<DateTime<Utc>>,
+    started_at: Option<DateTime<Utc>>,
+    completed_at: Option<DateTime<Utc>>,
+    status: BenchmarkJobStatus,
+    retry: u32,
 }
 
 impl BenchmarkJob {

--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -1,16 +1,6 @@
 use crate::pool::{Connection, ConnectionManager, ManagedConnection, Transaction};
 use crate::selector::CompileTestCase;
 use crate::{
-<<<<<<< HEAD
-    ArtifactCollection, ArtifactId, ArtifactIdNumber, Benchmark, BenchmarkJobStatus,
-||||||| parent of d0ed82ff (Feat; job_queue table definition & mark a request as complete if all jobs are finished)
-    ArtifactCollection, ArtifactId, ArtifactIdNumber, Benchmark, BenchmarkRequest,
-    BenchmarkRequestIndex, BenchmarkRequestStatus, BenchmarkRequestType, CodegenBackend,
-    CollectionId, Commit, CommitType, CompileBenchmark, Date, Index, Profile, QueuedCommit,
-    Scenario, Target, BENCHMARK_REQUEST_MASTER_STR, BENCHMARK_REQUEST_RELEASE_STR,
-=======
-    ArtifactCollection, ArtifactId, ArtifactIdNumber, Benchmark, BenchmarkJob, BenchmarkJobStatus,
->>>>>>> d0ed82ff (Feat; job_queue table definition & mark a request as complete if all jobs are finished)
     BenchmarkRequest, BenchmarkRequestIndex, BenchmarkRequestStatus, BenchmarkRequestType,
     CodegenBackend, CollectionId, Commit, CommitType, CompileBenchmark, Date, Index, Profile,
     QueuedCommit, Scenario, Target, BENCHMARK_REQUEST_MASTER_STR, BENCHMARK_REQUEST_RELEASE_STR,
@@ -1721,7 +1711,7 @@ where
             .collect())
     }
 
-    async fn try_mark_benchmark_request_as_completed(
+    async fn mark_benchmark_request_as_completed(
         &self,
         benchmark_request: &mut BenchmarkRequest,
     ) -> anyhow::Result<bool> {
@@ -1779,43 +1769,6 @@ where
             Ok(true)
         } else {
             Ok(false)
-        }
-    }
-
-    async fn get_benchmark_request_id(
-        &self,
-        benchmark_request: &BenchmarkRequest,
-    ) -> anyhow::Result<u32> {
-        anyhow::ensure!(
-            benchmark_request.tag().is_some(),
-            "Benchmark request has no tag"
-        );
-
-        let row = self
-            .conn()
-            .query_opt(
-                "
-                SELECT
-                    id
-                FROM
-                    benchmark_request
-                WHERE
-                    tag = $1
-                    AND commit_type = $2
-                    AND status = $3;",
-                &[
-                    &benchmark_request.tag(),
-                    &benchmark_request.commit_type,
-                    &benchmark_request.status,
-                ],
-            )
-            .await
-            .context("Failed to get id for benchmark_request")?;
-
-        if let Some(row) = row {
-            Ok(row.get::<_, i32>(0) as u32)
-        } else {
-            Ok(1)
         }
     }
 }

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -1,9 +1,9 @@
 use crate::pool::{Connection, ConnectionManager, ManagedConnection, Transaction};
 use crate::selector::CompileTestCase;
 use crate::{
-    ArtifactCollection, ArtifactId, Benchmark, BenchmarkRequest, BenchmarkRequestIndex,
-    BenchmarkRequestStatus, CodegenBackend, CollectionId, Commit, CommitType, CompileBenchmark,
-    Date, Profile, Target,
+    ArtifactCollection, ArtifactId, Benchmark, BenchmarkJob, BenchmarkRequest,
+    BenchmarkRequestIndex, BenchmarkRequestStatus, CodegenBackend, CollectionId, Commit,
+    CommitType, CompileBenchmark, Date, Profile, Target,
 };
 use crate::{ArtifactIdNumber, Index, QueuedCommit};
 use chrono::{DateTime, TimeZone, Utc};
@@ -1329,6 +1329,20 @@ impl Connection for SqliteConnection {
                 })
             })?
             .collect::<Result<_, _>>()?)
+    }
+
+    async fn try_mark_benchmark_request_as_completed(
+        &self,
+        _benchmark_request: &mut BenchmarkRequest,
+    ) -> anyhow::Result<bool> {
+        no_queue_implementation_abort!()
+    }
+
+    async fn get_benchmark_request_id(
+        &self,
+        _benchmark_request: &BenchmarkRequest,
+    ) -> anyhow::Result<u32> {
+        no_queue_implementation_abort!()
     }
 }
 

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -1,9 +1,9 @@
 use crate::pool::{Connection, ConnectionManager, ManagedConnection, Transaction};
 use crate::selector::CompileTestCase;
 use crate::{
-    ArtifactCollection, ArtifactId, Benchmark, BenchmarkJob, BenchmarkRequest,
-    BenchmarkRequestIndex, BenchmarkRequestStatus, CodegenBackend, CollectionId, Commit,
-    CommitType, CompileBenchmark, Date, Profile, Target,
+    ArtifactCollection, ArtifactId, Benchmark, BenchmarkRequest, BenchmarkRequestIndex,
+    BenchmarkRequestStatus, CodegenBackend, CollectionId, Commit, CommitType, CompileBenchmark,
+    Date, Profile, Target,
 };
 use crate::{ArtifactIdNumber, Index, QueuedCommit};
 use chrono::{DateTime, TimeZone, Utc};
@@ -1331,17 +1331,10 @@ impl Connection for SqliteConnection {
             .collect::<Result<_, _>>()?)
     }
 
-    async fn try_mark_benchmark_request_as_completed(
+    async fn mark_benchmark_request_as_completed(
         &self,
         _benchmark_request: &mut BenchmarkRequest,
     ) -> anyhow::Result<bool> {
-        no_queue_implementation_abort!()
-    }
-
-    async fn get_benchmark_request_id(
-        &self,
-        _benchmark_request: &BenchmarkRequest,
-    ) -> anyhow::Result<u32> {
         no_queue_implementation_abort!()
     }
 }

--- a/site/src/job_queue/mod.rs
+++ b/site/src/job_queue/mod.rs
@@ -253,8 +253,13 @@ async fn try_enqueue_next_benchmark_request(
                 break;
             }
             BenchmarkRequestStatus::InProgress => {
-                // TODO: Try to mark as completed
-                break;
+                if conn
+                    .try_mark_benchmark_request_as_completed(&mut request)
+                    .await?
+                {
+                    index.add_tag(request.tag().unwrap());
+                    continue;
+                }
             }
             BenchmarkRequestStatus::WaitingForArtifacts
             | BenchmarkRequestStatus::Completed { .. } => {


### PR DESCRIPTION
- Creates the `job_queue` table.
- Inserts into the `job_queue`.
- Marks a `benchmark_request` as complete if all jobs associated with the request have the status of `success` or `failure`.

I've omitted `job_splitting` as this PR is modestly big. However, bar marking things as complete, the PR is fairly mechanical.