### PR TITLE
Make missing test case check more granular

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,6 +397,7 @@ dependencies = [
  "env_logger",
  "flate2",
  "futures",
+ "hashbrown",
  "humansize",
  "inquire",
  "jobserver",

--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 clap = { workspace = true, features = ["derive"] }
 env_logger = { workspace = true }
+hashbrown = { workspace = true }
 log = { workspace = true }
 reqwest = { workspace = true, features = ["blocking", "json"] }
 serde = { workspace = true, features = ["derive"] }

--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -1819,7 +1819,7 @@ async fn bench_compile(
             tx.conn(),
             benchmark_name,
             &shared.artifact_id,
-            collector.artifact_row_id,
+            collector,
             config.is_self_profile,
         );
         let result = measure(&mut processor).await;

--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -225,6 +225,8 @@ fn profile_compile(
                 toolchain,
                 Some(1),
                 targets,
+                // We always want to profile everything
+                &hashbrown::HashSet::new(),
             ));
             eprintln!("Finished benchmark {benchmark_id}");
 
@@ -1804,11 +1806,8 @@ async fn bench_compile(
         print_intro: &dyn Fn(),
         measure: F,
     ) {
-        let is_fresh = collector.start_compile_step(conn, benchmark_name).await;
-        if !is_fresh {
-            eprintln!("skipping {} -- already benchmarked", benchmark_name);
-            return;
-        }
+        collector.start_compile_step(conn, benchmark_name).await;
+
         let mut tx = conn.transaction().await;
         let (supports_stable, category) = category.db_representation();
         tx.conn()
@@ -1866,6 +1865,7 @@ async fn bench_compile(
                     &shared.toolchain,
                     config.iterations,
                     &config.targets,
+                    &collector.measured_compile_test_cases,
                 ))
                 .await
                 .with_context(|| anyhow::anyhow!("Cannot compile {}", benchmark.name))

--- a/collector/src/compile/benchmark/codegen_backend.rs
+++ b/collector/src/compile/benchmark/codegen_backend.rs
@@ -10,3 +10,12 @@ impl CodegenBackend {
         vec![CodegenBackend::Llvm, CodegenBackend::Cranelift]
     }
 }
+
+impl From<CodegenBackend> for database::CodegenBackend {
+    fn from(value: CodegenBackend) -> Self {
+        match value {
+            CodegenBackend::Llvm => database::CodegenBackend::Llvm,
+            CodegenBackend::Cranelift => database::CodegenBackend::Cranelift,
+        }
+    }
+}

--- a/collector/src/compile/benchmark/mod.rs
+++ b/collector/src/compile/benchmark/mod.rs
@@ -334,11 +334,7 @@ impl Benchmark {
             return Ok(());
         }
 
-        eprintln!(
-            "Preparing {} (test cases: {})",
-            self.name,
-            benchmark_dirs.len()
-        );
+        eprintln!("Preparing {}", self.name);
 
         // In parallel (but with a limit to the number of CPUs), prepare all
         // profiles. This is done in parallel vs. sequentially because:
