### PR TITLE
Fix release benchmark with multiple collectors

### DIFF
--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -1749,6 +1749,10 @@ async fn run_benchmark_job(
                     "Cannot prepare benchmark configs: {error:?}"
                 ))
             })?;
+    if compile_config.is_none() && runtime_config.is_none() {
+        log::warn!("Nothing to benchmark");
+        return Ok(());
+    }
 
     let shared = SharedBenchmarkConfig {
         artifact_id,


### PR DESCRIPTION
Yet another fix for release benchmarks :D This time with multiple collectors. The code was crashing when there was nothing to benchmark, which happened for release benchmarks where set != 0.
