### PR TITLE
Sort jobs of in-progress benchmark requests by their creation date

### DIFF
--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -773,7 +773,10 @@ impl PostgresConnection {
                         SELECT tag FROM parents
                     )
                     -- Only get the jobs of in_progress requests
-                    SELECT * FROM job_queue INNER JOIN requests ON job_queue.request_tag = requests.tag
+                    SELECT *
+                    FROM job_queue
+                    INNER JOIN requests ON job_queue.request_tag = requests.tag
+                    ORDER BY created_at ASC
                 ")).await.unwrap(),
                 // Load pending benchmark requests, along with information whether their parent is
                 // completed or not


### PR DESCRIPTION
I noticed that the jobs on the status page were sort of in a random order. It would be better to order them by creation date, which will be used (more or less) also to determine in which order will the jobs actually be executed.
