### PR TITLE
Feat; mark benchmark requests as complete

### DIFF
--- a/database/schema.md
+++ b/database/schema.md
@@ -313,3 +313,36 @@ Columns:
   execute.
 * **is_active** (`boolean NOT NULL`): For controlling whether the collector is
   active for use. Useful for adding/removing collectors.
+
+### job_queue
+
+This table stores ephemeral benchmark jobs, which specifically tell the
+collector which benchmarks it should execute. The jobs will be kept in the
+table for ~30 days after being completed, so that we can quickly figure out
+what master parent jobs we need to backfill when handling try builds.
+
+Columns:
+
+- **id** (`bigint` / `serial`): Primary-key identifier for the job row;
+  auto-increments with each new job.
+- **request_id** (`bigint`): References the parent benchmark request that
+  spawned this job.
+- **target** (`text NOT NULL`): Hardware/ISA the benchmarks must run on
+  (e.g. AArch64, x86_64).
+- **backend** (`text NOT NULL`): Code generation backend the collector should
+  test (e.g. llvm, cranelift).
+- **benchmark_set** (`int NOT NULL`): ID of the predefined benchmark suite to
+  execute.
+- **collector_id** (`text`): Id of the collector that claimed the job
+  (populated once the job is started).
+- **created_at** (`timestamptz NOT NULL`): Datetime when the job was queued.
+- **started_at** (`timestamptz`): Datetime when the collector actually began
+  running the benchmarks; NULL until the job is claimed.
+- **completed_at** (`timestampt`): Datetime when the collector finished
+  (successfully or otherwise); used to purge rows after ~30 days.
+- **status** (`text NOT NULL`): Current job state. `queued`, `in_progress`,
+  `success`, or `failure`.
+- **retry** (`int NOT NULL`): Number of times the job has been re-queued after
+  a failure; 0 on the first attempt.
+- **error** (`text`): Optional error message or stack trace from the last
+  failed run; NULL when the job succeeded.

--- a/database/schema.md
+++ b/database/schema.md
@@ -323,26 +323,24 @@ what master parent jobs we need to backfill when handling try builds.
 
 Columns:
 
-- **id** (`bigint` / `serial`): Primary-key identifier for the job row;
-  auto-increments with each new job.
-- **request_id** (`bigint`): References the parent benchmark request that
+* **id** (`bigint` / `serial`): Primary*key identifier for the job row;
+  auto*increments with each new job.
+* **request_tag** (`text`): References the parent benchmark request that
   spawned this job.
-- **target** (`text NOT NULL`): Hardware/ISA the benchmarks must run on
+* **target** (`text NOT NULL`): Hardware/ISA the benchmarks must run on
   (e.g. AArch64, x86_64).
-- **backend** (`text NOT NULL`): Code generation backend the collector should
+* **backend** (`text NOT NULL`): Code generation backend the collector should
   test (e.g. llvm, cranelift).
-- **benchmark_set** (`int NOT NULL`): ID of the predefined benchmark suite to
+* **benchmark_set** (`int NOT NULL`): ID of the predefined benchmark suite to
   execute.
-- **collector_id** (`text`): Id of the collector that claimed the job
+* **collector_name** (`text`): Name of the collector that claimed the job
   (populated once the job is started).
-- **created_at** (`timestamptz NOT NULL`): Datetime when the job was queued.
-- **started_at** (`timestamptz`): Datetime when the collector actually began
+* **created_at** (`timestamptz NOT NULL`): Datetime when the job was queued.
+* **started_at** (`timestamptz`): Datetime when the collector actually began
   running the benchmarks; NULL until the job is claimed.
-- **completed_at** (`timestampt`): Datetime when the collector finished
+* **completed_at** (`timestampt`): Datetime when the collector finished
   (successfully or otherwise); used to purge rows after ~30 days.
-- **status** (`text NOT NULL`): Current job state. `queued`, `in_progress`,
+* **status** (`text NOT NULL`): Current job state. `queued`, `in_progress`,
   `success`, or `failure`.
-- **retry** (`int NOT NULL`): Number of times the job has been re-queued after
+* **retry** (`int NOT NULL`): Number of times the job has been re*queued after
   a failure; 0 on the first attempt.
-- **error** (`text`): Optional error message or stack trace from the last
-  failed run; NULL when the job succeeded.

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -1026,6 +1026,10 @@ impl BenchmarkRequest {
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| anyhow::anyhow!("Invalid backend: {e}"))
     }
+
+    pub fn is_completed(&self) -> bool {
+        matches!(self.status, BenchmarkRequestStatus::Completed { .. })
+    }
 }
 
 /// Cached information about benchmark requests in the DB
@@ -1046,6 +1050,11 @@ impl BenchmarkRequestIndex {
     /// Return tags of already completed benchmark requests.
     pub fn completed_requests(&self) -> &HashSet<String> {
         &self.completed
+    }
+
+    pub fn add_tag(&mut self, tag: &str) {
+        self.all.insert(tag.to_string());
+        self.completed.insert(tag.to_string());
     }
 }
 

--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -253,6 +253,13 @@ pub trait Connection: Send + Sync {
         target: &Target,
         benchmark_set: &BenchmarkSet,
     ) -> anyhow::Result<Option<BenchmarkJob>>;
+
+    /// Try and mark the benchmark_request as completed. Will return `true` if
+    /// it has been marked as completed else `false` meaning there was no change
+    async fn mark_benchmark_request_as_completed(
+        &self,
+        benchmark_request: &mut BenchmarkRequest,
+    ) -> anyhow::Result<bool>;
 }
 
 #[async_trait::async_trait]

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -1353,6 +1353,13 @@ impl Connection for SqliteConnection {
     ) -> anyhow::Result<CollectorConfig> {
         no_queue_implementation_abort!()
     }
+
+    async fn mark_benchmark_request_as_completed(
+        &self,
+        _benchmark_request: &mut BenchmarkRequest,
+    ) -> anyhow::Result<bool> {
+        no_queue_implementation_abort!()
+    }
 }
 
 fn parse_artifact_id(ty: &str, sha: &str, date: Option<i64>) -> ArtifactId {


### PR DESCRIPTION
Related to; https://github.com/rust-lang/rustc-perf/pull/2200 which I've closed as it was becoming fiddly to update.
- Mark `benchmark_request`'s as complete based on;
    - parent being complete if there is a parent
    - all jobs in the `job_queue` being in a terminal state.