### PR TITLE
Feat; Estimated duration for benchmark requests

### DIFF
--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -2,9 +2,9 @@ use crate::pool::{Connection, ConnectionManager, ManagedConnection, Transaction}
 use crate::selector::CompileTestCase;
 use crate::{
     ArtifactCollection, ArtifactId, Benchmark, BenchmarkJob, BenchmarkJobConclusion,
-    BenchmarkRequest, BenchmarkRequestIndex, BenchmarkRequestStatus, BenchmarkRequestWithErrors,
-    BenchmarkSet, CodegenBackend, CollectionId, CollectorConfig, Commit, CommitType,
-    CompileBenchmark, Date, Profile, Target,
+    BenchmarkRequest, BenchmarkRequestIndex, BenchmarkRequestWithErrors, BenchmarkSet,
+    CodegenBackend, CollectionId, CollectorConfig, Commit, CommitType, CompileBenchmark, Date,
+    Profile, Target,
 };
 use crate::{ArtifactIdNumber, Index, QueuedCommit};
 use chrono::{DateTime, TimeZone, Utc};
@@ -1310,11 +1310,7 @@ impl Connection for SqliteConnection {
         no_queue_implementation_abort!()
     }
 
-    async fn update_benchmark_request_status(
-        &self,
-        _tag: &str,
-        _status: BenchmarkRequestStatus,
-    ) -> anyhow::Result<()> {
+    async fn set_benchmark_request_in_progress(&self, _tag: &str) -> anyhow::Result<()> {
         no_queue_implementation_abort!()
     }
 

--- a/database/src/tests/builder.rs
+++ b/database/src/tests/builder.rs
@@ -1,6 +1,6 @@
 use crate::{
-    BenchmarkJob, BenchmarkJobConclusion, BenchmarkRequest, BenchmarkRequestStatus, BenchmarkSet,
-    CodegenBackend, CollectorConfig, Connection, Profile, Target,
+    BenchmarkJob, BenchmarkJobConclusion, BenchmarkRequest, BenchmarkSet, CodegenBackend,
+    CollectorConfig, Connection, Profile, Target,
 };
 use chrono::Utc;
 use hashbrown::{HashMap, HashSet};
@@ -55,7 +55,7 @@ impl RequestBuilder {
     }
 
     pub async fn set_in_progress(self, db: &dyn Connection) -> Self {
-        db.update_benchmark_request_status(self.tag(), BenchmarkRequestStatus::InProgress)
+        db.set_benchmark_request_in_progress(self.tag())
             .await
             .unwrap();
         self

--- a/site/frontend/src/pages/status_new/data.ts
+++ b/site/frontend/src/pages/status_new/data.ts
@@ -25,6 +25,7 @@ export type BenchmarkJob = {
   completedAt: string | null;
   status: BenchmarkJobStatus;
   dequeCounter: number;
+  estimatedCompletedAt: string | null;
 };
 
 export type CollectorConfig = {

--- a/site/frontend/src/pages/status_new/page.vue
+++ b/site/frontend/src/pages/status_new/page.vue
@@ -118,6 +118,13 @@ function PullRequestLink({request}: {request: BenchmarkRequest}) {
   );
 }
 
+function getCompletedAt(req: BenchmarkRequest) {
+  if (req.status === "Completed") {
+    return formatISODate(req.completedAt);
+  }
+  return `<strong>${formatISODate(req.completedAt)} (est.)</strong>`;
+}
+
 const {toggleExpanded: toggleExpandedErrors, isExpanded: hasExpandedErrors} =
   useExpandedStore();
 
@@ -158,7 +165,7 @@ loadStatusData(loading);
                     req.status === "Completed" && req.hasPendingJobs ? "*" : ""
                   }}
                 </td>
-                <td v-html="formatISODate(req.completedAt)"></td>
+                <td v-html="getCompletedAt(req)"></td>
                 <td v-html="getDuration(req)"></td>
 
                 <td v-if="hasErrors(req.errors)">

--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -418,6 +418,7 @@ pub mod status_new {
         pub status: BenchmarkRequestStatus,
         pub request_type: BenchmarkRequestType,
         pub created_at: DateTime<Utc>,
+        pub estimated_completed_at: Option<DateTime<Utc>>,
         pub completed_at: Option<DateTime<Utc>>,
         pub duration_s: Option<u64>,
         pub errors: HashMap<String, String>,


### PR DESCRIPTION
Modifies a SQL query to bring back an `estimated_completed_at` column for `in_progress` requests.

- Update `InProgress` enum variant to have an `estimated_completed_at` field
- Rename `update_benchmark_request_status` to `set_benchmark_request_in_progress` and only set the status to `in_progress`
- Small update to frontend to display the estimated time in bold