### PR TITLE
Ensure that deploys are not concurrent

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,8 @@ on:
 env:
   AWS_ACCESS_KEY_ID: AKIA46X5W6CZBLO3VBND
 
+concurrency: deploy
+
 jobs:
   deploy:
     name: Deploy


### PR DESCRIPTION
We have a merge queue now, but we still deploy from master - make sure that we always deploy at most one version at a time.
