### PR TITLE
Show stderr when an `eprintln` profiler invocation fails

### DIFF
--- a/collector/src/bin/rustc-fake.rs
+++ b/collector/src/bin/rustc-fake.rs
@@ -355,11 +355,18 @@ fn main() {
 
             "Eprintln" => {
                 let mut cmd = Command::new(tool);
+
+                let file_path = "eprintln";
                 cmd.args(args).stderr(std::process::Stdio::from(
-                    std::fs::File::create("eprintln").unwrap(),
+                    std::fs::File::create(file_path).unwrap(),
                 ));
 
-                run_with_determinism_env(cmd);
+                determinism_env(&mut cmd);
+                let status = cmd.status().expect("failed to spawn");
+                if !status.success() {
+                    let stderr = std::fs::read_to_string(file_path).unwrap_or_default();
+                    panic!("command did not complete successfully: {cmd:?}\nstderr:\n{stderr}");
+                }
             }
 
             "LlvmLines" => {


### PR DESCRIPTION
This allows us to see compiler failures during PGO/BOLT profiling on rustc CI.

https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/Help.20needed.20with.20PGO.20build.20failure/with/543890687
