### PR TITLE
Use the new job queue for request duration estimation

### DIFF
--- a/site/src/job_queue/mod.rs
+++ b/site/src/job_queue/mod.rs
@@ -170,7 +170,14 @@ fn sort_benchmark_requests(pending: PendingBenchmarkRequests) -> Vec<BenchmarkRe
 /// after an in-progress request is finished, the ordering of the rest of the queue does not
 /// change (unless some other request was added to the queue in the meantime).
 ///
-/// Does not consider requests that are waiting for artifacts or that are alredy completed.
+/// Does not consider requests that are waiting for artifacts or that are already completed.
+///
+/// The returned order is:
+/// - In progress (if present)
+/// - First to be benchmarked
+/// - Second to be benchmarked
+/// - Third to be benchmarked
+/// - ...
 pub async fn build_queue(
     conn: &dyn database::pool::Connection,
 ) -> anyhow::Result<Vec<BenchmarkRequest>> {


### PR DESCRIPTION
Currently, all GH PR comments show that there is nothing in the queue. This PR switches that estimation to the new job queue.
