### PR TITLE
Remove 's' from error count

### DIFF
--- a/site/frontend/src/pages/status/page.vue
+++ b/site/frontend/src/pages/status/page.vue
@@ -101,7 +101,7 @@ function hasErrors(request: BenchmarkRequest) {
 
 function getErrorsLength(errors: Dict<string>) {
   const errorsLen = Object.keys(errors).length;
-  return `${errorsLen} ${errorsLen > 1 ? "s" : ""}`;
+  return `${errorsLen}`;
 }
 
 function PullRequestLink({request}: {request: BenchmarkRequest}) {


### PR DESCRIPTION
Feedback from zulip to remove the `'s'`