### PR TITLE
Fix; queue ordering and errors formatting

### DIFF
--- a/site/frontend/src/pages/status_new/page.vue
+++ b/site/frontend/src/pages/status_new/page.vue
@@ -99,13 +99,7 @@ function formatStatus(status: BenchmarkRequestStatus): string {
 }
 
 function hasErrors(errors: Dict<string>) {
-  // This is a bit odd but if the error object has values the loop will be
-  // hit and thus return true.
-  for (const key in errors) {
-    console.log(key);
-    return true;
-  }
-  return false;
+  return Object.keys(errors).length !== 0;
 }
 
 function getErrorsLength(errors: Dict<string>) {


### PR DESCRIPTION
- Fixes the ordering of the queue.
- Fix formatting of errors, we now return a hashtable; I've formatted it to be `error_name: error\n`.
- Fix `createdAt` being used in the `Completed At` column (not sure if the column name is the one that needed changing or the value).

From the refactor we have lost the ability to have the parent that will be benchmarked appear "above the waterline".