### PR TITLE
Fix; enqueuing a job that has already been enqueued

### DIFF
--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -224,7 +224,7 @@ pub trait Connection: Send + Sync {
         commit_date: DateTime<Utc>,
     ) -> anyhow::Result<()>;
 
-    /// Add a benchmark job to the job queue and return its ID.
+    /// Add a benchmark job to the job queue.
     async fn enqueue_benchmark_job(
         &self,
         request_tag: &str,
@@ -232,7 +232,7 @@ pub trait Connection: Send + Sync {
         backend: CodegenBackend,
         profile: Profile,
         benchmark_set: u32,
-    ) -> anyhow::Result<u32>;
+    ) -> anyhow::Result<Option<u32>>;
 
     /// Add a benchmark job which is explicitly using a `parent_sha` we split
     /// this out to improve our error handling. A `parent_sha` may not have

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -1335,7 +1335,7 @@ impl Connection for SqliteConnection {
         _backend: CodegenBackend,
         _profile: Profile,
         _benchmark_set: u32,
-    ) -> anyhow::Result<u32> {
+    ) -> anyhow::Result<Option<u32>> {
         no_queue_implementation_abort!()
     }
 

--- a/database/src/tests/builder.rs
+++ b/database/src/tests/builder.rs
@@ -49,7 +49,7 @@ impl RequestBuilder {
                 )
                 .await
                 .unwrap();
-            self.jobs.push((job.clone(), id));
+            self.jobs.push((job.clone(), id.unwrap()));
         }
         self
     }


### PR DESCRIPTION
Fixes the error message below which happens when trying to enqueue a job that has already been enqueued. We only use the return value from this query in tests.

```
[2025-09-24T08:51:57Z ERROR site::job_queue] Cron job failed to execute: failed to insert benchmark_job

    Caused by:
        query returned an unexpected number of rows
```
