### PR TITLE
Fix profiling with samply.

### DIFF
--- a/collector/src/compile/execute/profiler.rs
+++ b/collector/src/compile/execute/profiler.rs
@@ -250,11 +250,13 @@ impl Processor for ProfileProcessor<'_> {
                 }
 
                 // Samply produces (via rustc-fake) a data file called
-                // `profile.json`. We copy it from the temp dir to the output dir,
-                // giving it a new name in the process.
+                // `profile.json.gz`. We copy it from the temp dir to the output dir,
+                // giving it a new name in the process. The new name must end
+                // in `.gz` for `samply load` to handle it.
                 Profiler::Samply => {
-                    let tmp_samply_file = filepath(data.cwd, "profile.json");
-                    let samply_file = filepath(self.output_dir, &out_file("samply"));
+                    let tmp_samply_file = filepath(data.cwd, "profile.json.gz");
+                    let samply_file =
+                        filepath(self.output_dir, &format!("{}.gz", out_file("samply")));
 
                     fs::copy(tmp_samply_file, samply_file)?;
                 }


### PR DESCRIPTION
samply now produces gzipped output files -- `profile.json.gz` instead of `profile.json`. This commit updates the code to handle them.