### PR TITLE
Do not enqueue rustc job for release benchmark requests

### DIFF
--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -1804,7 +1804,8 @@ async fn create_benchmark_configs(
             }
         }
         database::BenchmarkJobKind::Rustc => {
-            bench_rustc = !is_release;
+            assert!(!is_release, "Release job should not benchmark rustc");
+            bench_rustc = true;
         }
     }
 


### PR DESCRIPTION
Those should not run the `rustc` benchmark. Step 4/N of fixing release benchmarks in the new system.. :)