### PR TITLE
Fix; for query performance

### DIFF
--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -749,7 +749,7 @@ impl PostgresConnection {
                         SELECT tag FROM parents
                     )
                     -- Only get the jobs of in_progress requests
-                    SELECT * FROM job_queue WHERE job_queue.request_tag IN (SELECT * FROM requests)
+                    SELECT * FROM job_queue INNER JOIN requests ON job_queue.request_tag = requests.tag
                 ")).await.unwrap(),
             }),
             conn,


### PR DESCRIPTION
# Context
We wanted to see the `EXPLAIN ANALYSE` for' `completed`, `in_progress` and `dequeue` queries;

I've tested this with the following in the database;
- 91,303 requests
- 70,001 artifacts
- 40,047 errors
- 70,122 jobs

For small numbers of items it is _always_ faster to use a sequence scan as it avoids loading an index. Postgres seems to be smart enough to know when to switch from a sequence scan to an index scan depending on how many entries there are.

The below indexes are created off the basis of wanting to avoid _any_ sequence scan where possible.

## Completed
This needs an index on the column `completed_at` otherwise we get a full sequence scan on the `completed_at` column c799d67d230c73fe64b5102e3bbbf3d2cea2bc31. Similarly the `error` table needs an index on `aid` to prevent a full sequence scan of the error table when we do a join on the `artifact.id` 6a6dadb1d87b94c2b8a82dc70b38a720f3a494a1.

<details>
<summary>BEFORE</summary>

<img width="1578" height="1163" alt="image" src="https://github.com/user-attachments/assets/29dfd98b-6f54-463f-a5d3-77cfecaef254" />
</details>


<details>
<summary>AFTER</summary>
<img width="1961" height="823" alt="image" src="https://github.com/user-attachments/assets/b86d4183-2f41-4169-98a0-2709d2dc288e" />

</details>

## In Progress

This query needs no new indexes. We do a full sequence scan of the job queue table. I'm not sure yet if this is avoidable or acceptable. I'm also not exactly sure what we are wanting from the query. Below is the current `EXPLAIN ANALYSE` output

<details>
<summary>BEFORE - EXPLAIN ANALYSE output</summary>
<img width="1530" height="295" alt="image" src="https://github.com/user-attachments/assets/f2cd83a8-8734-497f-844a-a2a991c37597" />
</details>

If the query is to get the jobs of currently `in_progress` requests I have updated the query in this commit; fe911551812af11ae96e668cfa2ece133d228503

Which produces a more optimised;

<details>
<summary>AFTER - EXPLAIN ANALYSE output</summary>

<img width="1793" height="740" alt="image" src="https://github.com/user-attachments/assets/3aba4094-b3ac-4e72-8860-ea2eeaa2b2de" />

</details>



## Dequeue

This query needs no new indexes.

<details>
<summary>EXPLAIN ANALYSE output</summary>
<img width="2122" height="1040" alt="image" src="https://github.com/user-attachments/assets/3036aeec-f2ef-4a67-ad6d-c4c40866ccf6" />
</details>