@@ -456,7 +452,7 @@ impl Benchmark {
 
                 // Rustdoc does not support incremental compilation
                 if !profile.is_doc() {
-                    // An incremental  from scratch (slowest incremental case).
+                    // An incremental build from scratch (slowest incremental case).
                     // This is required for any subsequent incremental builds.
                     if scenarios.iter().any(|s| s.is_incr()) {
                         self.mk_cargo_process(toolchain, cwd, profile, backend, target)
@@ -529,21 +525,9 @@ impl Benchmark {
         }
 
         let benchmark = database::Benchmark::from(self.name.0.as_str());
-        let profile = match profile {
-            Profile::Check => database::Profile::Check,
-            Profile::Debug => database::Profile::Debug,
-            Profile::Doc => database::Profile::Doc,
-            Profile::DocJson => database::Profile::DocJson,
-            Profile::Opt => database::Profile::Opt,
-            Profile::Clippy => database::Profile::Clippy,
-        };
-        let backend = match backend {
-            CodegenBackend::Llvm => database::CodegenBackend::Llvm,
-            CodegenBackend::Cranelift => database::CodegenBackend::Cranelift,
-        };
-        let target = match target {
-            Target::X86_64UnknownLinuxGnu => database::Target::X86_64UnknownLinuxGnu,
-        };
+        let profile: database::Profile = (*profile).into();
+        let backend: database::CodegenBackend = (*backend).into();
+        let target: database::Target = (*target).into();
 
         match scenario {
             // For these scenarios, we can simply check if they were benchmarked or not

--- a/collector/src/compile/benchmark/mod.rs
+++ b/collector/src/compile/benchmark/mod.rs
@@ -523,6 +523,11 @@ impl Benchmark {
         target: &Target,
         already_computed: &hashbrown::HashSet<CompileTestCase>,
     ) -> bool {
+        // Keep this in sync with the logic in `Benchmark::measure`.
+        if scenario.is_incr() && profile.is_doc() {
+            return false;
+        }
+
         let benchmark = database::Benchmark::from(self.name.0.as_str());
         let profile = match profile {
             Profile::Check => database::Profile::Check,

--- a/collector/src/compile/benchmark/mod.rs
+++ b/collector/src/compile/benchmark/mod.rs
@@ -283,7 +283,7 @@ impl Benchmark {
 
         struct BenchmarkDir {
             dir: TempDir,
-            scenarios: HashSet<Scenario>,
+            scenarios: Vec<Scenario>,
             profile: Profile,
             backend: CodegenBackend,
             target: Target,
@@ -299,14 +299,17 @@ impl Benchmark {
                     // Do we have any scenarios left to compute?
                     let remaining_scenarios = scenarios
                         .iter()
-                        .flat_map(|scenario| {
-                            self.create_test_cases(scenario, profile, backend, target)
-                                .into_iter()
-                                .map(|test_case| (*scenario, test_case))
+                        .filter(|scenario| {
+                            self.should_run_scenario(
+                                scenario,
+                                profile,
+                                backend,
+                                target,
+                                already_computed,
+                            )
                         })
-                        .filter(|(_, test_case)| !already_computed.contains(test_case))
-                        .map(|(scenario, _)| scenario)
-                        .collect::<HashSet<Scenario>>();
+                        .copied()
+                        .collect::<Vec<Scenario>>();
                     if remaining_scenarios.is_empty() {
                         continue;
                     }
@@ -511,40 +514,65 @@ impl Benchmark {
         Ok(())
     }
 
-    fn create_test_cases(
+    /// Return true if the given `scenario` should be computed.
+    fn should_run_scenario(
         &self,
         scenario: &Scenario,
         profile: &Profile,
         backend: &CodegenBackend,
         target: &Target,
-    ) -> Vec<CompileTestCase> {
-        self.patches
-            .iter()
-            .map(|patch| CompileTestCase {
-                benchmark: database::Benchmark::from(self.name.0.as_str()),
-                profile: match profile {
-                    Profile::Check => database::Profile::Check,
-                    Profile::Debug => database::Profile::Debug,
-                    Profile::Doc => database::Profile::Doc,
-                    Profile::DocJson => database::Profile::DocJson,
-                    Profile::Opt => database::Profile::Opt,
-                    Profile::Clippy => database::Profile::Clippy,
-                },
-                scenario: match scenario {
-                    Scenario::Full => database::Scenario::Empty,
-                    Scenario::IncrFull => database::Scenario::IncrementalEmpty,
-                    Scenario::IncrUnchanged => database::Scenario::IncrementalFresh,
-                    Scenario::IncrPatched => database::Scenario::IncrementalPatch(patch.name),
-                },
-                backend: match backend {
-                    CodegenBackend::Llvm => database::CodegenBackend::Llvm,
-                    CodegenBackend::Cranelift => database::CodegenBackend::Cranelift,
-                },
-                target: match target {
-                    Target::X86_64UnknownLinuxGnu => database::Target::X86_64UnknownLinuxGnu,
-                },
-            })
-            .collect()
+        already_computed: &hashbrown::HashSet<CompileTestCase>,
+    ) -> bool {
+        let benchmark = database::Benchmark::from(self.name.0.as_str());
+        let profile = match profile {
+            Profile::Check => database::Profile::Check,
+            Profile::Debug => database::Profile::Debug,
+            Profile::Doc => database::Profile::Doc,
+            Profile::DocJson => database::Profile::DocJson,
+            Profile::Opt => database::Profile::Opt,
+            Profile::Clippy => database::Profile::Clippy,
+        };
+        let backend = match backend {
+            CodegenBackend::Llvm => database::CodegenBackend::Llvm,
+            CodegenBackend::Cranelift => database::CodegenBackend::Cranelift,
+        };
+        let target = match target {
+            Target::X86_64UnknownLinuxGnu => database::Target::X86_64UnknownLinuxGnu,
+        };
+
+        match scenario {
+            // For these scenarios, we can simply check if they were benchmarked or not
+            Scenario::Full | Scenario::IncrFull | Scenario::IncrUnchanged => {
+                let test_case = CompileTestCase {
+                    benchmark,
+                    profile,
+                    backend,
+                    target,
+                    scenario: match scenario {
+                        Scenario::Full => database::Scenario::Empty,
+                        Scenario::IncrFull => database::Scenario::IncrementalEmpty,
+                        Scenario::IncrUnchanged => database::Scenario::IncrementalFresh,
+                        Scenario::IncrPatched => unreachable!(),
+                    },
+                };
+                !already_computed.contains(&test_case)
+            }
+            // For incr-patched, it is a bit more complicated.
+            // If there is at least a single uncomputed `IncrPatched`, we need to rerun
+            // all of them, because they stack on top of one another.
+            // Note that we don't need to explicitly include `IncrFull` if `IncrPatched`
+            // is selected, as the benchmark code will always run `IncrFull` before `IncrPatched`.
+            Scenario::IncrPatched => self.patches.iter().any(|patch| {
+                let test_case = CompileTestCase {
+                    benchmark,
+                    profile,
+                    scenario: database::Scenario::IncrementalPatch(patch.name),
+                    backend,
+                    target,
+                };
+                !already_computed.contains(&test_case)
+            }),
+        }
     }
 }
 

--- a/collector/src/compile/benchmark/profile.rs
+++ b/collector/src/compile/benchmark/profile.rs
@@ -41,3 +41,16 @@ impl Profile {
         }
     }
 }
+
+impl From<Profile> for database::Profile {
+    fn from(value: Profile) -> Self {
+        match value {
+            Profile::Check => database::Profile::Check,
+            Profile::Debug => database::Profile::Debug,
+            Profile::Doc => database::Profile::Doc,
+            Profile::DocJson => database::Profile::DocJson,
+            Profile::Opt => database::Profile::Opt,
+            Profile::Clippy => database::Profile::Clippy,
+        }
+    }
+}

--- a/collector/src/compile/benchmark/target.rs
+++ b/collector/src/compile/benchmark/target.rs
@@ -19,10 +19,20 @@ impl Target {
     pub fn all() -> Vec<Self> {
         vec![Self::X86_64UnknownLinuxGnu]
     }
+}
 
-    pub fn from_db_target(target: &database::Target) -> Target {
-        match target {
+impl From<database::Target> for Target {
+    fn from(value: database::Target) -> Self {
+        match value {
             database::Target::X86_64UnknownLinuxGnu => Self::X86_64UnknownLinuxGnu,
+        }
+    }
+}
+
+impl From<Target> for database::Target {
+    fn from(value: Target) -> Self {
+        match value {
+            Target::X86_64UnknownLinuxGnu => database::Target::X86_64UnknownLinuxGnu,
         }
     }
 }

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -354,13 +354,9 @@ pub struct CollectorCtx {
 }
 
 impl CollectorCtx {
-    pub async fn start_compile_step(
-        &self,
-        conn: &dyn Connection,
-        benchmark_name: &BenchmarkName,
-    ) -> bool {
+    pub async fn start_compile_step(&self, conn: &dyn Connection, benchmark_name: &BenchmarkName) {
         conn.collector_start_step(self.artifact_row_id, &benchmark_name.0)
-            .await
+            .await;
     }
 
     pub async fn end_compile_step(&self, conn: &dyn Connection, benchmark_name: &BenchmarkName) {

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -18,7 +18,9 @@ pub mod utils;
 
 use crate::compile::benchmark::{Benchmark, BenchmarkName};
 use crate::runtime::{BenchmarkGroup, BenchmarkSuite};
+use database::selector::CompileTestCase;
 use database::{ArtifactId, ArtifactIdNumber, Connection};
+use hashbrown::HashSet;
 use process::Stdio;
 use std::time::{Duration, Instant};
 
@@ -331,13 +333,24 @@ impl CollectorStepBuilder {
             tx.commit().await.unwrap();
             artifact_row_id
         };
-        CollectorCtx { artifact_row_id }
+        // Find out which tests cases were already computed
+        let measured_compile_test_cases = conn
+            .get_compile_test_cases_with_measurements(&artifact_row_id)
+            .await
+            .expect("cannot fetch measured compile test cases from DB");
+
+        CollectorCtx {
+            artifact_row_id,
+            measured_compile_test_cases,
+        }
     }
 }
 
 /// Represents an in-progress run for a given artifact.
 pub struct CollectorCtx {
     pub artifact_row_id: ArtifactIdNumber,
+    /// Which tests cases were already computed **before** this collection began?
+    pub measured_compile_test_cases: HashSet<CompileTestCase>,
 }
 
 impl CollectorCtx {

--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -353,15 +353,10 @@ impl Pool {
 mod tests {
     use super::*;
     use crate::metric::Metric;
-    use crate::{tests::run_db_test, Commit, CommitType, Date};
+    use crate::tests::run_postgres_test;
+    use crate::{tests::run_db_test, BenchmarkRequestType, Commit, CommitType, Date};
     use chrono::Utc;
     use std::str::FromStr;
-
-    use super::*;
-    use crate::{
-        tests::{run_db_test, run_postgres_test},
-        BenchmarkRequestStatus, BenchmarkRequestType, Commit, CommitType, Date,
-    };
 
     /// Create a Commit
     fn create_commit(commit_sha: &str, time: chrono::DateTime<Utc>, r#type: CommitType) -> Commit {

--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -1176,19 +1176,14 @@ where
             == 1
     }
     async fn collector_end_step(&self, aid: ArtifactIdNumber, step: &str) {
-        let did_modify = self
-            .conn()
+        self.conn()
             .execute(
                 "update collector_progress set end_time = statement_timestamp() \
-                where aid = $1 and step = $2 and start_time is not null and end_time is null;",
+                where aid = $1 and step = $2 and start_time is not null;",
                 &[&(aid.0 as i32), &step],
             )
             .await
-            .unwrap()
-            == 1;
-        if !did_modify {
-            log::error!("did not end {} for {:?}", step, aid);
-        }
+            .unwrap();
     }
     async fn collector_remove_step(&self, aid: ArtifactIdNumber, step: &str) {
         self.conn()

--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -1168,7 +1168,7 @@ where
         self.conn()
             .execute(
                 "update collector_progress set start_time = statement_timestamp() \
-                where aid = $1 and step = $2 and end_time is null;",
+                where aid = $1 and step = $2 and start_time is null and end_time is null;",
                 &[&(aid.0 as i32), &step],
             )
             .await

--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -1,4 +1,5 @@
 use crate::pool::{Connection, ConnectionManager, ManagedConnection, Transaction};
+use crate::selector::CompileTestCase;
 use crate::{
     ArtifactCollection, ArtifactId, ArtifactIdNumber, Benchmark, BenchmarkJobStatus,
     BenchmarkRequest, BenchmarkRequestIndex, BenchmarkRequestStatus, BenchmarkRequestType,
@@ -442,6 +443,7 @@ pub struct CachedStatements {
     record_artifact_size: Statement,
     get_artifact_size: Statement,
     load_benchmark_request_index: Statement,
+    get_compile_test_cases_with_measurements: Statement,
 }
 
 pub struct PostgresTransaction<'a> {
@@ -628,6 +630,15 @@ impl PostgresConnection {
                     SELECT tag, status
                     FROM benchmark_request
                     WHERE tag IS NOT NULL
+                ").await.unwrap(),
+                get_compile_test_cases_with_measurements: conn.prepare("
+                    SELECT DISTINCT crate, profile, scenario, backend, target
+                    FROM pstat_series
+                    WHERE id IN (
+                        SELECT DISTINCT series
+                        FROM pstat
+                        WHERE aid = $1
+                    )
                 ").await.unwrap(),
             }),
             conn,
@@ -1679,6 +1690,30 @@ where
             .await
             .context("failed to insert benchmark_job")?;
         Ok(())
+    }
+
+    async fn get_compile_test_cases_with_measurements(
+        &self,
+        artifact_row_id: &ArtifactIdNumber,
+    ) -> anyhow::Result<HashSet<CompileTestCase>> {
+        let rows = self
+            .conn()
+            .query(
+                &self.statements().get_compile_test_cases_with_measurements,
+                &[&(artifact_row_id.0 as i32)],
+            )
+            .await
+            .context("cannot query compile-time test cases with measurements")?;
+        Ok(rows
+            .into_iter()
+            .map(|row| CompileTestCase {
+                benchmark: Benchmark::from(row.get::<_, &str>(0)),
+                profile: Profile::from_str(row.get::<_, &str>(1)).unwrap(),
+                scenario: row.get::<_, &str>(2).parse().unwrap(),
+                backend: CodegenBackend::from_str(row.get::<_, &str>(3)).unwrap(),
+                target: Target::from_str(row.get::<_, &str>(4)).unwrap(),
+            })
+            .collect())
     }
 }
 

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -1,4 +1,5 @@
 use crate::pool::{Connection, ConnectionManager, ManagedConnection, Transaction};
+use crate::selector::CompileTestCase;
 use crate::{
     ArtifactCollection, ArtifactId, Benchmark, BenchmarkRequest, BenchmarkRequestIndex,
     BenchmarkRequestStatus, CodegenBackend, CollectionId, Commit, CommitType, CompileBenchmark,
@@ -6,7 +7,7 @@ use crate::{
 };
 use crate::{ArtifactIdNumber, Index, QueuedCommit};
 use chrono::{DateTime, TimeZone, Utc};
-use hashbrown::HashMap;
+use hashbrown::{HashMap, HashSet};
 use rusqlite::params;
 use rusqlite::OptionalExtension;
 use std::path::PathBuf;
@@ -1306,6 +1307,33 @@ impl Connection for SqliteConnection {
         _benchmark_set: u32,
     ) -> anyhow::Result<()> {
         no_queue_implementation_abort!()
+    }
+
+    async fn get_compile_test_cases_with_measurements(
+        &self,
+        artifact_row_id: &ArtifactIdNumber,
+    ) -> anyhow::Result<HashSet<CompileTestCase>> {
+        Ok(self
+            .raw_ref()
+            .prepare_cached(
+                "SELECT DISTINCT crate, profile, scenario, backend, target
+                FROM pstat_series
+                WHERE id IN (
+                    SELECT DISTINCT series
+                    FROM pstat
+                    WHERE aid = ?
+                );",
+            )?
+            .query_map(params![artifact_row_id.0], |row| {
+                Ok(CompileTestCase {
+                    benchmark: Benchmark::from(row.get::<_, String>(0)?.as_str()),
+                    profile: row.get::<_, String>(1)?.parse().unwrap(),
+                    scenario: row.get::<_, String>(2)?.parse().unwrap(),
+                    backend: row.get::<_, String>(3)?.parse().unwrap(),
+                    target: row.get::<_, String>(4)?.parse().unwrap(),
+                })
+            })?
+            .collect::<Result<_, _>>()?)
     }
 }
 

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -1062,18 +1062,13 @@ impl Connection for SqliteConnection {
     }
 
     async fn collector_end_step(&self, aid: ArtifactIdNumber, step: &str) {
-        let did_modify = self
-            .raw_ref()
+        self.raw_ref()
             .execute(
                 "update collector_progress set end = strftime('%s','now') \
-                where aid = ? and step = ? and start is not null and end is null;",
+                where aid = ? and step = ? and start is not null;",
                 params![&aid.0, &step],
             )
-            .unwrap()
-            == 1;
-        if !did_modify {
-            log::error!("did not end {} for {:?}", step, aid);
-        }
+            .unwrap();
     }
 
     async fn collector_remove_step(&self, aid: ArtifactIdNumber, step: &str) {

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -1054,7 +1054,7 @@ impl Connection for SqliteConnection {
         self.raw_ref()
             .execute(
                 "update collector_progress set start = strftime('%s','now') \
-                where aid = ? and step = ? and end is null;",
+                where aid = ? and step = ? and start is null and end is null;",
                 params![&aid.0, &step],
             )
             .unwrap()

--- a/site/src/job_queue/mod.rs
+++ b/site/src/job_queue/mod.rs
@@ -197,9 +197,7 @@ pub async fn enqueue_benchmark_request(
 
     // Target x benchmark_set x backend x profile -> BenchmarkJob
     for target in Target::all() {
-        for benchmark_set in 0..benchmark_set_count(
-            collector::compile::benchmark::target::Target::from_db_target(&target),
-        ) {
+        for benchmark_set in 0..benchmark_set_count(target.into()) {
             for backend in backends.iter() {
                 for profile in profiles.iter() {
                     tx.conn()


### PR DESCRIPTION
This is a reland of https://github.com/rust-lang/rustc-perf/pull/2161, which was reverted in https://github.com/rust-lang/rustc-perf/pull/2187. I fixed the issue with recomputing incremental doc builds, and also made sure that when something is recomputed, the corresponding step won't be restarted from scratch (`start_time`), to avoid weirdly short steps (now they will be weirdly long instead, but that's good, as it can tell us on the status page that some recomputation happened).

This will be needed soon for the new benchmarking scheme.