### PR TITLE
Do not use the benchmark index when computing benchmark request queue

### DIFF
--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -1041,12 +1041,9 @@ impl BenchmarkRequest {
 }
 
 /// Cached information about benchmark requests in the DB
-/// FIXME: only store non-try requests here
 pub struct BenchmarkRequestIndex {
     /// Tags (SHA or release name) of all known benchmark requests
     all: HashSet<String>,
-    /// Tags (SHA or release name) of all benchmark requests in the completed status
-    completed: HashSet<String>,
 }
 
 impl BenchmarkRequestIndex {
@@ -1054,16 +1051,13 @@ impl BenchmarkRequestIndex {
     pub fn contains_tag(&self, tag: &str) -> bool {
         self.all.contains(tag)
     }
+}
 
-    /// Return tags of already completed benchmark requests.
-    pub fn completed_requests(&self) -> &HashSet<String> {
-        &self.completed
-    }
-
-    pub fn add_tag(&mut self, tag: &str) {
-        self.all.insert(tag.to_string());
-        self.completed.insert(tag.to_string());
-    }
+/// Contains pending (ArtifactsReady or InProgress) benchmark requests, and a set of their parents
+/// that are already completed.
+pub struct PendingBenchmarkRequests {
+    pub requests: Vec<BenchmarkRequest>,
+    pub completed_parent_tags: HashSet<String>,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -2,7 +2,8 @@ use crate::selector::CompileTestCase;
 use crate::{
     ArtifactCollection, ArtifactId, ArtifactIdNumber, BenchmarkJob, BenchmarkJobConclusion,
     BenchmarkRequest, BenchmarkRequestIndex, BenchmarkRequestStatus, BenchmarkRequestWithErrors,
-    BenchmarkSet, CodegenBackend, CollectorConfig, CompileBenchmark, Target,
+    BenchmarkSet, CodegenBackend, CollectorConfig, CompileBenchmark, PendingBenchmarkRequests,
+    Target,
 };
 use crate::{CollectionId, Index, Profile, QueuedCommit, Scenario, Step};
 use chrono::{DateTime, Utc};
@@ -189,7 +190,8 @@ pub trait Connection: Send + Sync {
     async fn purge_artifact(&self, aid: &ArtifactId);
 
     /// Add an item to the `benchmark_requests`, if the `benchmark_request`
-    /// exists an Error will be returned
+    /// exists an Error will be returned.
+    /// We require the caller to pass an index, to ensure that it is always kept up-to-date.
     async fn insert_benchmark_request(
         &self,
         benchmark_request: &BenchmarkRequest,
@@ -200,7 +202,9 @@ pub trait Connection: Send + Sync {
 
     /// Load all pending benchmark requests, i.e. those that have artifacts ready, but haven't
     /// been completed yet. Pending statuses are `ArtifactsReady` and `InProgress`.
-    async fn load_pending_benchmark_requests(&self) -> anyhow::Result<Vec<BenchmarkRequest>>;
+    /// Also returns their parents, so that we can quickly check which requests are ready for being
+    /// enqueued.
+    async fn load_pending_benchmark_requests(&self) -> anyhow::Result<PendingBenchmarkRequests>;
 
     /// Update the status of a `benchmark_request` with the given `tag`.
     /// If no such request exists in the DB, returns an error.
@@ -426,6 +430,7 @@ mod tests {
     use crate::tests::run_postgres_test;
     use crate::{tests::run_db_test, BenchmarkRequestType, Commit, CommitType, Date};
     use chrono::Utc;
+    use std::collections::BTreeSet;
     use std::str::FromStr;
 
     /// Create a Commit
@@ -629,42 +634,47 @@ mod tests {
     async fn load_pending_benchmark_requests() {
         run_postgres_test(|ctx| async {
             let db = ctx.db();
-            let time = chrono::DateTime::from_str("2021-09-01T00:00:00.000Z").unwrap();
-            let target = Target::X86_64UnknownLinuxGnu;
-            let collector_name = "collector-1";
-            let benchmark_set = 1;
-
-            db.add_collector_config(collector_name, target, benchmark_set, true)
-                .await
-                .unwrap();
 
             // ArtifactsReady
-            let req_a = BenchmarkRequest::create_master("sha-1", "parent-sha-1", 42, time);
+            let req_a = ctx.insert_master_request("sha-1", "parent-sha-1", 42).await;
             // ArtifactsReady
-            let req_b = BenchmarkRequest::create_release("1.80.0", time);
+            let req_b = ctx.insert_release_request("1.80.0").await;
             // WaitingForArtifacts
-            let req_c = BenchmarkRequest::create_try_without_artifacts(50, "", "");
+            ctx.insert_try_request(50).await;
             // InProgress
-            let req_d = BenchmarkRequest::create_master("sha-2", "parent-sha-2", 51, time);
+            let req_d = ctx.insert_master_request("sha-2", "parent-sha-2", 51).await;
             // Completed
-            let req_e = BenchmarkRequest::create_release("1.79.0", time);
+            ctx.insert_release_request("1.79.0").await;
 
-            for &req in &[&req_a, &req_b, &req_c, &req_d, &req_e] {
-                db.insert_benchmark_request(req).await.unwrap();
-            }
-
-            complete_request(db, "1.79.0", collector_name, benchmark_set, target).await;
+            ctx.complete_request("1.79.0").await;
+            ctx.insert_master_request("parent-sha-1", "grandparent-sha-0", 100)
+                .await;
+            ctx.complete_request("parent-sha-1").await;
+            ctx.insert_master_request("parent-sha-2", "grandparent-sha-1", 101)
+                .await;
+            ctx.complete_request("parent-sha-2").await;
 
             db.update_benchmark_request_status("sha-2", BenchmarkRequestStatus::InProgress)
                 .await
                 .unwrap();
 
-            let requests = db.load_pending_benchmark_requests().await.unwrap();
+            let pending = db.load_pending_benchmark_requests().await.unwrap();
+            let requests = pending.requests;
 
             assert_eq!(requests.len(), 3);
             for req in &[req_a, req_b, req_d] {
                 assert!(requests.iter().any(|r| r.tag() == req.tag()));
             }
+
+            assert_eq!(
+                pending
+                    .completed_parent_tags
+                    .into_iter()
+                    .collect::<BTreeSet<_>>()
+                    .into_iter()
+                    .collect::<Vec<_>>(),
+                vec!["parent-sha-1".to_string(), "parent-sha-2".to_string()]
+            );
 
             Ok(ctx)
         })
@@ -687,6 +697,7 @@ mod tests {
                 .load_pending_benchmark_requests()
                 .await
                 .unwrap()
+                .requests
                 .into_iter()
                 .next()
                 .unwrap();

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -4,7 +4,7 @@ use crate::{
     ArtifactCollection, ArtifactId, Benchmark, BenchmarkJob, BenchmarkJobConclusion,
     BenchmarkRequest, BenchmarkRequestIndex, BenchmarkRequestStatus, BenchmarkRequestWithErrors,
     BenchmarkSet, CodegenBackend, CollectionId, CollectorConfig, Commit, CommitType,
-    CompileBenchmark, Date, Profile, Target,
+    CompileBenchmark, Date, PendingBenchmarkRequests, Profile, Target,
 };
 use crate::{ArtifactIdNumber, Index, QueuedCommit};
 use chrono::{DateTime, TimeZone, Utc};
@@ -1306,7 +1306,7 @@ impl Connection for SqliteConnection {
         no_queue_implementation_abort!()
     }
 
-    async fn load_pending_benchmark_requests(&self) -> anyhow::Result<Vec<BenchmarkRequest>> {
+    async fn load_pending_benchmark_requests(&self) -> anyhow::Result<PendingBenchmarkRequests> {
         no_queue_implementation_abort!()
     }
 

--- a/database/src/tests/mod.rs
+++ b/database/src/tests/mod.rs
@@ -139,6 +139,20 @@ impl TestContext {
         req
     }
 
+    /// Create a new release benchmark request and add it to the DB.
+    pub async fn insert_release_request(&self, tag: &str) -> BenchmarkRequest {
+        let req = BenchmarkRequest::create_release(tag, Utc::now());
+        self.db().insert_benchmark_request(&req).await.unwrap();
+        req
+    }
+
+    /// Create a new try benchmark request without artifacts and add it to the DB.
+    pub async fn insert_try_request(&self, pr: u32) -> BenchmarkRequest {
+        let req = BenchmarkRequest::create_try_without_artifacts(pr, "", "");
+        self.db().insert_benchmark_request(&req).await.unwrap();
+        req
+    }
+
     pub async fn complete_request(&self, tag: &str) {
         // Note: this assumes that there are not non-completed jobs in the DB for the request
         self.db()

--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -250,7 +250,7 @@ async fn attach_shas_to_try_benchmark_request(
             )
             .await
         {
-            log::error!("Failed to add shas to try commit {}", e);
+            log::error!("Failed to add shas to try commit: {e:?}");
         }
     }
 }

--- a/site/src/main.rs
+++ b/site/src/main.rs
@@ -4,6 +4,7 @@ use site::job_queue::{cron_main, run_new_queue};
 use site::load;
 use std::env;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::task;
 
 #[cfg(unix)]
@@ -60,7 +61,11 @@ async fn main() {
 
     if run_new_queue() {
         task::spawn(async move {
-            cron_main(ctxt.clone(), queue_update_interval_seconds).await;
+            cron_main(
+                ctxt.clone(),
+                Duration::from_secs(queue_update_interval_seconds),
+            )
+            .await;
         });
     }
 

--- a/site/src/request_handlers/status_page_new.rs
+++ b/site/src/request_handlers/status_page_new.rs
@@ -13,10 +13,8 @@ use std::time::Duration;
 pub async fn handle_status_page_new(ctxt: Arc<SiteCtxt>) -> anyhow::Result<status_new::Response> {
     let conn = ctxt.conn().await;
 
-    let index = conn.load_benchmark_request_index().await?;
-
     // The queue contains any in-progress request(s) and then the following requests in queue order
-    let queue = build_queue(&*conn, &index).await?;
+    let queue = build_queue(&*conn).await?;
     let completed = conn.get_last_n_completed_benchmark_requests(10).await?;
 
     // Figure out approximately how long was the most recent master benchmark request


### PR DESCRIPTION
This removes one half of the usage of the benchmark index. Now when loading the status page or computing the queue for deciding which requests to enqueue, we only load pending requests from the database, together with the information whether their parent is completed or not, and we no longer have to load all completed requests from the DB.

This leaves only one usage of the benchmark index, when determining whether to add master/release requests into the database.