### PR TITLE
Fix job queue migration

### DIFF
--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -1242,6 +1242,7 @@ mod tests {
                 CodegenBackend::Llvm,
                 Profile::Check,
                 0,
+                BenchmarkJobKind::Compiletime,
             )
             .await
             .unwrap()

--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -418,7 +418,7 @@ static MIGRATIONS: &[&str] = &[
     CREATE INDEX benchmark_request_completed_idx ON benchmark_request(completed_at);
     "#,
     r#"
-    ALTER TABLE job_queue ADD COLUMN kind TEXT NOT NULL;
+    ALTER TABLE job_queue ADD COLUMN kind TEXT NOT NULL DEFAULT 'compiletime';
     "#,
 ];
 


### PR DESCRIPTION
Migrations that add a new `NOT NULL` column should always contain a `DEFAULT` value.