### PR TITLE
Add basic benchmark set implementation

### DIFF
--- a/collector/compile-benchmarks/README.md
+++ b/collector/compile-benchmarks/README.md
@@ -203,6 +203,7 @@ Rust code being written today.
       applies correctly, e.g. `target/release/collector bench_local +nightly
       --id Test --profiles=Check --scenarios=IncrPatched
       --include=$NEW_BENCHMARK`
+  - Add the new entry to `collector/src/benchmark_set/compile_benchmarks.rs`.
   - Add the new entry to `collector/compile-benchmarks/README.md`.
   - Add a new licensing entry to `collector/compile-benchmarks/REUSE.toml` (see existing entries
   for inspiration).
@@ -245,6 +246,7 @@ Rust code being written today.
 - In the first commit just remove the old code.
   - Do this with `git rm -r` on the directory.
 - In the second commit do everything else.
+  - Remove the entry from `collector/src/benchmark_set/compile_benchmarks.rs`.
   - Remove the entry from `collector/compile-benchmarks/README.md`.
   - Remove the entry from `collector/compile-benchmarks/REUSE.toml`.
   - `git grep` for occurrences of the old benchmark name (e.g. in

--- a/collector/src/benchmark_set/compile_benchmarks.rs
+++ b/collector/src/benchmark_set/compile_benchmarks.rs
@@ -1,0 +1,57 @@
+//! This file contains an exhaustive list of all **non-stable** compile-time benchmarks
+//! located in the `collector/compile-benchmarks` directory that are benchmarked in production.
+//! If new benchmarks are added/removed, they have to also be added/removed here, and in
+//! the [super::expand_benchmark_set] function.
+
+pub(super) const AWAIT_CALL_TREE: &str = "await-call-tree";
+pub(super) const BITMAPS_3_2_1: &str = "bitmaps-3.2.1";
+pub(super) const BITMAPS_3_2_1_NEW_SOLVER: &str = "bitmaps-3.2.1-new-solver";
+pub(super) const CARGO_0_87_1: &str = "cargo-0.87.1";
+pub(super) const CLAP_DERIVE_4_5_32: &str = "clap_derive-4.5.32";
+pub(super) const COERCIONS: &str = "coercions";
+pub(super) const CRANELIFT_CODEGEN_0_119_0: &str = "cranelift-codegen-0.119.0";
+pub(super) const CTFE_STRESS_5: &str = "ctfe-stress-5";
+pub(super) const DEEP_VECTOR: &str = "deep-vector";
+pub(super) const DEEPLY_NESTED_MULTI: &str = "deeply-nested-multi";
+pub(super) const DERIVE: &str = "derive";
+pub(super) const DIESEL_2_2_10: &str = "diesel-2.2.10";
+pub(super) const EXTERNS: &str = "externs";
+pub(super) const EZA_0_21_2: &str = "eza-0.21.2";
+pub(super) const HELLOWORLD: &str = "helloworld";
+pub(super) const HELLOWORLD_TINY: &str = "helloworld-tiny";
+pub(super) const HTML5EVER_0_31_0: &str = "html5ever-0.31.0";
+pub(super) const HTML5EVER_0_31_0_NEW_SOLVER: &str = "html5ever-0.31.0-new-solver";
+pub(super) const HYPER_1_6_0: &str = "hyper-1.6.0";
+pub(super) const IMAGE_0_25_6: &str = "image-0.25.6";
+pub(super) const INCLUDE_BLOB: &str = "include-blob";
+pub(super) const ISSUE_46449: &str = "issue-46449";
+pub(super) const ISSUE_58319: &str = "issue-58319";
+pub(super) const ISSUE_88862: &str = "issue-88862";
+pub(super) const LARGE_WORKSPACE: &str = "large-workspace";
+pub(super) const LIBC_0_2_172: &str = "libc-0.2.172";
+pub(super) const MANY_ASSOC_ITEMS: &str = "many-assoc-items";
+pub(super) const MATCH_STRESS: &str = "match-stress";
+pub(super) const NALGEBRA_0_33_0: &str = "nalgebra-0.33.0";
+pub(super) const NALGEBRA_0_33_0_NEW_SOLVER: &str = "nalgebra-0.33.0-new-solver";
+pub(super) const PROJECTION_CACHING: &str = "projection-caching";
+pub(super) const REGEX_AUTOMATA_0_4_8: &str = "regex-automata-0.4.8";
+pub(super) const REGRESSION_31157: &str = "regression-31157";
+pub(super) const RIPGREP_14_1_1: &str = "ripgrep-14.1.1";
+pub(super) const RIPGREP_14_1_1_TINY: &str = "ripgrep-14.1.1-tiny";
+pub(super) const SERDE_1_0_219: &str = "serde-1.0.219";
+pub(super) const SERDE_1_0_219_NEW_SOLVER: &str = "serde-1.0.219-new-solver";
+pub(super) const SERDE_1_0_219_THREADS4: &str = "serde-1.0.219-threads4";
+pub(super) const SERDE_DERIVE_1_0_219: &str = "serde_derive-1.0.219";
+pub(super) const STM32F4_0_15_1: &str = "stm32f4-0.15.1";
+pub(super) const SYN_2_0_101: &str = "syn-2.0.101";
+pub(super) const SYN_2_0_101_NEW_SOLVER: &str = "syn-2.0.101-new-solver";
+pub(super) const TOKEN_STREAM_STRESS: &str = "token-stream-stress";
+pub(super) const TT_MUNCHER: &str = "tt-muncher";
+pub(super) const TUPLE_STRESS: &str = "tuple-stress";
+pub(super) const TYPENUM_1_18_0: &str = "typenum-1.18.0";
+pub(super) const UCD: &str = "ucd";
+pub(super) const UNICODE_NORMALIZATION_0_1_24: &str = "unicode-normalization-0.1.24";
+pub(super) const UNIFY_LINEARLY: &str = "unify-linearly";
+pub(super) const UNUSED_WARNINGS: &str = "unused-warnings";
+pub(super) const WF_PROJECTION_STRESS_65510: &str = "wf-projection-stress-65510";
+pub(super) const WG_GRAMMAR: &str = "wg-grammar";

--- a/collector/src/benchmark_set/mod.rs
+++ b/collector/src/benchmark_set/mod.rs
@@ -1,0 +1,199 @@
+//! This module serves for defining the benchmark sets that are used by individual collectors.
+//! Each benchmark set is identified by a pair (target, ID); each target has a specific number
+//! of IDs.
+//! The union of all benchmark sets for a given target should represent all the benchmarks that
+//! should be executed on a master/try artifact.
+//! Release artifacts do not participate in the benchmark set splitting and are always executed
+//! on a single collector per target.
+
+mod compile_benchmarks;
+
+use crate::compile::benchmark::target::Target;
+use crate::compile::benchmark::BenchmarkName;
+
+/// Represents a single set of master/try benchmarks.
+#[derive(Debug)]
+pub struct BenchmarkSetId {
+    target: Target,
+    index: u32,
+}
+
+impl BenchmarkSetId {
+    pub fn new(target: Target, index: u32) -> Self {
+        Self { target, index }
+    }
+}
+
+/// Represents a subset of benchmarks that should be benchmarked by a single collector.
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub enum BenchmarkSetMember {
+    /// Benchmark a specific compile-time benchmark
+    CompileBenchmark(BenchmarkName),
+    /// Benchmark *all* the runtime benchmarks.
+    /// For simplicity, we currently always benchmark all of them on a single collector.
+    RuntimeBenchmarks,
+    /// Benchmark the rustc bootstrap
+    Rustc,
+}
+
+/// Return the number of benchmark sets for the given target.
+pub fn benchmark_set_count(target: Target) -> usize {
+    match target {
+        Target::X86_64UnknownLinuxGnu => 1,
+    }
+}
+
+/// Expand all the benchmarks that should be performed by a single collector.
+pub fn expand_benchmark_set(id: BenchmarkSetId) -> Vec<BenchmarkSetMember> {
+    use compile_benchmarks::*;
+
+    match (id.target, id.index) {
+        (Target::X86_64UnknownLinuxGnu, 0) => {
+            vec![
+                compile(AWAIT_CALL_TREE),
+                compile(BITMAPS_3_2_1),
+                compile(BITMAPS_3_2_1_NEW_SOLVER),
+                compile(CARGO_0_87_1),
+                compile(CLAP_DERIVE_4_5_32),
+                compile(COERCIONS),
+                compile(CRANELIFT_CODEGEN_0_119_0),
+                compile(CTFE_STRESS_5),
+                compile(DEEP_VECTOR),
+                compile(DEEPLY_NESTED_MULTI),
+                compile(DERIVE),
+                compile(DIESEL_2_2_10),
+                compile(EXTERNS),
+                compile(EZA_0_21_2),
+                compile(HELLOWORLD),
+                compile(HELLOWORLD_TINY),
+                compile(HTML5EVER_0_31_0),
+                compile(HTML5EVER_0_31_0_NEW_SOLVER),
+                compile(HYPER_1_6_0),
+                compile(IMAGE_0_25_6),
+                compile(INCLUDE_BLOB),
+                compile(ISSUE_46449),
+                compile(ISSUE_58319),
+                compile(ISSUE_88862),
+                compile(LARGE_WORKSPACE),
+                compile(LIBC_0_2_172),
+                compile(MANY_ASSOC_ITEMS),
+                compile(MATCH_STRESS),
+                compile(NALGEBRA_0_33_0),
+                compile(NALGEBRA_0_33_0_NEW_SOLVER),
+                compile(PROJECTION_CACHING),
+                compile(REGEX_AUTOMATA_0_4_8),
+                compile(REGRESSION_31157),
+                compile(RIPGREP_14_1_1),
+                compile(RIPGREP_14_1_1_TINY),
+                compile(SERDE_1_0_219),
+                compile(SERDE_1_0_219_NEW_SOLVER),
+                compile(SERDE_1_0_219_THREADS4),
+                compile(SERDE_DERIVE_1_0_219),
+                compile(STM32F4_0_15_1),
+                compile(SYN_2_0_101),
+                compile(SYN_2_0_101_NEW_SOLVER),
+                compile(TOKEN_STREAM_STRESS),
+                compile(TT_MUNCHER),
+                compile(TUPLE_STRESS),
+                compile(TYPENUM_1_18_0),
+                compile(UCD),
+                compile(UNICODE_NORMALIZATION_0_1_24),
+                compile(UNIFY_LINEARLY),
+                compile(UNUSED_WARNINGS),
+                compile(WF_PROJECTION_STRESS_65510),
+                compile(WG_GRAMMAR),
+                BenchmarkSetMember::Rustc,
+                BenchmarkSetMember::RuntimeBenchmarks,
+            ]
+        }
+        (Target::X86_64UnknownLinuxGnu, 1..) => {
+            panic!("Unknown benchmark set id {id:?}");
+        }
+    }
+}
+
+/// Helper function for creating compile-time benchmark member sets.
+fn compile(name: &str) -> BenchmarkSetMember {
+    BenchmarkSetMember::CompileBenchmark(BenchmarkName::from(name))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::benchmark_set::{
+        benchmark_set_count, expand_benchmark_set, BenchmarkSetId, BenchmarkSetMember,
+    };
+    use crate::compile::benchmark::target::Target;
+    use crate::compile::benchmark::{
+        get_compile_benchmarks, BenchmarkName, CompileBenchmarkFilter,
+    };
+    use std::collections::HashSet;
+    use std::path::Path;
+
+    /// Sanity check for making sure that the expanded benchmark sets are non-overlapping and
+    /// complete, i.e. they don't miss any benchmarks.
+    #[test]
+    fn check_benchmark_set_x64() {
+        let target = Target::X86_64UnknownLinuxGnu;
+        let sets = (0..benchmark_set_count(target))
+            .map(|index| {
+                expand_benchmark_set(BenchmarkSetId {
+                    target,
+                    index: index as u32,
+                })
+            })
+            .collect::<Vec<Vec<BenchmarkSetMember>>>();
+
+        // Assert set is unique
+        for set in &sets {
+            let hashset = set.iter().collect::<HashSet<_>>();
+            assert_eq!(
+                set.len(),
+                hashset.len(),
+                "Benchmark set {set:?} contains duplicates"
+            );
+        }
+
+        // Go through all unique pairs of sets and assert that they don't overlap
+        for i in 0..sets.len() {
+            for j in i + 1..sets.len() {
+                let set_a = &sets[i];
+                let set_b = &sets[j];
+                let hashset_a = set_a.iter().collect::<HashSet<_>>();
+                let hashset_b = set_b.iter().collect::<HashSet<_>>();
+                assert!(
+                    hashset_a.is_disjoint(&hashset_b),
+                    "Benchmark sets {set_a:?} and {set_b:?} overlap"
+                );
+            }
+        }
+
+        // Check that the union of all sets contains all the required benchmarks
+        let all_members = sets.iter().flatten().collect::<HashSet<_>>();
+        assert!(all_members.contains(&BenchmarkSetMember::Rustc));
+        assert!(all_members.contains(&BenchmarkSetMember::RuntimeBenchmarks));
+
+        const BENCHMARK_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/compile-benchmarks");
+        let all_compile_benchmarks =
+            get_compile_benchmarks(Path::new(BENCHMARK_DIR), CompileBenchmarkFilter::All)
+                .unwrap()
+                .into_iter()
+                .filter(|b| !b.category().is_stable())
+                .map(|b| b.name)
+                .collect::<Vec<BenchmarkName>>();
+        for benchmark in &all_compile_benchmarks {
+            assert!(
+                all_members.contains(&BenchmarkSetMember::CompileBenchmark(benchmark.clone())),
+                "Compile-time benchmark `{benchmark}` is missing in the union of all sets"
+            );
+        }
+        for benchmark in &all_members {
+            if let BenchmarkSetMember::CompileBenchmark(name) = benchmark {
+                assert!(
+                    all_compile_benchmarks.contains(name),
+                    "Compile-time benchmark {name} does not exist on disk or is a stable benchmark"
+                );
+            }
+        }
+        assert_eq!(all_members.len(), all_compile_benchmarks.len() + 2);
+    }
+}

--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -1042,12 +1042,7 @@ fn main_result() -> anyhow::Result<i32> {
 
                         let compile_config = CompileBenchmarkConfig {
                             benchmarks,
-                            profiles: vec![
-                                Profile::Check,
-                                Profile::Debug,
-                                Profile::Doc,
-                                Profile::Opt,
-                            ],
+                            profiles: Profile::default_profiles(),
                             scenarios: Scenario::all(),
                             backends,
                             iterations: runs.map(|v| v as usize),

--- a/collector/src/compile/benchmark/mod.rs
+++ b/collector/src/compile/benchmark/mod.rs
@@ -98,8 +98,14 @@ impl BenchmarkConfig {
     }
 }
 
-#[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Hash)]
+#[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Hash, Debug)]
 pub struct BenchmarkName(pub String);
+
+impl<'a> From<&'a str> for BenchmarkName {
+    fn from(value: &'a str) -> Self {
+        Self(value.to_string())
+    }
+}
 
 impl std::fmt::Display for BenchmarkName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/collector/src/compile/benchmark/profile.rs
+++ b/collector/src/compile/benchmark/profile.rs
@@ -34,6 +34,11 @@ impl Profile {
         ]
     }
 
+    /// Set of default profiles that should be benchmarked for a master/try artifact.
+    pub fn default_profiles() -> Vec<Self> {
+        vec![Profile::Check, Profile::Debug, Profile::Doc, Profile::Opt]
+    }
+
     pub fn is_doc(&self) -> bool {
         match self {
             Profile::Doc | Profile::DocJson => true,

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -7,6 +7,7 @@ use std::process::{self, Command};
 
 pub mod api;
 pub mod artifact_stats;
+pub mod benchmark_set;
 pub mod cargo;
 pub mod codegen;
 pub mod compare;


### PR DESCRIPTION
This will be used to determine how many benchmark sets there are for a given target, and also for determining the actual benchmarks that should be performed on a given collector.

This PR just creates the initial infrastructure, collectors don't make use of it yet. The website should be first modified to actually create jobs in the `job_queue` DB table according to the number of benchmark sets per target.