### PR TITLE
Add more error logs

### DIFF
--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -1028,7 +1028,7 @@ impl BenchmarkRequest {
             .split(',')
             .map(Profile::from_str)
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| anyhow::anyhow!("Invalid backend: {e}"))
+            .map_err(|e| anyhow::anyhow!("Invalid profile: {e}"))
     }
 
     pub fn is_completed(&self) -> bool {

--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -1874,9 +1874,9 @@ where
             .await
             .context("failed to insert benchmark_job")?;
         if let Some(row) = rows.first() {
-            return Ok(Some(row.get::<_, i32>(0) as u32));
+            Ok(Some(row.get::<_, i32>(0) as u32))
         } else {
-            return Ok(None);
+            Ok(None)
         }
     }
 


### PR DESCRIPTION
The queue is stuck, probably because `enqueue_parent_benchmark_job` returns an unexpected number of rows.

I will investigate tomorrow, for now adding more error logging.
