### PR TITLE
Treat in-progress requests as completed when computing queue order

### DIFF
--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -1055,6 +1055,7 @@ impl BenchmarkRequestIndex {
 
 /// Contains pending (ArtifactsReady or InProgress) benchmark requests, and a set of their parents
 /// that are already completed.
+#[derive(Debug)]
 pub struct PendingBenchmarkRequests {
     pub requests: Vec<BenchmarkRequest>,
     pub completed_parent_tags: HashSet<String>,


### PR DESCRIPTION
If all pending requests have a parent that is also pending or in-progress, then the queue ordering would get stuck on the "No master/try commit is ready for benchmarking" edge-case. We thus treat in-progress requests as already completed when computing the queue ordering.
