### PR TITLE
Make `html5ever` compilable on beta

### DIFF
--- a/collector/compile-benchmarks/html5ever/src/lib.rs
+++ b/collector/compile-benchmarks/html5ever/src/lib.rs
@@ -11,6 +11,7 @@
 #![crate_type="dylib"]
 
 #![allow(unused_parens)]
+#![allow(semicolon_in_expressions_from_macros)]
 
 #![cfg_attr(feature = "heap_size", feature(plugin, custom_derive))]
 #![cfg_attr(feature = "heap_size", plugin(heapsize_plugin))]


### PR DESCRIPTION
Context: https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/html5ever.20benchmark.20started.20failing.20in.20beta

Caused by https://github.com/rust-lang/rust/issues/144370.
