### PR TITLE
Stop hardcoding the master branch of rust-lang/rust

### DIFF
--- a/collector/src/compile/execute/rustc.rs
+++ b/collector/src/compile/execute/rustc.rs
@@ -193,9 +193,9 @@ fn checkout(artifact: &ArtifactId) -> anyhow::Result<()> {
             .current_dir("rust")
             .arg("fetch")
             .arg("origin")
-            .arg("master")
+            .arg("HEAD")
             .status()
-            .context("git fetch origin master")?;
+            .context("git fetch origin HEAD")?;
         assert!(status.success(), "git fetch successful");
     } else {
         let status = Command::new("git")

--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -647,6 +647,12 @@ pub mod github {
         pub head_commit: HeadCommit,
         pub before: String,
         pub commits: Vec<Commit>,
+        pub repository: Repository,
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct Repository {
+        pub default_branch: String,
     }
 
     #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/site/src/request_handlers/github.rs
+++ b/site/src/request_handlers/github.rs
@@ -23,7 +23,9 @@ pub async fn handle_github(
 
 async fn handle_push(ctxt: Arc<SiteCtxt>, push: github::Push) -> ServerResult<github::Response> {
     let gh_client = client::Client::from_ctxt(&ctxt, RUST_REPO_GITHUB_API_URL.to_owned());
-    if push.r#ref != "refs/heads/master" || push.sender.login != "bors" {
+    if push.r#ref != format!("refs/heads/{}", push.repository.default_branch)
+        || push.sender.login != "bors"
+    {
         return Ok(github::Response);
     }
     let rollup_pr_number = match rollup_pr_number(&gh_client, &push.head_commit.message).await? {


### PR DESCRIPTION
- https://docs.github.com/en/webhooks/webhook-events-and-payloads#push
- https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#get-a-repository

Those were the only two occurrences that I found.