### PR TITLE
Show full sha on hover

### DIFF
--- a/site/frontend/src/pages/status/commit-sha.vue
+++ b/site/frontend/src/pages/status/commit-sha.vue
@@ -11,6 +11,7 @@ const looksLikeSha = computed(() => props.tag.length === 40);
 <template>
   <a
     v-if="looksLikeSha"
+    :title="tag"
     :href="'https://github.com/rust-lang/rust/commit/' + tag"
   >
     {{ tag.substring(0, 13) }}


### PR DESCRIPTION
Lets us see the full sha when hovering with a mouse

Addresses some of the comments in; https://github.com/rust-lang/rustc-perf/issues/2244 

Took the photo on my phone as I couldn't take a screen shot of it without the cursor losing focus.
![WhatsApp Image 2025-11-05 at 08 53 32](https://github.com/user-attachments/assets/db53591d-ffb4-4a93-948d-7d2ad8f1863b)