### PR TITLE
Fix; Allow postgres to persist data

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,3 @@ services:
       interval: 2s
       timeout: 2s
       retries: 15
-    tmpfs:
-      - /var/lib/postgresql/data       # store data in RAM
-


### PR DESCRIPTION
I've lost countless useful database setups due to me turning off my computer turning it back on again and then losing the data as it's only stored in RAM.

Removing this line has a negligible performance impact on tests.