### PR TITLE
Correctly pass backend when computing benchmark detail graph

### DIFF
--- a/database/src/selector.rs
+++ b/database/src/selector.rs
@@ -212,6 +212,11 @@ impl CompileBenchmarkQuery {
         self
     }
 
+    pub fn backend(mut self, selector: Selector<CodegenBackend>) -> Self {
+        self.backend = selector;
+        self
+    }
+
     pub fn metric(mut self, selector: Selector<Metric>) -> Self {
         self.metric = selector.map(|v| v.as_str().into());
         self

--- a/site/frontend/src/pages/compare/compile/table/benchmark-detail-graph.vue
+++ b/site/frontend/src/pages/compare/compile/table/benchmark-detail-graph.vue
@@ -38,6 +38,7 @@ function createGraphsSelector(): CompileDetailGraphsSelector {
     benchmark: props.testCase.benchmark,
     profile: props.testCase.profile,
     scenario: props.testCase.scenario,
+    backend: props.testCase.backend,
     stat: props.metric,
     start,
     end,

--- a/site/frontend/src/pages/compare/compile/table/detail-resolver.ts
+++ b/site/frontend/src/pages/compare/compile/table/detail-resolver.ts
@@ -13,6 +13,7 @@ export interface CompileDetailGraphsSelector {
   benchmark: string;
   scenario: string;
   profile: string;
+  backend: string;
   kinds: GraphKind[];
 }
 
@@ -62,7 +63,7 @@ export const COMPILE_DETAIL_GRAPHS_RESOLVER: CachedDataLoader<
   CompileDetailGraphs
 > = new CachedDataLoader(
   (key: CompileDetailGraphsSelector) =>
-    `${key.benchmark};${key.profile};${key.scenario};${key.start};${key.end};${key.stat};${key.kinds}`,
+    `${key.benchmark};${key.profile};${key.scenario};${key.backend};${key.start};${key.end};${key.stat};${key.kinds}`,
   loadGraphsDetail
 );
 
@@ -76,6 +77,7 @@ async function loadGraphsDetail(
     benchmark: selector.benchmark,
     scenario: selector.scenario,
     profile: selector.profile,
+    backend: selector.backend,
     kinds: selector.kinds.join(","),
   };
   return await getJson<CompileDetailGraphs>(
@@ -89,7 +91,7 @@ export const COMPILE_DETAIL_SECTIONS_RESOLVER: CachedDataLoader<
   CompileDetailSectionsSelector,
   CompileDetailSections
 > = new CachedDataLoader(
-  (key: CompileDetailGraphsSelector) =>
+  (key: CompileDetailSectionsSelector) =>
     `${key.benchmark};${key.profile};${key.scenario};${key.start};${key.end}`,
   loadSectionsDetail
 );

--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -158,6 +158,7 @@ pub mod detail_graphs {
         pub benchmark: String,
         pub scenario: String,
         pub profile: String,
+        pub backend: String,
         #[serde(deserialize_with = "vec_from_comma_separated")]
         pub kinds: Vec<GraphKind>,
     }

--- a/site/src/request_handlers/graph.rs
+++ b/site/src/request_handlers/graph.rs
@@ -36,6 +36,7 @@ pub async fn handle_compile_detail_graphs(
                 .benchmark(Selector::One(request.benchmark.clone()))
                 .profile(Selector::One(request.profile.parse()?))
                 .scenario(Selector::One(scenario))
+                .backend(Selector::One(request.backend.parse()?))
                 .metric(Selector::One(request.stat.parse()?)),
             artifact_ids.clone(),
         )


### PR DESCRIPTION
I tried to do a backfill of Cranelift results, which stored some Cranelift data in the production database. This is now starting to uncover some weak spots in the querying logic where we were not selecting the right backend correctly.

This PR fixes the compile-time detailed graph endpoint.

Found [here](https://rust-lang.zulipchat.com/#narrow/channel/247081-t-compiler.2Fperformance/topic/30.20day.20history.20graph.20endpoint.20.20returns.20502/with/553860741).
