### PR TITLE
Fix endless comment loop

### DIFF
--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -616,6 +616,7 @@ pub mod github {
     #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
     pub struct User {
         pub id: u64,
+        pub login: String,
     }
 
     #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/site/src/request_handlers/github.rs
+++ b/site/src/request_handlers/github.rs
@@ -97,6 +97,11 @@ async fn handle_rust_timer(
     comment: github::Comment,
     issue: github::Issue,
 ) -> ServerResult<github::Response> {
+    // Avoid reacting to the bot's comments
+    if comment.user.login == "rust-timer" {
+        return Ok(github::Response);
+    }
+
     if comment.author_association != github::Association::Owner
         && !get_authorized_users().await?.contains(&comment.user.id)
     {


### PR DESCRIPTION
Avoid creating comments that contain `@rust-timer`, and avoid reading comments created by the bot itself.