### PR TITLE
drop dep from tabled

### DIFF
--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -36,7 +36,7 @@ rustc-demangle = { version = "0.1", features = ["std"] }
 similar = "2.2"
 console = "0.15"
 object = "0.36.0"
-tabled = { version = "0.20", features = ["ansi-str", "ansi"] }
+tabled = { version = "0.20", default-features = false, features = ["derive", "ansi"] }
 humansize = "2.1.3"
 regex = "1.7.1"
 analyzeme = "12.0.0"


### PR DESCRIPTION
This removes optional dep `testing_table` from builded deps (but it still preserved in Cargo.lock).