### PR TITLE
Rename CI jobs to make them more accurate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   test-linux:
-    name: Test and deploy
+    name: Test on Linux
     runs-on: ubuntu-22.04
     env:
       TEST_DB_URL: postgres://postgres:testpass@localhost:5432/postgres

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Manual deploy
+name: Deploy
 on:
   push:
     branches:


### PR DESCRIPTION
We no longer deploy from the job that was called "Test and deploy".
