### PR TITLE
fix - add "times are local" caveat

### DIFF
--- a/site/frontend/src/pages/status/page.vue
+++ b/site/frontend/src/pages/status/page.vue
@@ -164,6 +164,7 @@ loadStatusData(loading);
     <div class="status-page-wrapper">
       <div class="timeline-wrapper">
         <h1>Timeline</h1>
+        <strong>Times are local.</strong>
         <div style="margin-bottom: 10px">
           Queue length: {{ data.queueLength }}
         </div>


### PR DESCRIPTION
I've added this to the top as when we add more collectors the "Times are local" will not be visible. Or indeed if the queue is massive.

<img width="1127" height="635" alt="image" src="https://github.com/user-attachments/assets/047f885a-82c5-42ac-ba71-89cc7a396add" />
