### PR TITLE
Feat; Split request job into benchmark jobs

### DIFF
--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -1042,7 +1042,12 @@ fn main_result() -> anyhow::Result<i32> {
 
                         let compile_config = CompileBenchmarkConfig {
                             benchmarks,
-                            profiles: Profile::default_profiles(),
+                            profiles: vec![
+                                Profile::Check,
+                                Profile::Debug,
+                                Profile::Doc,
+                                Profile::Opt,
+                            ],
                             scenarios: Scenario::all(),
                             backends,
                             iterations: runs.map(|v| v as usize),

--- a/collector/src/compile/benchmark/profile.rs
+++ b/collector/src/compile/benchmark/profile.rs
@@ -34,11 +34,6 @@ impl Profile {
         ]
     }
 
-    /// Set of default profiles that should be benchmarked for a master/try artifact.
-    pub fn default_profiles() -> Vec<Self> {
-        vec![Profile::Check, Profile::Debug, Profile::Doc, Profile::Opt]
-    }
-
     pub fn is_doc(&self) -> bool {
         match self {
             Profile::Doc | Profile::DocJson => true,

--- a/collector/src/compile/benchmark/target.rs
+++ b/collector/src/compile/benchmark/target.rs
@@ -14,3 +14,15 @@ impl Default for Target {
         Self::X86_64UnknownLinuxGnu
     }
 }
+
+impl Target {
+    pub fn all() -> Vec<Self> {
+        vec![Self::X86_64UnknownLinuxGnu]
+    }
+
+    pub fn from_db_target(target: &database::Target) -> Target {
+        match target {
+            database::Target::X86_64UnknownLinuxGnu => Self::X86_64UnknownLinuxGnu,
+        }
+    }
+}

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -1092,6 +1092,12 @@ impl fmt::Display for BenchmarkJobStatus {
 #[derive(Debug, Clone, PartialEq)]
 pub struct BenchmarkSet(u32);
 
+/// A single unit of work generated from a benchmark request. Split by profiles
+/// and backends
+///
+/// Each request is split into several `BenchmarkJob`s. Collectors poll the
+/// queue and claim a job only when its `benchmark_set` matches one of the sets
+/// they are responsible for.
 #[derive(Debug, Clone, PartialEq)]
 pub struct BenchmarkJob {
     target: Target,
@@ -1102,49 +1108,4 @@ pub struct BenchmarkJob {
     created_at: DateTime<Utc>,
     status: BenchmarkJobStatus,
     retry: u32,
-}
-
-impl BenchmarkJob {
-    pub fn create_queued(
-        target: Target,
-        backend: CodegenBackend,
-        profile: Profile,
-        request_tag: &str,
-        benchmark_set: u32,
-    ) -> Self {
-        BenchmarkJob {
-            target,
-            backend,
-            profile,
-            created_at: Utc::now(),
-            request_tag: request_tag.to_string(),
-            benchmark_set: BenchmarkSet(benchmark_set),
-            status: BenchmarkJobStatus::Queued,
-            retry: 0,
-        }
-    }
-
-    pub fn request_tag(&self) -> &str {
-        &self.request_tag
-    }
-
-    pub fn target(&self) -> Target {
-        self.target
-    }
-
-    pub fn backend(&self) -> CodegenBackend {
-        self.backend
-    }
-
-    pub fn profile(&self) -> Profile {
-        self.profile
-    }
-
-    pub fn benchmark_set(&self) -> u32 {
-        self.benchmark_set.0
-    }
-
-    pub fn status(&self) -> &BenchmarkJobStatus {
-        &self.status
-    }
 }

--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -345,7 +345,7 @@ mod tests {
     use super::*;
     use crate::{
         tests::{run_db_test, run_postgres_test},
-        BenchmarkJob, BenchmarkRequestStatus, BenchmarkRequestType, Commit, CommitType, Date,
+        BenchmarkRequestStatus, BenchmarkRequestType, Commit, CommitType, Date,
     };
 
     /// Create a Commit
@@ -604,14 +604,6 @@ mod tests {
             let benchmark_request =
                 BenchmarkRequest::create_master("sha-1", "parent-sha-1", 42, time);
 
-            let benchmark_job = BenchmarkJob::create_queued(
-                Target::X86_64UnknownLinuxGnu,
-                CodegenBackend::Llvm,
-                Profile::Opt,
-                benchmark_request.tag().unwrap(),
-                2,
-            );
-
             // Insert the request so we don't violate the foreign key
             db.insert_benchmark_request(&benchmark_request)
                 .await
@@ -620,10 +612,10 @@ mod tests {
             // Now we can insert the job
             let result = db
                 .enqueue_benchmark_job(
-                    benchmark_job.request_tag(),
-                    &benchmark_job.target(),
-                    &benchmark_job.backend(),
-                    &benchmark_job.profile(),
+                    benchmark_request.tag().unwrap(),
+                    &Target::X86_64UnknownLinuxGnu,
+                    &CodegenBackend::Llvm,
+                    &Profile::Opt,
                     0u32,
                 )
                 .await;

--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -1,6 +1,6 @@
 use crate::{
-    ArtifactCollection, ArtifactId, ArtifactIdNumber, BenchmarkRequest, BenchmarkRequestIndex,
-    BenchmarkRequestStatus, CodegenBackend, CompileBenchmark, Target,
+    ArtifactCollection, ArtifactId, ArtifactIdNumber, BenchmarkJob, BenchmarkRequest,
+    BenchmarkRequestIndex, BenchmarkRequestStatus, CodegenBackend, CompileBenchmark, Target,
 };
 use crate::{CollectionId, Index, Profile, QueuedCommit, Scenario, Step};
 use chrono::{DateTime, Utc};
@@ -210,6 +210,9 @@ pub trait Connection: Send + Sync {
         sha: &str,
         parent_sha: &str,
     ) -> anyhow::Result<()>;
+
+    /// Add a benchmark job to the job queue.
+    async fn enqueue_benchmark_job(&self, benchmark_job: &BenchmarkJob) -> anyhow::Result<()>;
 }
 
 #[async_trait::async_trait]

--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -344,13 +344,18 @@ static MIGRATIONS: &[&str] = &[
             REFERENCES benchmark_request(tag)
             ON DELETE CASCADE,
 
-       CONSTRAINT job_queue_unique
-       UNIQUE (
-           request_tag,
-           target,
-           backend,
-           profile,
-           benchmark_set
+        CONSTRAINT job_queue_collector
+            FOREIGN KEY (collector_id)
+            REFERENCES collector_config(id)
+            ON DELETE CASCADE,
+
+        CONSTRAINT job_queue_unique
+        UNIQUE (
+            request_tag,
+            target,
+            backend,
+            profile,
+            benchmark_set
         )
     );
     CREATE INDEX IF NOT EXISTS job_queue_request_tag_idx ON job_queue (request_tag);

--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -342,7 +342,9 @@ static MIGRATIONS: &[&str] = &[
         CONSTRAINT job_queue_request_fk
             FOREIGN KEY (request_tag)
             REFERENCES benchmark_request(tag)
-            ON DELETE CASCADE
+            ON DELETE CASCADE,
+
+       CONSTRAINT job_queue_unique UNIQUE(request_tag, target, backend, profile)
     );
     CREATE INDEX IF NOT EXISTS job_queue_request_tag_idx ON job_queue (request_tag);
     "#,

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -1,8 +1,8 @@
 use crate::pool::{Connection, ConnectionManager, ManagedConnection, Transaction};
 use crate::{
-    ArtifactCollection, ArtifactId, Benchmark, BenchmarkRequest, BenchmarkRequestIndex,
-    BenchmarkRequestStatus, CodegenBackend, CollectionId, Commit, CommitType, CompileBenchmark,
-    Date, Profile, Target,
+    ArtifactCollection, ArtifactId, Benchmark, BenchmarkJob, BenchmarkRequest,
+    BenchmarkRequestIndex, BenchmarkRequestStatus, CodegenBackend, CollectionId, Commit,
+    CommitType, CompileBenchmark, Date, Profile, Target,
 };
 use crate::{ArtifactIdNumber, Index, QueuedCommit};
 use chrono::{DateTime, TimeZone, Utc};
@@ -1294,6 +1294,10 @@ impl Connection for SqliteConnection {
         _sha: &str,
         _parent_sha: &str,
     ) -> anyhow::Result<()> {
+        no_queue_implementation_abort!()
+    }
+
+    async fn enqueue_benchmark_job(&self, _benchmark_job: &BenchmarkJob) -> anyhow::Result<()> {
         no_queue_implementation_abort!()
     }
 }

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -1,8 +1,8 @@
 use crate::pool::{Connection, ConnectionManager, ManagedConnection, Transaction};
 use crate::{
-    ArtifactCollection, ArtifactId, Benchmark, BenchmarkJob, BenchmarkRequest,
-    BenchmarkRequestIndex, BenchmarkRequestStatus, CodegenBackend, CollectionId, Commit,
-    CommitType, CompileBenchmark, Date, Profile, Target,
+    ArtifactCollection, ArtifactId, Benchmark, BenchmarkRequest, BenchmarkRequestIndex,
+    BenchmarkRequestStatus, CodegenBackend, CollectionId, Commit, CommitType, CompileBenchmark,
+    Date, Profile, Target,
 };
 use crate::{ArtifactIdNumber, Index, QueuedCommit};
 use chrono::{DateTime, TimeZone, Utc};
@@ -1297,7 +1297,14 @@ impl Connection for SqliteConnection {
         no_queue_implementation_abort!()
     }
 
-    async fn enqueue_benchmark_job(&self, _benchmark_job: &BenchmarkJob) -> anyhow::Result<()> {
+    async fn enqueue_benchmark_job(
+        &self,
+        _request_tag: &str,
+        _target: &Target,
+        _backend: &CodegenBackend,
+        _profile: &Profile,
+        _benchmark_set: u32,
+    ) -> anyhow::Result<()> {
         no_queue_implementation_abort!()
     }
 }

--- a/site/src/job_queue/mod.rs
+++ b/site/src/job_queue/mod.rs
@@ -230,6 +230,7 @@ pub async fn create_benchmark_jobs(
     tx.conn()
         .update_benchmark_request_status(request_tag, BenchmarkRequestStatus::InProgress)
         .await?;
+    tx.commit().await?;
     Ok(())
 }
 

--- a/site/src/request_handlers/github.rs
+++ b/site/src/request_handlers/github.rs
@@ -86,6 +86,7 @@ async fn record_try_benchmark_request_without_artifacts(
     if run_new_queue() {
         let try_request =
             BenchmarkRequest::create_try_without_artifacts(pr, chrono::Utc::now(), backends, "");
+        log::info!("Inserting try benchmark request {try_request:?}");
         if let Err(e) = conn.insert_benchmark_request(&try_request).await {
             log::error!("Failed to insert try benchmark request: {}", e);
         }


### PR DESCRIPTION
Adds the database table `job_queue` along with creating a `BenchmarkJob` from a `BenchmarkRequest`.

This does not include enqueuing a parent if there is a missing backend/profile.