### PR TITLE
Change error handling for creating parent jobs

### DIFF
--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -15,6 +15,14 @@ use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 pub mod postgres;
 pub mod sqlite;
 
+#[derive(Debug)]
+pub enum JobEnqueueResult {
+    JobCreated(u32),
+    JobAlreadyExisted,
+    RequestShaNotFound { error: String },
+    Other(anyhow::Error),
+}
+
 #[async_trait::async_trait]
 pub trait Connection: Send + Sync {
     async fn maybe_create_indices(&mut self);
@@ -238,20 +246,7 @@ pub trait Connection: Send + Sync {
         profile: Profile,
         benchmark_set: u32,
         kind: BenchmarkJobKind,
-    ) -> anyhow::Result<Option<u32>>;
-
-    /// Add a benchmark job which is explicitly using a `parent_sha` we split
-    /// this out to improve our error handling. A `parent_sha` may not have
-    /// an associated request in the `benchmarek`
-    async fn enqueue_parent_benchmark_job(
-        &self,
-        parent_sha: &str,
-        target: Target,
-        backend: CodegenBackend,
-        profile: Profile,
-        benchmark_set: u32,
-        kind: BenchmarkJobKind,
-    ) -> (bool, anyhow::Result<u32>);
+    ) -> JobEnqueueResult;
 
     /// Returns a set of compile-time benchmark test cases that were already computed for the
     /// given artifact.
@@ -457,6 +452,15 @@ mod tests {
             sha: commit_sha.into(),
             date: Date(time),
             r#type,
+        }
+    }
+
+    impl JobEnqueueResult {
+        pub fn unwrap(self) -> u32 {
+            match self {
+                JobEnqueueResult::JobCreated(id) => id,
+                error => panic!("Unexpected job enqueue result: {error:?}"),
+            }
         }
     }
 
@@ -715,7 +719,10 @@ mod tests {
                     BenchmarkJobKind::Runtime,
                 )
                 .await;
-            assert!(result.is_ok());
+            match result {
+                JobEnqueueResult::JobCreated(_) => {}
+                error => panic!("Invalid result: {error:?}"),
+            }
 
             Ok(ctx)
         })
@@ -861,16 +868,20 @@ mod tests {
                 .unwrap();
 
             // Now we can insert the job
-            db.enqueue_benchmark_job(
-                benchmark_request.tag().unwrap(),
-                Target::X86_64UnknownLinuxGnu,
-                CodegenBackend::Llvm,
-                Profile::Opt,
-                1u32,
-                BenchmarkJobKind::Runtime,
-            )
-            .await
-            .unwrap();
+            match db
+                .enqueue_benchmark_job(
+                    benchmark_request.tag().unwrap(),
+                    Target::X86_64UnknownLinuxGnu,
+                    CodegenBackend::Llvm,
+                    Profile::Opt,
+                    1u32,
+                    BenchmarkJobKind::Runtime,
+                )
+                .await
+            {
+                JobEnqueueResult::JobCreated(_) => {}
+                error => panic!("Invalid result: {error:?}"),
+            };
 
             let (benchmark_job, artifact_id) = db
                 .dequeue_benchmark_job(
@@ -1206,29 +1217,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn enqueue_parent_benchmark_job() {
-        run_postgres_test(|ctx| async {
-            let db = ctx.db();
-
-            let (violates_foreign_key, _) = db
-                .enqueue_parent_benchmark_job(
-                    "sha-0",
-                    Target::X86_64UnknownLinuxGnu,
-                    CodegenBackend::Llvm,
-                    Profile::Debug,
-                    0,
-                    BenchmarkJobKind::Runtime,
-                )
-                .await;
-
-            assert!(violates_foreign_key);
-
-            Ok(ctx)
-        })
-        .await;
-    }
-
-    #[tokio::test]
     async fn purge_artifact() {
         run_postgres_test(|ctx| async {
             let db = ctx.db();
@@ -1244,7 +1232,6 @@ mod tests {
                 BenchmarkJobKind::Compiletime,
             )
             .await
-            .unwrap()
             .unwrap();
             db.purge_artifact(&ArtifactId::Tag("foo".to_string())).await;
 

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -1,4 +1,6 @@
-use crate::pool::{Connection, ConnectionManager, ManagedConnection, Transaction};
+use crate::pool::{
+    Connection, ConnectionManager, JobEnqueueResult, ManagedConnection, Transaction,
+};
 use crate::selector::CompileTestCase;
 use crate::{
     ArtifactCollection, ArtifactId, Benchmark, BenchmarkJob, BenchmarkJobConclusion,
@@ -1356,19 +1358,7 @@ impl Connection for SqliteConnection {
         _profile: Profile,
         _benchmark_set: u32,
         _kind: BenchmarkJobKind,
-    ) -> anyhow::Result<Option<u32>> {
-        no_queue_implementation_abort!()
-    }
-
-    async fn enqueue_parent_benchmark_job(
-        &self,
-        _parent_sha: &str,
-        _target: Target,
-        _backend: CodegenBackend,
-        _profile: Profile,
-        _benchmark_set: u32,
-        _kind: BenchmarkJobKind,
-    ) -> (bool, anyhow::Result<u32>) {
+    ) -> JobEnqueueResult {
         no_queue_implementation_abort!()
     }
 


### PR DESCRIPTION
I missed this comment: `// This will return zero rows if the job already exists`, we used `query_one` in the parent version of the enqueue job function, which was failing if the parent job was already in the DB.

Rather than having two separate functions whose functionality can slightly diverge, I unified the logic into a single function.
