### PR TITLE
Update memchr to 2.7.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1658,9 +1658,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memmap2"


### PR DESCRIPTION
memchr 2.7.6 contains a bugfix for aarch64_be