### PR TITLE
Make rustc-perf example Cargo commands more bulletproof

### DIFF
--- a/site/frontend/src/pages/compare/compile/table/shortcuts/binary-size-shortcut.vue
+++ b/site/frontend/src/pages/compare/compile/table/shortcuts/binary-size-shortcut.vue
@@ -8,6 +8,7 @@ import {CompileTestCase} from "../../common";
 import {ArtifactDescription} from "../../../types";
 import Tooltip from "../../../tooltip.vue";
 import {normalizeProfile} from "./utils";
+import {cargo_collector_command} from "../../../../../utils/cargo";
 
 const props = defineProps<{
   artifact: ArtifactDescription;
@@ -30,13 +31,12 @@ function normalizeBackend(backend: string): string {
     Command for analyzing binary size locally
     <Tooltip>
       Execute this command in a checkout of
-      <a href="https://github.com/rust-lang/rustc-perf">rustc-perf</a>, after a
-      `cargo build --release`, to compare binary section sizes. Add `--symbols`
-      to include a diff of symbol sizes.
+      <a href="https://github.com/rust-lang/rustc-perf">rustc-perf</a>. Add
+      `--symbols` to include a diff of symbol sizes.
     </Tooltip>
   </div>
 
-  <pre><code>cargo run --release --bin collector \
+  <pre><code>{{ cargo_collector_command() }} \
     binary_stats compile \
     +{{ props.baseArtifact.commit }} \
     --rustc2 +{{ props.artifact.commit }} \

--- a/site/frontend/src/pages/compare/compile/table/shortcuts/cachegrind-cmd.vue
+++ b/site/frontend/src/pages/compare/compile/table/shortcuts/cachegrind-cmd.vue
@@ -6,6 +6,7 @@
 import {CompileTestCase} from "../../common";
 import {computed} from "vue";
 import {normalizeProfile} from "./utils";
+import {cargo_collector_command} from "../../../../../utils/cargo";
 
 const props = defineProps<{
   commit: string;
@@ -36,7 +37,7 @@ function normalizeScenario(scenario: string): string {
 </script>
 
 <template>
-  <pre><code>cargo run --release --bin collector \
+  <pre><code>{{ cargo_collector_command() }} \
     profile_local cachegrind \
     +{{ firstCommit }} \<template v-if="props.baselineCommit !== undefined">
     --rustc2 +{{ props.commit }} \</template>

--- a/site/frontend/src/pages/compare/compile/table/shortcuts/profile-shortcut.vue
+++ b/site/frontend/src/pages/compare/compile/table/shortcuts/profile-shortcut.vue
@@ -49,8 +49,8 @@ const profileBaselineCommit = computed(() => {
     Command for profiling locally
     <Tooltip>
       Execute this command in a checkout of
-      <a href="https://github.com/rust-lang/rustc-perf">rustc-perf</a>, after a
-      `cargo build --release`, to generate a Cachegrind profile.
+      <a href="https://github.com/rust-lang/rustc-perf">rustc-perf</a> to
+      generate a Cachegrind profile.
     </Tooltip>
   </div>
 

--- a/site/frontend/src/pages/detailed-query/utils.ts
+++ b/site/frontend/src/pages/detailed-query/utils.ts
@@ -2,6 +2,7 @@ import {
   chromeProfileUrl,
   processedSelfProfileRelativeUrl,
 } from "../../self-profile";
+import {cargo_collector_command} from "../../utils/cargo";
 
 export interface Selector {
   commit: string;
@@ -198,7 +199,7 @@ export function createDownloadLinksData(selector: Selector | null): {
 
   const localCommands = {
     base: state.base_commit
-      ? `cargo run --release --bin collector profile_local cachegrind
+      ? `${cargo_collector_command()} profile_local cachegrind
                     +${state.base_commit} --exact-match ${benchName(
           state.benchmark
         )} --profiles
@@ -206,7 +207,7 @@ export function createDownloadLinksData(selector: Selector | null): {
           state.scenario
         )}`
       : "",
-    new: `cargo run --release --bin collector profile_local cachegrind
+    new: `${cargo_collector_command()} profile_local cachegrind
                 +${state.commit} --exact-match ${benchName(
       state.benchmark
     )} --profiles
@@ -214,7 +215,7 @@ export function createDownloadLinksData(selector: Selector | null): {
       state.scenario
     )}`,
     diff: state.base_commit
-      ? `cargo run --release --bin collector profile_local cachegrind
+      ? `${cargo_collector_command()} profile_local cachegrind
                 +${state.base_commit} --rustc2 +${
           state.commit
         } --exact-match ${benchName(state.benchmark)} --profiles

--- a/site/frontend/src/utils/cargo.ts
+++ b/site/frontend/src/utils/cargo.ts
@@ -1,0 +1,9 @@
+/**
+ * Return a Cargo command that builds rustc-perf properly and then executes
+ * the collector.
+ * The returned command is meant to be followed by a `collector` command and its
+ * arguments.
+ */
+export function cargo_collector_command(): string {
+  return "cargo build --release -p collector && ./target/release/collector";
+}


### PR DESCRIPTION
Hopefully this should resolve issues like https://rust-lang.zulipchat.com/#narrow/channel/247081-t-compiler.2Fperformance/topic/collector.20can't.20rustc.20--print.20sysroot/with/547044191 for good.
