### PR TITLE
Test stable benchmarks with the beta toolchain

### DIFF
--- a/.github/workflows/beta-stable-benchmarks.yml
+++ b/.github/workflows/beta-stable-benchmarks.yml
@@ -1,0 +1,35 @@
+name: Test stable benchmarks with beta
+on:
+  pull_request:
+  schedule:
+    - cron: "0 12 * * 1" # Every Monday at 12:00 UTC
+
+jobs:
+  test-stable:
+    name: Test stable benchmarks
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout the source code
+        uses: actions/checkout@v4
+
+      - name: Install beta toolchain
+        run: |
+          rustup install beta
+          rustup default beta
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: beta
+
+      - name: Configure environment
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y linux-tools-common linux-tools-generic linux-tools-`uname -r`
+          echo -1 | sudo tee /proc/sys/kernel/perf_event_paranoid
+
+      - name: Build
+        run: cargo build -p collector
+
+      - name: Run stable benchmarks
+        run: |
+          cargo run --bin collector bench_local `rustup +beta which rustc` --category Stable


### PR DESCRIPTION
It's better to find issues early on CI rather than in the CI perf. log... I also enabled it on PR CI to see if changes in stable benchmarks have any effect on beta.