### PR TITLE
Do not update collector progress when the job queue is used

### DIFF
--- a/collector/src/runtime/mod.rs
+++ b/collector/src/runtime/mod.rs
@@ -35,7 +35,6 @@ pub async fn bench_runtime(
     collector: &CollectorCtx,
     filter: RuntimeBenchmarkFilter,
     iterations: u32,
-    job_id: Option<u32>,
 ) -> anyhow::Result<()> {
     let filtered = suite.filtered_benchmark_count(&filter);
     println!("Executing {filtered} benchmarks\n");
@@ -94,7 +93,7 @@ pub async fn bench_runtime(
                     collector.artifact_row_id,
                     &step_name,
                     &format!("{error:?}"),
-                    job_id,
+                    collector.job_id,
                 )
                 .await;
         };


### PR DESCRIPTION
Otherwise the old system would pick up benchmark requests and that breaks it. Found while testing the new system in production.