### PR TITLE
Remove unused try benchmark request parameters

### DIFF
--- a/site/frontend/templates/pages/help.html
+++ b/site/frontend/templates/pages/help.html
@@ -28,21 +28,6 @@
   </p>
   <p><code>@rust-timer queue</code> has a few extra options that can be useful:</p>
   <ul>
-    <li><code>include=&lt;INCLUDE&gt;</code> is a comma-separated list of benchmark prefixes. A
-      benchmark is included in
-      the run only if its name matches one of the given prefixes.
-    </li>
-    <li><code>exclude=&lt;EXCLUDE&gt;</code> is a comma-separated list of benchmark prefixes, and
-      the inverse of <code>include=</code>.
-      A benchmark is excluded from the run if its name matches one of the given prefixes.
-    </li>
-    <li><code>runs=&lt;RUNS&gt;</code> configures how many times the benchmark is run. <code>&lt;RUNS&gt;</code>
-      is an integer. All benchmarks run at least once by default, but some run more than one time.
-      You can use
-      the <code>runs</code> option to override the default run count and make every benchmark run
-      for
-      <code>&lt;RUNS&gt;</code> times.
-    </li>
     <li><code>backends=&lt;BACKENDS&gt;</code> configures which codegen backends should be
       benchmarked.
       By default, only the LLVM backend is benchmarked. If you select a non-default codegen backend,
@@ -54,8 +39,8 @@
       parent/baseline commit, so that we have something to compare to.
     </li>
     <li><code>targets=&lt;TARGETS&gt;</code> configures which targets should be benchmarked.
-        If no targets are provided <code>x86_64-unknown-linux-gnu</code> is the default.
-        Please note presently the only valid option is <code>x86_64-unknown-linux-gnu</code>.
+      If no targets are provided <code>x86_64-unknown-linux-gnu</code> is the default.
+      Please note presently the only valid option is <code>x86_64-unknown-linux-gnu</code>.
     </li>
   </ul>
   <p><code>@rust-timer build $commit</code> will queue a perf run for the given commit


### PR DESCRIPTION
I haven't ever seen anyone use runs, include or exclude on try build perf. runs, and the new system doesn't support them anyway. We now have better ways of selecting a subset of benchmarks I think, with targets, backends and profiles.
