### PR TITLE
Do not require pushes to main to be triggered by bors

### DIFF
--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -602,7 +602,6 @@ pub mod github {
     #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Push {
         pub r#ref: String,
-        pub sender: Sender,
         pub head_commit: HeadCommit,
         pub before: String,
         pub commits: Vec<Commit>,
@@ -624,11 +623,6 @@ pub mod github {
     #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct HeadCommit {
         pub message: String,
-    }
-
-    #[derive(Debug, Clone, Serialize, Deserialize)]
-    pub struct Sender {
-        pub login: String,
     }
 
     #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/site/src/request_handlers.rs
+++ b/site/src/request_handlers.rs
@@ -7,7 +7,7 @@ mod status_page;
 
 pub use bootstrap::handle_bootstrap;
 pub use dashboard::handle_dashboard;
-pub use github::handle_github;
+pub use github::handle_github_webhook;
 pub use graph::{
     handle_compile_detail_graphs, handle_compile_detail_sections, handle_graphs,
     handle_runtime_detail_graphs,

--- a/site/src/request_handlers/github.rs
+++ b/site/src/request_handlers/github.rs
@@ -12,7 +12,7 @@ use database::{
 use hashbrown::HashMap;
 use std::sync::Arc;
 
-pub async fn handle_github(
+pub async fn handle_github_webhook(
     request: github::Request,
     ctxt: Arc<SiteCtxt>,
 ) -> ServerResult<github::Response> {
@@ -25,9 +25,7 @@ pub async fn handle_github(
 
 async fn handle_push(ctxt: Arc<SiteCtxt>, push: github::Push) -> ServerResult<github::Response> {
     let gh_client = client::Client::from_ctxt(&ctxt, RUST_REPO_GITHUB_API_URL.to_owned());
-    if push.r#ref != format!("refs/heads/{}", push.repository.default_branch)
-        || push.sender.login != "bors"
-    {
+    if push.r#ref != format!("refs/heads/{}", push.repository.default_branch) {
         return Ok(github::Response);
     }
     let rollup_pr_number = match rollup_pr_number(&gh_client, &push.head_commit.message).await? {

--- a/site/src/server.rs
+++ b/site/src/server.rs
@@ -392,7 +392,11 @@ async fn serve_req(server: Server, req: Request) -> Result<Response, ServerError
             };
             match event.as_str() {
                 "issue_comment" | "push" => Ok(to_response(
-                    request_handlers::handle_github(check!(parse_body(&body)), ctxt.clone()).await,
+                    request_handlers::handle_github_webhook(
+                        check!(parse_body(&body)),
+                        ctxt.clone(),
+                    )
+                    .await,
                     &compression,
                 )),
                 _ => Ok(http::Response::builder()


### PR DESCRIPTION
This will be required for the switch to new bors. Found this while examining how we could fix the rollup SHAs being enqueued too soon.
