### PR TITLE
Do not send "commit queued" comments after every try build completes

### DIFF
--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -1717,21 +1717,21 @@ where
         sha: &str,
         parent_sha: &str,
         commit_date: DateTime<Utc>,
-    ) -> anyhow::Result<()> {
-        self.conn()
+    ) -> anyhow::Result<bool> {
+        let modified_rows = self
+            .conn()
             .execute(
-                "UPDATE
-                benchmark_request
-            SET
-                tag = $1,
-                parent_sha = $2,
-                status = $3,
-                commit_date = $6
-            WHERE
-                pr = $4
-                AND commit_type = 'try'
-                AND tag IS NULL
-                AND status = $5;",
+                "UPDATE benchmark_request
+                SET
+                    tag = $1,
+                    parent_sha = $2,
+                    status = $3,
+                    commit_date = $6
+                WHERE
+                    pr = $4
+                    AND commit_type = 'try'
+                    AND tag IS NULL
+                    AND status = $5;",
                 &[
                     &sha,
                     &parent_sha,
@@ -1744,7 +1744,7 @@ where
             .await
             .context("failed to attach SHAs to try benchmark request")?;
 
-        Ok(())
+        Ok(modified_rows > 0)
     }
 
     async fn load_pending_benchmark_requests(&self) -> anyhow::Result<PendingBenchmarkRequests> {

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -1344,7 +1344,7 @@ impl Connection for SqliteConnection {
         _sha: &str,
         _parent_sha: &str,
         _commit_date: DateTime<Utc>,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<bool> {
         no_queue_implementation_abort!()
     }
 


### PR DESCRIPTION
The code was doing something pretty silly - posting an "enqueued" message on *any* PR on which a try build has finished :D Regardless whether it was actually queued or not.

Reported [here](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Moving.20rustc-perf.20to.20the.20new.20job.20queue/near/553491022).
