### PR TITLE
-Zthreads=N support implemented as an additional dimension 'Parallel'

### DIFF
--- a/ci/check-profiling.sh
+++ b/ci/check-profiling.sh
@@ -32,9 +32,10 @@ cargo build -p collector --bin rustc-fake
 #        --profiles Check \
 #        --cargo $bindir/cargo \
 #        --include helloworld \
-#        --scenarios Full
-#test -f results/perf-Test-helloworld-Check-Full
-#grep -q "PERFILE" results/perf-Test-helloworld-Check-Full
+#        --scenarios Full \
+#        --parallels 1
+#test -f results/perf-Test-helloworld-Check-Full-par1
+#grep -q "PERFILE" results/perf-Test-helloworld-Check-Full-par1
 
 # oprofile: untested... it's not used much, and might have the same problems
 # that `perf` has due to virtualized hardware.
@@ -50,13 +51,14 @@ RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=
         --profiles Check \
         --cargo $bindir/cargo \
         --include helloworld \
-        --scenarios Full
-test -f results/cgout-Test-helloworld-Check-Full
-grep -q "events: Ir" results/cgout-Test-helloworld-Check-Full
-test -f results/cgann-Test-helloworld-Check-Full
-grep -q "PROGRAM TOTALS" results/cgann-Test-helloworld-Check-Full
+        --scenarios Full \
+        --parallels 1
+test -f results/cgout-Test-helloworld-Check-Full-par1
+grep -q "events: Ir" results/cgout-Test-helloworld-Check-Full-par1
+test -f results/cgann-Test-helloworld-Check-Full-par1
+grep -q "PROGRAM TOTALS" results/cgann-Test-helloworld-Check-Full-par1
 # Ensure that we also profile the memory allocator
-grep -q "malloc" results/cgann-Test-helloworld-Check-Full
+grep -q "malloc" results/cgann-Test-helloworld-Check-Full-par1
 
 # Callgrind.
 RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=debug \
@@ -66,11 +68,12 @@ RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=
         --profiles Check \
         --cargo $bindir/cargo \
         --include helloworld \
-        --scenarios Full
-test -f results/clgout-Test-helloworld-Check-Full
-grep -q "creator: callgrind" results/clgout-Test-helloworld-Check-Full
-test -f results/clgann-Test-helloworld-Check-Full
-grep -q "Profile data file" results/clgann-Test-helloworld-Check-Full
+        --scenarios Full \
+        --parallels 1
+test -f results/clgout-Test-helloworld-Check-Full-par1
+grep -q "creator: callgrind" results/clgout-Test-helloworld-Check-Full-par1
+test -f results/clgann-Test-helloworld-Check-Full-par1
+grep -q "Profile data file" results/clgann-Test-helloworld-Check-Full-par1
 
 # DHAT.
 RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=debug \
@@ -80,9 +83,10 @@ RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=
         --profiles Check \
         --cargo $bindir/cargo \
         --include helloworld \
-        --scenarios Full
-test -f results/dhout-Test-helloworld-Check-Full
-grep -q "dhatFileVersion" results/dhout-Test-helloworld-Check-Full
+        --scenarios Full \
+        --parallels 1
+test -f results/dhout-Test-helloworld-Check-Full-par1
+grep -q "dhatFileVersion" results/dhout-Test-helloworld-Check-Full-par1
 
 
 # DHAT (copy mode).
@@ -95,9 +99,10 @@ RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=
         --profiles Check \
         --cargo $bindir/cargo \
         --include helloworld \
-        --scenarios Full
-test -f results/dhcopy-Test-helloworld-Check-Full
-grep -q "dhatFileVersion" results/dhcopy-Test-helloworld-Check-Full
+        --scenarios Full \
+        --parallels 1
+test -f results/dhcopy-Test-helloworld-Check-Full-par1
+grep -q "dhatFileVersion" results/dhcopy-Test-helloworld-Check-Full-par1
 
 # Massif.
 RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=debug \
@@ -107,9 +112,10 @@ RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=
         --profiles Check \
         --cargo $bindir/cargo \
         --include helloworld \
-        --scenarios Full
-test -f results/msout-Test-helloworld-Check-Full
-grep -q "snapshot=0" results/msout-Test-helloworld-Check-Full
+        --scenarios Full \
+        --parallels 1
+test -f results/msout-Test-helloworld-Check-Full-par1
+grep -q "snapshot=0" results/msout-Test-helloworld-Check-Full-par1
 
 # Bytehound.
 # This is currently broken in CI, commenting out to fix CI for this.
@@ -120,8 +126,9 @@ grep -q "snapshot=0" results/msout-Test-helloworld-Check-Full
 #         --profiles Check \
 #         --cargo $bindir/cargo \
 #         --include helloworld \
-#         --scenarios Full
-# test -f results/bhout-Test-helloworld-Check-Full
+#         --scenarios Full \
+#         --parallels 1
+# test -f results/bhout-Test-helloworld-Check-Full-par1
 
 # eprintln. The output file is empty because a vanilla rustc doesn't print
 # anything to stderr.
@@ -132,9 +139,10 @@ RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=
         --profiles Check \
         --cargo $bindir/cargo \
         --include helloworld \
-        --scenarios Full
-test   -f results/eprintln-Test-helloworld-Check-Full
-test ! -s results/eprintln-Test-helloworld-Check-Full
+        --scenarios Full \
+        --parallels 1
+test   -f results/eprintln-Test-helloworld-Check-Full-par1
+test ! -s results/eprintln-Test-helloworld-Check-Full-par1
 
 # llvm-lines. `Debug` not `Check` because it doesn't support `Check` profiles.
 # Including both `helloworld` and `regex-automata-0.4.8` benchmarks, as they exercise the
@@ -147,11 +155,12 @@ RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=
         --profiles Debug \
         --cargo $bindir/cargo \
         --include helloworld,regex-automata-0.4.8 \
-        --scenarios Full
-test -f results/ll-Test-helloworld-Debug-Full
-grep -q "Lines.*Copies.*Function name" results/ll-Test-helloworld-Debug-Full
-test -f results/ll-Test-regex-automata-0.4.8-Debug-Full
-grep -q "Lines.*Copies.*Function name" results/ll-Test-regex-automata-0.4.8-Debug-Full
+        --scenarios Full \
+        --parallels 1
+test -f results/ll-Test-helloworld-Debug-Full-par1
+grep -q "Lines.*Copies.*Function name" results/ll-Test-helloworld-Debug-Full-par1
+test -f results/ll-Test-regex-automata-0.4.8-Debug-Full-par1
+grep -q "Lines.*Copies.*Function name" results/ll-Test-regex-automata-0.4.8-Debug-Full-par1
 
 # llvm-ir. `Debug` not `Check` because it works better that way.
 RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=debug \
@@ -161,9 +170,10 @@ RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=
         --profiles Debug \
         --cargo $bindir/cargo \
         --include helloworld \
-        --scenarios Full
-test -f results/llir-Test-helloworld-Debug-Full
-grep -q "; ModuleID" results/llir-Test-helloworld-Debug-Full
+        --scenarios Full \
+        --parallels 1
+test -f results/llir-Test-helloworld-Debug-Full-par1
+grep -q "; ModuleID" results/llir-Test-helloworld-Debug-Full-par1
 
 # mono-items. `Debug` not `Check` because it works better that way.
 RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=debug \
@@ -173,9 +183,10 @@ RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=
         --profiles Debug \
         --cargo $bindir/cargo \
         --include helloworld \
-        --scenarios Full
-test -f results/mono-items-Test-helloworld-Debug-Full/raw
-grep -q "MONO_ITEM" results/mono-items-Test-helloworld-Debug-Full/raw
+        --scenarios Full \
+        --parallels 1
+test -f results/mono-items-Test-helloworld-Debug-Full-par1/raw
+grep -q "MONO_ITEM" results/mono-items-Test-helloworld-Debug-Full-par1/raw
 
 # dep-graph. `IncrFull` not `Full` because it doesn't work with `Full`.
 RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=debug \
@@ -185,9 +196,10 @@ RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=
         --profiles Check \
         --cargo $bindir/cargo \
         --include helloworld \
-        --scenarios IncrFull
-test -f results/dep-graph-Test-helloworld-Check-IncrFull.txt
-grep -q "hir_owner" results/dep-graph-Test-helloworld-Check-IncrFull.txt
+        --scenarios IncrFull \
+        --parallels 1
+test -f results/dep-graph-Test-helloworld-Check-IncrFull-par1.txt
+grep -q "hir_owner" results/dep-graph-Test-helloworld-Check-IncrFull-par1.txt
 
 #----------------------------------------------------------------------------
 # Test option handling
@@ -200,23 +212,24 @@ RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=
     profile_local eprintln $bindir/rustc \
         --id Builds1 \
         --cargo $bindir/cargo \
-        --include helloworld
-test   -f results/eprintln-Builds1-helloworld-Check-Full
-test   -f results/eprintln-Builds1-helloworld-Check-IncrFull
-test   -f results/eprintln-Builds1-helloworld-Check-IncrPatched0
-test   -f results/eprintln-Builds1-helloworld-Check-IncrUnchanged
-test   -f results/eprintln-Builds1-helloworld-Debug-Full
-test   -f results/eprintln-Builds1-helloworld-Debug-IncrFull
-test   -f results/eprintln-Builds1-helloworld-Debug-IncrPatched0
-test   -f results/eprintln-Builds1-helloworld-Debug-IncrUnchanged
-test   -f results/eprintln-Builds1-helloworld-Opt-Full
-test   -f results/eprintln-Builds1-helloworld-Opt-IncrFull
-test   -f results/eprintln-Builds1-helloworld-Opt-IncrPatched0
-test   -f results/eprintln-Builds1-helloworld-Opt-IncrUnchanged
-test ! -e results/eprintln-Builds1-helloworld-Doc-Full
-test ! -e results/eprintln-Builds1-helloworld-Doc-IncrFull
-test ! -e results/eprintln-Builds1-helloworld-Doc-IncrPatched0
-test ! -e results/eprintln-Builds1-helloworld-Doc-IncrUnchanged
+        --include helloworld \
+        --parallels 1
+test   -f results/eprintln-Builds1-helloworld-Check-Full-par1
+test   -f results/eprintln-Builds1-helloworld-Check-IncrFull-par1
+test   -f results/eprintln-Builds1-helloworld-Check-IncrPatched0-par1
+test   -f results/eprintln-Builds1-helloworld-Check-IncrUnchanged-par1
+test   -f results/eprintln-Builds1-helloworld-Debug-Full-par1
+test   -f results/eprintln-Builds1-helloworld-Debug-IncrFull-par1
+test   -f results/eprintln-Builds1-helloworld-Debug-IncrPatched0-par1
+test   -f results/eprintln-Builds1-helloworld-Debug-IncrUnchanged-par1
+test   -f results/eprintln-Builds1-helloworld-Opt-Full-par1
+test   -f results/eprintln-Builds1-helloworld-Opt-IncrFull-par1
+test   -f results/eprintln-Builds1-helloworld-Opt-IncrPatched0-par1
+test   -f results/eprintln-Builds1-helloworld-Opt-IncrUnchanged-par1
+test ! -e results/eprintln-Builds1-helloworld-Doc-Full-par1
+test ! -e results/eprintln-Builds1-helloworld-Doc-IncrFull-par1
+test ! -e results/eprintln-Builds1-helloworld-Doc-IncrPatched0-par1
+test ! -e results/eprintln-Builds1-helloworld-Doc-IncrUnchanged-par1
 
 # With `--profiles Doc` specified, `Check`/`Debug`/`Opt` files must not be
 # present, and `Doc` files must be present (but not for incremental runs).
@@ -226,23 +239,24 @@ RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=
         --id Builds2 \
         --profiles Doc \
         --cargo $bindir/cargo \
-        --include helloworld
-test ! -e results/eprintln-Builds2-helloworld-Check-Full
-test ! -e results/eprintln-Builds2-helloworld-Check-IncrFull
-test ! -e results/eprintln-Builds2-helloworld-Check-IncrUnchanged
-test ! -e results/eprintln-Builds2-helloworld-Check-IncrPatched0
-test ! -e results/eprintln-Builds2-helloworld-Debug-Full
-test ! -e results/eprintln-Builds2-helloworld-Debug-IncrFull
-test ! -e results/eprintln-Builds2-helloworld-Debug-IncrUnchanged
-test ! -e results/eprintln-Builds2-helloworld-Debug-IncrPatched0
-test ! -e results/eprintln-Builds2-helloworld-Opt-Full
-test ! -e results/eprintln-Builds2-helloworld-Opt-IncrFull
-test ! -e results/eprintln-Builds2-helloworld-Opt-IncrUnchanged
-test ! -e results/eprintln-Builds2-helloworld-Opt-IncrPatched0
-test   -f results/eprintln-Builds2-helloworld-Doc-Full
-test ! -f results/eprintln-Builds2-helloworld-Doc-IncrFull
-test ! -f results/eprintln-Builds2-helloworld-Doc-IncrPatched0
-test ! -f results/eprintln-Builds2-helloworld-Doc-IncrUnchanged
+        --include helloworld \
+        --parallels 1
+test ! -e results/eprintln-Builds2-helloworld-Check-Full-par1
+test ! -e results/eprintln-Builds2-helloworld-Check-IncrFull-par1
+test ! -e results/eprintln-Builds2-helloworld-Check-IncrUnchanged-par1
+test ! -e results/eprintln-Builds2-helloworld-Check-IncrPatched0-par1
+test ! -e results/eprintln-Builds2-helloworld-Debug-Full-par1
+test ! -e results/eprintln-Builds2-helloworld-Debug-IncrFull-par1
+test ! -e results/eprintln-Builds2-helloworld-Debug-IncrUnchanged-par1
+test ! -e results/eprintln-Builds2-helloworld-Debug-IncrPatched0-par1
+test ! -e results/eprintln-Builds2-helloworld-Opt-Full-par1
+test ! -e results/eprintln-Builds2-helloworld-Opt-IncrFull-par1
+test ! -e results/eprintln-Builds2-helloworld-Opt-IncrUnchanged-par1
+test ! -e results/eprintln-Builds2-helloworld-Opt-IncrPatched0-par1
+test   -f results/eprintln-Builds2-helloworld-Doc-Full-par1
+test ! -f results/eprintln-Builds2-helloworld-Doc-IncrFull-par1
+test ! -f results/eprintln-Builds2-helloworld-Doc-IncrPatched0-par1
+test ! -f results/eprintln-Builds2-helloworld-Doc-IncrUnchanged-par1
 
 # With `--scenarios IncrUnchanged` specified, `IncrFull` and `IncrUnchanged`
 # files must be present.
@@ -253,11 +267,12 @@ RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=
         --profiles Check \
         --cargo $bindir/cargo \
         --include helloworld \
-        --scenarios IncrUnchanged
-test ! -e results/eprintln-Runs1-helloworld-Check-Full
-test   -f results/eprintln-Runs1-helloworld-Check-IncrFull
-test   -f results/eprintln-Runs1-helloworld-Check-IncrUnchanged
-test ! -e results/eprintln-Runs1-helloworld-Check-IncrPatched0
+        --scenarios IncrUnchanged \
+        --parallels 1
+test ! -e results/eprintln-Runs1-helloworld-Check-Full-par1
+test   -f results/eprintln-Runs1-helloworld-Check-IncrFull-par1
+test   -f results/eprintln-Runs1-helloworld-Check-IncrUnchanged-par1
+test ! -e results/eprintln-Runs1-helloworld-Check-IncrPatched0-par1
 
 # With `--scenarios IncrPatched` specified, `IncrFull` and `IncrPatched0` files
 # must be present.
@@ -268,11 +283,12 @@ RUST_BACKTRACE=1 RUST_LOG=raw_cargo_messages=trace,collector=debug,rust_sysroot=
         --profiles Check \
         --cargo $bindir/cargo \
         --include helloworld \
-        --scenarios IncrPatched
-test ! -e results/eprintln-Runs2-helloworld-Check-Full
-test   -f results/eprintln-Runs2-helloworld-Check-IncrFull
-test ! -e results/eprintln-Runs2-helloworld-Check-IncrUnchanged
-test   -f results/eprintln-Runs2-helloworld-Check-IncrPatched0
+        --scenarios IncrPatched \
+        --parallels 1
+test ! -e results/eprintln-Runs2-helloworld-Check-Full-par1
+test   -f results/eprintln-Runs2-helloworld-Check-IncrFull-par1
+test ! -e results/eprintln-Runs2-helloworld-Check-IncrUnchanged-par1
+test   -f results/eprintln-Runs2-helloworld-Check-IncrPatched0-par1
 
 kill $PING_LOOP_PID
 exit 0

--- a/collector/README.md
+++ b/collector/README.md
@@ -160,6 +160,8 @@ The following options alter the behaviour of the `bench_local` subcommand.
   `IncrUnchanged`, `IncrPatched`, and `All`. The default is `All`. Note that
   `IncrFull` is always run if either of `IncrUnchanged` or `IncrPatched` are
   run (even if not requested).
+- `--parallels <PARALLELS>`: the parallel frontend options to be benchmarked.
+  Comma-separated list of thread numbers (arguments for -Zthreads=N). The default is `1,4`.
 - `--backends <BACKENDS>`: the codegen backends to be benchmarked. The possible
   choices are one or more (comma-separated) of `Llvm`, `Cranelift`. The default
   is `Llvm`.
@@ -489,6 +491,7 @@ The following options alter the behaviour of the `profile_local` subcommand.
   diff files will also be produced.
 - `--rustdoc <RUSTDOC>` as for `bench_local`.
 - `--scenarios <SCENARIOS>`: as for `bench_local`.
+- `--parallels <PARALLELS>`: as for `bench_local`.
 - `--backends <BACKENDS>`: as for `bench_local`.
 - `--jobs <JOB-COUNT>`: execute `<JOB-COUNT>` benchmarks in parallel. This is only allowed for certain
 profilers whose results are not affected by system noise (e.g. `callgrind` or `eprintln`).

--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -36,6 +36,7 @@ use collector::benchmark_set::{get_benchmark_set, BenchmarkSetId, BenchmarkSetMe
 use collector::codegen::{codegen_diff, CodegenType};
 use collector::compile::benchmark::category::Category;
 use collector::compile::benchmark::codegen_backend::CodegenBackend;
+use collector::compile::benchmark::parallel::Parallel;
 use collector::compile::benchmark::profile::Profile;
 use collector::compile::benchmark::scenario::Scenario;
 use collector::compile::benchmark::target::Target;
@@ -116,6 +117,7 @@ struct CompileBenchmarkConfig {
     self_profile_storage: Option<Box<dyn SelfProfileStorage>>,
     bench_rustc: bool,
     targets: Vec<Target>,
+    parallels: Vec<Parallel>,
 }
 
 struct RuntimeBenchmarkConfig {
@@ -166,50 +168,54 @@ fn generate_diffs(
     benchmarks: &[Benchmark],
     profiles: &[Profile],
     scenarios: &[Scenario],
+    parallels: &[Parallel],
     errors: &mut BenchmarkErrors,
     profiler: &Profiler,
 ) -> Vec<PathBuf> {
     let mut annotated_diffs = Vec::new();
     for benchmark in benchmarks {
         for &profile in profiles {
-            for scenario in scenarios.iter().flat_map(|scenario| {
-                if profile.is_doc() && scenario.is_incr() {
-                    return vec![];
-                }
-                match scenario {
-                    Scenario::Full | Scenario::IncrFull | Scenario::IncrUnchanged => {
-                        vec![format!("{:?}", scenario)]
+            for &parallel in parallels {
+                for scenario in scenarios.iter().flat_map(|scenario| {
+                    if profile.is_doc() && scenario.is_incr() {
+                        return vec![];
                     }
-                    Scenario::IncrPatched => (0..benchmark.patches.len())
-                        .map(|i| format!("{scenario:?}{i}"))
-                        .collect::<Vec<_>>(),
-                }
-            }) {
-                let filename = |prefix, id| {
-                    format!(
-                        "{}-{}-{}-{:?}-{}{}",
-                        prefix,
-                        id,
-                        benchmark.name,
-                        profile,
-                        scenario,
-                        profiler.postfix()
-                    )
-                };
-                let id_diff = format!("{id1}-{id2}");
-                let prefix = profiler.prefix();
-                let prefix2 = profiler.prefix2();
-                let left = out_dir.join(filename(prefix, id1));
-                let right = out_dir.join(filename(prefix, id2));
-                let output = out_dir.join(filename(&format!("{prefix2}-diff"), &id_diff));
+                    match scenario {
+                        Scenario::Full | Scenario::IncrFull | Scenario::IncrUnchanged => {
+                            vec![format!("{:?}", scenario)]
+                        }
+                        Scenario::IncrPatched => (0..benchmark.patches.len())
+                            .map(|i| format!("{scenario:?}{i}"))
+                            .collect::<Vec<_>>(),
+                    }
+                }) {
+                    let filename = |prefix, id| {
+                        format!(
+                            "{}-{}-{}-{:?}-{}-{}{}",
+                            prefix,
+                            id,
+                            benchmark.name,
+                            profile,
+                            scenario,
+                            parallel.par_n(),
+                            profiler.postfix()
+                        )
+                    };
+                    let id_diff = format!("{id1}-{id2}");
+                    let prefix = profiler.prefix();
+                    let prefix2 = profiler.prefix2();
+                    let left = out_dir.join(filename(prefix, id1));
+                    let right = out_dir.join(filename(prefix, id2));
+                    let output = out_dir.join(filename(&format!("{prefix2}-diff"), &id_diff));
 
-                if let Err(e) = profiler.diff(&left, &right, &output) {
-                    errors.incr();
-                    eprintln!("collector error: {e:?}");
-                    continue;
-                }
+                    if let Err(e) = profiler.diff(&left, &right, &output) {
+                        errors.incr();
+                        eprintln!("collector error: {e:?}");
+                        continue;
+                    }
 
-                annotated_diffs.push(output);
+                    annotated_diffs.push(output);
+                }
             }
         }
     }
@@ -227,6 +233,7 @@ fn profile_compile(
     backends: &[CodegenBackend],
     errors: &mut BenchmarkErrors,
     targets: &[Target],
+    parallels: &[Parallel],
 ) {
     eprintln!("Profiling {} with {:?}", toolchain.id, profiler);
     if let Profiler::SelfProfile = profiler {
@@ -248,6 +255,7 @@ fn profile_compile(
                 toolchain,
                 Some(1),
                 targets,
+                parallels,
                 // We always want to profile everything
                 &hashbrown::HashSet::new(),
             ));
@@ -411,6 +419,10 @@ struct CompileTimeOptions {
     /// It should be a path to the `clippy-driver` binary.
     #[arg(long)]
     clippy: Option<PathBuf>,
+
+    /// Parallel frontend options in comma-separated list
+    #[arg(long, value_delimiter = ',', default_value = "1,4")]
+    parallels: Vec<u32>,
 }
 
 #[derive(Debug, clap::Args)]
@@ -994,6 +1006,7 @@ fn main_result() -> anyhow::Result<i32> {
             log_db(&db);
             let profiles = opts.profiles.0;
             let scenarios = opts.scenarios.0;
+            let parallels = opts.parallels;
             let backends = opts.codegen_backends.0;
 
             let pool = database::Pool::open(&db.db);
@@ -1044,6 +1057,7 @@ fn main_result() -> anyhow::Result<i32> {
                 },
                 bench_rustc: bench_rustc.bench_rustc,
                 targets: vec![Target::host()],
+                parallels: parallels.into_iter().map(|v| v.into()).collect(),
             };
 
             rt.block_on(run_benchmarks(conn.as_mut(), shared, Some(config), None))?;
@@ -1084,6 +1098,7 @@ fn main_result() -> anyhow::Result<i32> {
 
             let profiles = &opts.profiles.0;
             let scenarios = &opts.scenarios.0;
+            let parallels: Vec<Parallel> = opts.parallels.into_iter().map(Parallel).collect();
             let backends = &opts.codegen_backends.0;
 
             let mut benchmarks = get_compile_benchmarks(&compile_benchmark_dir, (&local).into())?;
@@ -1123,6 +1138,7 @@ fn main_result() -> anyhow::Result<i32> {
                         backends,
                         &mut errors,
                         &[Target::host()],
+                        &parallels,
                     );
                     Ok(id)
                 };
@@ -1141,6 +1157,7 @@ fn main_result() -> anyhow::Result<i32> {
                     &benchmarks,
                     profiles,
                     scenarios,
+                    &parallels,
                     &mut errors,
                     &profiler,
                 );
@@ -1680,6 +1697,7 @@ async fn create_benchmark_configs(
             },
             bench_rustc,
             targets: vec![job.target().into()],
+            parallels: Parallel::default_opts(),
         })
     } else {
         None
@@ -2135,6 +2153,11 @@ async fn bench_published_artifact(
     } else {
         Scenario::all_non_incr()
     };
+    let parallels = if collector::version_supports_parallel_frontend(&toolchain.id) {
+        Parallel::default_opts()
+    } else {
+        vec![Parallel(1)]
+    };
 
     // Exclude benchmarks that don't work with a stable compiler.
     let mut compile_benchmarks = get_compile_benchmarks(dirs.compile, CompileBenchmarkFilter::All)?;
@@ -2168,6 +2191,7 @@ async fn bench_published_artifact(
             self_profile_storage: None,
             bench_rustc: false,
             targets: vec![Target::host()],
+            parallels,
         }),
         Some(RuntimeBenchmarkConfig::new(
             runtime_suite,
@@ -2274,6 +2298,7 @@ async fn bench_compile(
                     &shared.toolchain,
                     config.iterations,
                     &config.targets,
+                    &config.parallels,
                     &collector.measured_compile_test_cases,
                 ))
                 .await

--- a/collector/src/compile/benchmark/mod.rs
+++ b/collector/src/compile/benchmark/mod.rs
@@ -1,5 +1,6 @@
 use crate::compile::benchmark::category::Category;
 use crate::compile::benchmark::codegen_backend::CodegenBackend;
+use crate::compile::benchmark::parallel::Parallel;
 use crate::compile::benchmark::patch::Patch;
 use crate::compile::benchmark::profile::Profile;
 use crate::compile::benchmark::scenario::Scenario;
@@ -19,6 +20,7 @@ use tempfile::TempDir;
 
 pub mod category;
 pub mod codegen_backend;
+pub mod parallel;
 pub(crate) mod patch;
 pub mod profile;
 pub mod scenario;
@@ -195,6 +197,7 @@ impl Benchmark {
         profile: Profile,
         backend: CodegenBackend,
         target: Target,
+        parallel: Parallel,
     ) -> CargoProcess<'a> {
         let mut cargo_args = self
             .config
@@ -236,6 +239,7 @@ impl Benchmark {
             touch_file: self.config.touch_file.clone(),
             jobserver: None,
             target,
+            parallel,
             workspace_package: self.config.package.clone(),
         }
     }
@@ -251,6 +255,7 @@ impl Benchmark {
         toolchain: &Toolchain,
         iterations: Option<usize>,
         targets: &[Target],
+        parallels: &[Parallel],
         already_computed: &hashbrown::HashSet<CompileTestCase>,
     ) -> anyhow::Result<()> {
         if self.config.disabled {
@@ -288,6 +293,7 @@ impl Benchmark {
             profile: Profile,
             backend: CodegenBackend,
             target: Target,
+            parallel: Parallel,
         }
 
         // Materialize the test cases that we want to benchmark
@@ -297,32 +303,36 @@ impl Benchmark {
         for backend in backends {
             for profile in &profiles {
                 for target in targets {
-                    // Do we have any scenarios left to compute?
-                    let remaining_scenarios = scenarios
-                        .iter()
-                        .filter(|scenario| {
-                            self.should_run_scenario(
-                                scenario,
-                                profile,
-                                backend,
-                                target,
-                                already_computed,
-                            )
-                        })
-                        .copied()
-                        .collect::<Vec<Scenario>>();
-                    if remaining_scenarios.is_empty() {
-                        continue;
-                    }
+                    for parallel in parallels {
+                        // Do we have any scenarios left to compute?
+                        let remaining_scenarios = scenarios
+                            .iter()
+                            .filter(|scenario| {
+                                self.should_run_scenario(
+                                    scenario,
+                                    parallel,
+                                    profile,
+                                    backend,
+                                    target,
+                                    already_computed,
+                                )
+                            })
+                            .copied()
+                            .collect::<Vec<Scenario>>();
+                        if remaining_scenarios.is_empty() {
+                            continue;
+                        }
 
-                    let temp_dir = self.make_temp_dir(&self.path)?;
-                    benchmark_dirs.push(BenchmarkDir {
-                        dir: temp_dir,
-                        scenarios: remaining_scenarios,
-                        profile: *profile,
-                        backend: *backend,
-                        target: *target,
-                    });
+                        let temp_dir = self.make_temp_dir(&self.path)?;
+                        benchmark_dirs.push(BenchmarkDir {
+                            dir: temp_dir,
+                            scenarios: remaining_scenarios,
+                            profile: *profile,
+                            backend: *backend,
+                            target: *target,
+                            parallel: *parallel,
+                        });
+                    }
                 }
             }
         }
@@ -382,6 +392,7 @@ impl Benchmark {
                             benchmark_dir.profile,
                             benchmark_dir.backend,
                             benchmark_dir.target,
+                            benchmark_dir.parallel,
                         )
                         .jobserver(server)
                         .run_rustc(false)
@@ -421,9 +432,10 @@ impl Benchmark {
             let profile = benchmark_dir.profile;
             let target = benchmark_dir.target;
             let scenarios = &benchmark_dir.scenarios;
+            let parallel = benchmark_dir.parallel;
             eprintln!(
-                "Running {}: {:?} + {:?} + {:?} + {:?}",
-                self.name, profile, scenarios, backend, target,
+                "Running {}: {:?} + {:?} + {:?} + {:?} + {}",
+                self.name, profile, scenarios, backend, target, parallel,
             );
 
             // We want at least two runs for all benchmarks (since we run
@@ -445,7 +457,7 @@ impl Benchmark {
 
                 // A full non-incremental build.
                 if scenarios.contains(&Scenario::Full) {
-                    self.mk_cargo_process(toolchain, cwd, profile, backend, target)
+                    self.mk_cargo_process(toolchain, cwd, profile, backend, target, parallel)
                         .processor(processor, Scenario::Full, "Full", None)
                         .run_rustc(true)
                         .await?;
@@ -456,7 +468,7 @@ impl Benchmark {
                     // An incremental build from scratch (slowest incremental case).
                     // This is required for any subsequent incremental builds.
                     if scenarios.iter().any(|s| s.is_incr()) {
-                        self.mk_cargo_process(toolchain, cwd, profile, backend, target)
+                        self.mk_cargo_process(toolchain, cwd, profile, backend, target, parallel)
                             .incremental(true)
                             .processor(processor, Scenario::IncrFull, "IncrFull", None)
                             .run_rustc(true)
@@ -465,7 +477,7 @@ impl Benchmark {
 
                     // An incremental build with no changes (fastest incremental case).
                     if scenarios.contains(&Scenario::IncrUnchanged) {
-                        self.mk_cargo_process(toolchain, cwd, profile, backend, target)
+                        self.mk_cargo_process(toolchain, cwd, profile, backend, target, parallel)
                             .incremental(true)
                             .processor(processor, Scenario::IncrUnchanged, "IncrUnchanged", None)
                             .run_rustc(true)
@@ -480,16 +492,13 @@ impl Benchmark {
                             // An incremental build with some changes (realistic
                             // incremental case).
                             let scenario_str = format!("IncrPatched{i}");
-                            self.mk_cargo_process(toolchain, cwd, profile, backend, target)
-                                .incremental(true)
-                                .processor(
-                                    processor,
-                                    Scenario::IncrPatched,
-                                    &scenario_str,
-                                    Some(patch),
-                                )
-                                .run_rustc(true)
-                                .await?;
+                            self.mk_cargo_process(
+                                toolchain, cwd, profile, backend, target, parallel,
+                            )
+                            .incremental(true)
+                            .processor(processor, Scenario::IncrPatched, &scenario_str, Some(patch))
+                            .run_rustc(true)
+                            .await?;
                         }
                     }
                 }
@@ -515,6 +524,7 @@ impl Benchmark {
     fn should_run_scenario(
         &self,
         scenario: &Scenario,
+        parallel: &Parallel,
         profile: &Profile,
         backend: &CodegenBackend,
         target: &Target,
@@ -529,6 +539,7 @@ impl Benchmark {
         let profile: database::Profile = (*profile).into();
         let backend: database::CodegenBackend = (*backend).into();
         let target: database::Target = (*target).into();
+        let parallel: database::Parallel = (*parallel).into();
 
         match scenario {
             // For these scenarios, we can simply check if they were benchmarked or not
@@ -544,6 +555,7 @@ impl Benchmark {
                         Scenario::IncrUnchanged => database::Scenario::IncrementalFresh,
                         Scenario::IncrPatched => unreachable!(),
                     },
+                    parallel,
                 };
                 !already_computed.contains(&test_case)
             }
@@ -557,6 +569,7 @@ impl Benchmark {
                     benchmark,
                     profile,
                     scenario: database::Scenario::IncrementalPatch(patch.name),
+                    parallel,
                     backend,
                     target,
                 };

--- a/collector/src/compile/benchmark/parallel.rs
+++ b/collector/src/compile/benchmark/parallel.rs
@@ -1,0 +1,42 @@
+use std::fmt;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct Parallel(pub u32);
+
+impl Parallel {
+    // Default parallel frontend options
+    pub fn default_opts() -> Vec<Parallel> {
+        database::Parallel::default_opts()
+            .iter()
+            .map(|v| (*v).into())
+            .collect()
+    }
+
+    pub fn par_n(self) -> String {
+        database::Parallel(self.0).par_n()
+    }
+}
+
+impl From<u32> for Parallel {
+    fn from(item: u32) -> Self {
+        Self(item)
+    }
+}
+
+impl From<database::Parallel> for Parallel {
+    fn from(value: database::Parallel) -> Self {
+        Parallel(value.0)
+    }
+}
+
+impl From<Parallel> for database::Parallel {
+    fn from(value: Parallel) -> Self {
+        database::Parallel(value.0)
+    }
+}
+
+impl fmt::Display for Parallel {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "-Zthreads={}", self.0)
+    }
+}

--- a/collector/src/compile/execute/bencher.rs
+++ b/collector/src/compile/execute/bencher.rs
@@ -27,6 +27,7 @@ pub struct RecordedSelfProfile {
     profile: database::Profile,
     codegen_backend: database::CodegenBackend,
     target: database::Target,
+    parallel: database::Parallel,
     files: SelfProfileFiles,
 }
 
@@ -87,6 +88,7 @@ impl<'a> BenchProcessor<'a> {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn insert_stats(
         &mut self,
         collection: CollectionId,
@@ -95,6 +97,7 @@ impl<'a> BenchProcessor<'a> {
         backend: CodegenBackend,
         target: Target,
         stats: Stats,
+        parallel: database::Parallel,
     ) {
         let mut buf = FuturesUnordered::new();
         for (stat, value) in stats.iter() {
@@ -107,6 +110,7 @@ impl<'a> BenchProcessor<'a> {
                 backend.into(),
                 target.into(),
                 stat,
+                parallel,
                 value,
             ));
         }
@@ -168,6 +172,7 @@ impl Processor for BenchProcessor<'_> {
                             execute::store_documentation_size_into_stats(&mut res.0, &doc_dir);
                         }
                     }
+                    let parallel = database::Parallel(data.parallel.0);
 
                     let scenario = match data.scenario {
                         Scenario::Full => database::Scenario::Empty,
@@ -189,6 +194,7 @@ impl Processor for BenchProcessor<'_> {
                             profile,
                             codegen_backend: data.backend.into(),
                             target: data.target.into(),
+                            parallel,
                             files,
                         });
 
@@ -206,6 +212,7 @@ impl Processor for BenchProcessor<'_> {
                         data.backend,
                         data.target,
                         res.0,
+                        parallel,
                     )
                     .await;
 
@@ -255,6 +262,7 @@ impl Processor for BenchProcessor<'_> {
                         benchmark: self.benchmark.clone(),
                         profile: profile.profile,
                         scenario: profile.scenario,
+                        parallel: profile.parallel,
                         backend: profile.codegen_backend,
                         target: profile.target,
                     };

--- a/collector/src/compile/execute/mod.rs
+++ b/collector/src/compile/execute/mod.rs
@@ -1,6 +1,7 @@
 //! Execute benchmarks.
 
 use crate::compile::benchmark::codegen_backend::CodegenBackend;
+use crate::compile::benchmark::parallel::Parallel;
 use crate::compile::benchmark::patch::Patch;
 use crate::compile::benchmark::profile::Profile;
 use crate::compile::benchmark::scenario::Scenario;
@@ -132,6 +133,7 @@ pub struct CargoProcess<'a> {
     pub touch_file: Option<String>,
     pub jobserver: Option<jobserver::Client>,
     pub target: Target,
+    pub parallel: Parallel,
     pub workspace_package: Option<String>,
 }
 
@@ -358,13 +360,14 @@ impl<'a> CargoProcess<'a> {
     // really.
     pub async fn run_rustc(&mut self, needs_final: bool) -> anyhow::Result<()> {
         log::info!(
-            "run_rustc with incremental={}, profile={:?}, scenario={:?}, patch={:?}, backend={:?}, target={:?}, phase={}",
+            "run_rustc with incremental={}, profile={:?}, scenario={:?}, patch={:?}, backend={:?}, target={:?}, parallel={}, phase={}",
             self.incremental,
             self.profile,
             self.processor_etc.as_ref().map(|v| v.1),
             self.processor_etc.as_ref().and_then(|v| v.3),
             self.backend,
             self.target,
+            self.parallel.0,
             if needs_final { "benchmark" } else { "dependencies" }
         );
 
@@ -406,6 +409,9 @@ impl<'a> CargoProcess<'a> {
 
             let mut cmd = self.base_command(self.cwd, cargo_subcommand);
             cmd.arg("-p").arg(self.get_pkgid(self.cwd)?);
+            if self.parallel.0 != 1 {
+                cmd.env("RUSTC_THREAD_COUNT", self.parallel.0.to_string());
+            }
             match self.profile {
                 Profile::Check => {
                     cmd.arg("--profile").arg("check");
@@ -537,6 +543,7 @@ impl<'a> CargoProcess<'a> {
                     patch,
                     backend: self.backend,
                     target: self.target,
+                    parallel: self.parallel,
                 };
                 match processor.process_output(&data, output).await {
                     Ok(Retry::No) => return Ok(()),
@@ -602,6 +609,7 @@ pub struct ProcessOutputData<'a> {
     patch: Option<&'a Patch>,
     backend: CodegenBackend,
     target: Target,
+    parallel: Parallel,
 }
 
 /// Trait used by `Benchmark::measure()` to provide different kinds of

--- a/collector/src/compile/execute/profiler.rs
+++ b/collector/src/compile/execute/profiler.rs
@@ -131,11 +131,16 @@ impl Processor for ProfileProcessor<'_> {
         Box::pin(async move {
             fs::create_dir_all(self.output_dir)?;
 
-            // Produce a name of the form $PREFIX-$ID-$BENCHMARK-$PROFILE-$SCENARIO.
+            // Produce a name of the form $PREFIX-$ID-$BENCHMARK-$PROFILE-$SCENARIO-$PAR<N>.
             let out_file = |prefix: &str| -> String {
                 format!(
-                    "{}-{}-{}-{:?}-{}",
-                    prefix, self.id, data.name, data.profile, data.scenario_str
+                    "{}-{}-{}-{:?}-{}-{}",
+                    prefix,
+                    self.id,
+                    data.name,
+                    data.profile,
+                    data.scenario_str,
+                    data.parallel.par_n()
                 )
             };
 

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -139,6 +139,15 @@ pub fn version_supports_incremental(version_str: &str) -> bool {
     }
 }
 
+pub fn version_supports_parallel_frontend(version_str: &str) -> bool {
+    if let Ok(version) = version_str.parse::<semver::Version>() {
+        version >= semver::Version::new(1, 33, 0)
+    } else {
+        assert!(version_str.starts_with("beta") || version_str.starts_with("master"));
+        true
+    }
+}
+
 /// Rounds serialized and deserialized floats to 2 decimal places.
 pub mod round_float {
     use serde::{Deserialize, Deserializer, Serializer};

--- a/collector/src/self_profile.rs
+++ b/collector/src/self_profile.rs
@@ -3,7 +3,7 @@ use crate::compile::execute::SelfProfileFiles;
 use analyzeme::ProfilingData;
 use anyhow::Context;
 use database::{
-    ArtifactId, ArtifactIdNumber, CodegenBackend, CollectionId, Profile, Scenario, Target,
+    ArtifactId, ArtifactIdNumber, CodegenBackend, CollectionId, Parallel, Profile, Scenario, Target,
 };
 use reqwest::StatusCode;
 use std::future::Future;
@@ -31,6 +31,7 @@ pub enum SelfProfileId {
         benchmark: BenchmarkName,
         profile: Profile,
         scenario: Scenario,
+        parallel: Parallel,
         backend: CodegenBackend,
         target: Target,
     },
@@ -53,13 +54,14 @@ impl SelfProfileId {
                 .join(profile.to_string())
                 .join(scenario.to_id())
                 .join(format!("self-profile-{collection}.mm_profdata.sz")),
-            //  self-profile/<artifact id>/<benchmark>/<target>/<backend>/<profile>/<scenario>
+            //  self-profile/<artifact id>/<benchmark>/<target>/<backend>/<profile>/<scenario>/<parallel>
             //    /self-profile.mm_profdata.sz
             SelfProfileId::Simple {
                 artifact_id,
                 benchmark,
                 profile,
                 scenario,
+                parallel,
                 backend: codegen_backend,
                 target,
             } => {
@@ -74,6 +76,7 @@ impl SelfProfileId {
                     .join(codegen_backend.to_string())
                     .join(profile.to_string())
                     .join(scenario.to_id())
+                    .join(parallel.par_n())
                     .join("self-profile.mm_profdata.sz")
             }
         }

--- a/database/schema.md
+++ b/database/schema.md
@@ -35,7 +35,8 @@ Here is the diagram for compile-time benchmarks:
   │ scenario      │  │ cid      │   │
   │ backend       │  │ value    ├───┘
   │ metric        │  └──────────┘
-  │ target        │
+  │ target        |
+  │ parallel      │
   └───────────────┘
 ```
 
@@ -101,7 +102,7 @@ Columns:
 ### pstat_series
 
 Describes the parametrization of a compile-time benchmark. Contains a unique combination
-of a crate, profile, scenario and the metric being collected.
+of a crate, profile, scenario, metric and parallel frontend option being collected.
 
 Columns:
 
@@ -110,6 +111,7 @@ Columns:
 * **scenario** (`text`): Describes how much of the incremental cache is full. An empty incremental cache means that the compiler must do a full build.
 * **backend** (`text`): Codegen backend used for compilation, for example 'llvm'
 * **metric** (`text`): the type of metric being collected.
+* **parallel** (`text`): Parallel frontend option ('-Zthreads=N').
 
 This corresponds to a [`statistic description`](../docs/glossary.md).
 

--- a/database/src/bin/import-sqlite.rs
+++ b/database/src/bin/import-sqlite.rs
@@ -45,7 +45,7 @@ async fn main() {
         let sqlite_aid = sqlite_conn.artifact_id(&aid).await;
         let postgres_aid = postgres_conn.artifact_id(&aid).await;
 
-        for (&(benchmark, profile, scenario, backend, target, metric), id) in
+        for (&(benchmark, profile, scenario, backend, target, metric, parallel), id) in
             sqlite_idx.compile_statistic_descriptions()
         {
             if benchmarks.insert(benchmark) {
@@ -76,6 +76,7 @@ async fn main() {
                         backend,
                         target,
                         metric.as_str(),
+                        parallel,
                         stat,
                     )
                     .await;

--- a/database/src/bin/postgres-to-sqlite.rs
+++ b/database/src/bin/postgres-to-sqlite.rs
@@ -189,12 +189,12 @@ impl Table for PstatSeries {
     }
 
     fn postgres_select_statement(&self, _since_weeks_ago: Option<u32>) -> String {
-        "select id, crate, profile, scenario, backend, target, metric from ".to_string()
+        "select id, crate, profile, scenario, backend, target, metric, parallel from ".to_string()
             + self.name()
     }
 
     fn sqlite_insert_statement(&self) -> &'static str {
-        "insert into pstat_series (id, crate, profile, scenario, backend, target, metric) VALUES (?, ?, ?, ?, ?, ?, ?)"
+        "insert into pstat_series (id, crate, profile, scenario, backend, target, metric, parallel) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
     }
 
     fn sqlite_execute_insert(&self, statement: &mut rusqlite::Statement, row: tokio_postgres::Row) {

--- a/database/src/bin/sqlite-to-postgres.rs
+++ b/database/src/bin/sqlite-to-postgres.rs
@@ -243,6 +243,7 @@ struct PstatSeriesRow<'a> {
     backend: &'a str,
     target: &'a str,
     metric: &'a str,
+    parallel: u32,
 }
 
 impl Table for PstatSeries {
@@ -251,11 +252,11 @@ impl Table for PstatSeries {
     }
 
     fn sqlite_attributes() -> &'static str {
-        "id, crate, profile, scenario, backend, target, metric"
+        "id, crate, profile, scenario, backend, target, metric, parallel"
     }
 
     fn postgres_attributes() -> &'static str {
-        "id, crate, profile, scenario, backend, target, metric"
+        "id, crate, profile, scenario, backend, target, metric, parallel"
     }
 
     fn postgres_generated_id_attribute() -> Option<&'static str> {
@@ -272,6 +273,7 @@ impl Table for PstatSeries {
                 backend: row.get_ref(4).unwrap().as_str().unwrap(),
                 target: row.get_ref(5).unwrap().as_str().unwrap(),
                 metric: row.get_ref(6).unwrap().as_str().unwrap(),
+                parallel: row.get(7).unwrap(),
             })
             .unwrap();
     }

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -21,6 +21,32 @@ intern!(pub struct Metric);
 intern!(pub struct Benchmark);
 intern!(pub struct TargetName);
 
+#[derive(Serialize, Deserialize, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub struct Parallel(pub u32);
+
+impl Parallel {
+    pub fn par_n(self) -> String {
+        format!("par{}", self.0)
+    }
+    // Default parallel frontend options
+    pub fn default_opts() -> Vec<Parallel> {
+        vec![Parallel(1), Parallel(4)]
+    }
+    pub fn single(self) -> bool {
+        self.0 == 1
+    }
+}
+
+impl std::str::FromStr for Parallel {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let v: u32 = s
+            .parse()
+            .map_err(|e: std::num::ParseIntError| e.to_string())?;
+        Ok(Self(v))
+    }
+}
+
 pub fn intern_target_name(target: &str) -> TargetName {
     intern(target)
 }
@@ -562,7 +588,15 @@ pub struct Index {
     artifacts: Indexed<Box<str>>,
     /// Id lookup of compile stat description ids
     /// For legacy reasons called `pstat_series` in the database, and so the name is kept here.
-    pstat_series: Indexed<(Benchmark, Profile, Scenario, CodegenBackend, Target, Metric)>,
+    pstat_series: Indexed<(
+        Benchmark,
+        Profile,
+        Scenario,
+        CodegenBackend,
+        Target,
+        Metric,
+        Parallel,
+    )>,
     /// Id lookup of runtime stat description ids
     runtime_pstat_series: Indexed<(Benchmark, Target, Metric)>,
 }
@@ -685,6 +719,7 @@ pub enum DbLabel {
         backend: CodegenBackend,
         target: Target,
         metric: Metric,
+        parallel: Parallel,
     },
 }
 
@@ -704,9 +739,10 @@ impl Lookup for DbLabel {
                 backend,
                 metric,
                 target,
-            } => index
-                .pstat_series
-                .get(&(*benchmark, *profile, *scenario, *backend, *target, *metric)),
+                parallel,
+            } => index.pstat_series.get(&(
+                *benchmark, *profile, *scenario, *backend, *target, *metric, *parallel,
+            )),
         }
     }
 }
@@ -722,6 +758,15 @@ impl Lookup for ArtifactId {
 }
 
 pub type StatisticalDescriptionId = u32;
+pub type CompileStatisticDescription = (
+    Benchmark,
+    Profile,
+    Scenario,
+    CodegenBackend,
+    Target,
+    Metric,
+    Parallel,
+);
 
 impl Index {
     pub async fn load(conn: &mut dyn pool::Connection) -> Index {
@@ -754,7 +799,7 @@ impl Index {
         self.pstat_series
             .map
             .keys()
-            .map(|(_, _, _, _, _, metric)| metric)
+            .map(|(_, _, _, _, _, metric, _)| metric)
             .collect::<std::collections::HashSet<_>>()
             .into_iter()
             .map(|s| s.to_string())
@@ -777,7 +822,7 @@ impl Index {
         self.pstat_series
             .map
             .keys()
-            .map(|(_, _, _, _, target, _)| target)
+            .map(|(_, _, _, _, target, _, _)| target)
             .collect::<std::collections::HashSet<_>>()
             .into_iter()
             .cloned()
@@ -790,12 +835,7 @@ impl Index {
     // for it as keeping indices around would be annoying.
     pub fn compile_statistic_descriptions(
         &self,
-    ) -> impl Iterator<
-        Item = (
-            &(Benchmark, Profile, Scenario, CodegenBackend, Target, Metric),
-            StatisticalDescriptionId,
-        ),
-    > + '_ {
+    ) -> impl Iterator<Item = (&CompileStatisticDescription, StatisticalDescriptionId)> + '_ {
         self.pstat_series
             .map
             .iter()

--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -5,7 +5,7 @@ use crate::{
     BenchmarkRequestWithErrors, BenchmarkSet, CodegenBackend, CollectorConfig, CompileBenchmark,
     PendingBenchmarkRequests, Target,
 };
-use crate::{CollectionId, Index, Profile, Scenario};
+use crate::{CollectionId, Index, Parallel, Profile, Scenario};
 use chrono::{DateTime, Utc};
 use hashbrown::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
@@ -59,6 +59,7 @@ pub trait Connection: Send + Sync {
         backend: CodegenBackend,
         target: Target,
         metric: &str,
+        parallel: Parallel,
         value: f64,
     );
     async fn record_runtime_statistic(
@@ -743,6 +744,7 @@ mod tests {
                 CodegenBackend::Llvm,
                 Target::X86_64UnknownLinuxGnu,
                 Metric::CacheMisses.as_str(),
+                Parallel(1),
                 1.0,
             )
             .await;
@@ -755,6 +757,7 @@ mod tests {
                     benchmark: "benchmark".into(),
                     profile: Profile::Check,
                     scenario: Scenario::IncrementalFresh,
+                    parallel: Parallel(1),
                     backend: CodegenBackend::Llvm,
                     target: Target::X86_64UnknownLinuxGnu,
                 }])

--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -7,8 +7,8 @@ use crate::{
     BenchmarkJobKind, BenchmarkJobStatus, BenchmarkRequest, BenchmarkRequestIndex,
     BenchmarkRequestInsertResult, BenchmarkRequestStatus, BenchmarkRequestType,
     BenchmarkRequestWithErrors, BenchmarkSet, CodegenBackend, CollectionId, CollectorConfig,
-    Commit, CommitType, CompileBenchmark, Date, Index, PendingBenchmarkRequests, Profile, Scenario,
-    Target, BENCHMARK_JOB_STATUS_FAILURE_STR, BENCHMARK_JOB_STATUS_IN_PROGRESS_STR,
+    Commit, CommitType, CompileBenchmark, Date, Index, Parallel, PendingBenchmarkRequests, Profile,
+    Scenario, Target, BENCHMARK_JOB_STATUS_FAILURE_STR, BENCHMARK_JOB_STATUS_IN_PROGRESS_STR,
     BENCHMARK_JOB_STATUS_QUEUED_STR, BENCHMARK_JOB_STATUS_SUCCESS_STR,
     BENCHMARK_REQUEST_MASTER_STR, BENCHMARK_REQUEST_RELEASE_STR,
     BENCHMARK_REQUEST_STATUS_ARTIFACTS_READY_STR, BENCHMARK_REQUEST_STATUS_COMPLETED_STR,
@@ -441,6 +441,12 @@ static MIGRATIONS: &[&str] = &[
     "#,
     r#"ALTER TABLE job_queue ADD COLUMN is_optional BOOLEAN NOT NULL DEFAULT FALSE"#,
     r#"ALTER TABLE benchmark_request ADD COLUMN targets TEXT NOT NULL DEFAULT ''"#,
+    // Add parallel to pstat_series
+    r#"
+    alter table pstat_series add parallel int not null default 1;
+    alter table pstat_series drop constraint test_case;
+    alter table pstat_series add constraint test_case UNIQUE(crate, profile, scenario, backend, target, metric, parallel);
+    "#,
 ];
 
 #[async_trait::async_trait]
@@ -633,8 +639,8 @@ impl PostgresConnection {
                     .await
                     .unwrap(),
                 get_error: conn.prepare("select context, message from error where aid = $1").await.unwrap(),
-                insert_pstat_series: conn.prepare("insert into pstat_series (crate, profile, scenario, backend, target, metric) VALUES ($1, $2, $3, $4, $5, $6) ON CONFLICT DO NOTHING RETURNING id").await.unwrap(),
-                select_pstat_series: conn.prepare("select id from pstat_series where crate = $1 and profile = $2 and scenario = $3 and backend = $4 and target = $5 and metric = $6").await.unwrap(),
+                insert_pstat_series: conn.prepare("insert into pstat_series (crate, profile, scenario, backend, target, metric, parallel) VALUES ($1, $2, $3, $4, $5, $6, $7) ON CONFLICT DO NOTHING RETURNING id").await.unwrap(),
+                select_pstat_series: conn.prepare("select id from pstat_series where crate = $1 and profile = $2 and scenario = $3 and backend = $4 and target = $5 and metric = $6 and parallel = $7").await.unwrap(),
                 collection_id: conn.prepare("insert into collection (perf_commit) VALUES ($1) returning id").await.unwrap(),
                 get_benchmarks: conn.prepare("
                     select name, category
@@ -686,7 +692,7 @@ impl PostgresConnection {
                     WHERE tag IS NOT NULL
                 ").await.unwrap(),
                 get_compile_test_cases_with_measurements: conn.prepare("
-                    SELECT DISTINCT crate, profile, scenario, backend, target
+                    SELECT DISTINCT crate, profile, scenario, backend, target, parallel
                     FROM pstat_series
                     WHERE id IN (
                         SELECT DISTINCT series
@@ -885,7 +891,7 @@ where
             pstat_series: self
                 .conn()
                 .query(
-                    "select id, crate, profile, scenario, backend, target, metric from pstat_series;",
+                    "select id, crate, profile, scenario, backend, target, metric, parallel from pstat_series;",
                     &[],
                 )
                 .await
@@ -901,6 +907,7 @@ where
                             CodegenBackend::from_str(row.get::<_, String>(4).as_str()).unwrap(),
                             Target::from_str(row.get::<_, String>(5).as_str()).unwrap(),
                             row.get::<_, String>(6).as_str().into(),
+                            Parallel(row.get::<_, i32>(7) as u32),
                         ),
                     )
                 })
@@ -1021,17 +1028,21 @@ where
         backend: CodegenBackend,
         target: Target,
         metric: &str,
+        parallel: Parallel,
         stat: f64,
     ) {
         let profile = profile.to_string();
         let scenario = scenario.to_string();
         let backend = backend.to_string();
         let target = target.to_string();
+        let parallel = parallel.0 as i32;
         let sid = self
             .conn()
             .query_opt(
                 &self.statements().select_pstat_series,
-                &[&benchmark, &profile, &scenario, &backend, &target, &metric],
+                &[
+                    &benchmark, &profile, &scenario, &backend, &target, &metric, &parallel,
+                ],
             )
             .await
             .unwrap();
@@ -1041,14 +1052,18 @@ where
                 self.conn()
                     .query_opt(
                         &self.statements().insert_pstat_series,
-                        &[&benchmark, &profile, &scenario, &backend, &target, &metric],
+                        &[
+                            &benchmark, &profile, &scenario, &backend, &target, &metric, &parallel,
+                        ],
                     )
                     .await
                     .unwrap();
                 self.conn()
                     .query_one(
                         &self.statements().select_pstat_series,
-                        &[&benchmark, &profile, &scenario, &backend, &target, &metric],
+                        &[
+                            &benchmark, &profile, &scenario, &backend, &target, &metric, &parallel,
+                        ],
                     )
                     .await
                     .unwrap()
@@ -1625,6 +1640,7 @@ where
                 scenario: row.get::<_, &str>(2).parse().unwrap(),
                 backend: CodegenBackend::from_str(row.get::<_, &str>(3)).unwrap(),
                 target: Target::from_str(row.get::<_, &str>(4)).unwrap(),
+                parallel: Parallel(row.get::<_, i32>(5) as u32),
             })
             .collect())
     }

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -6,7 +6,8 @@ use crate::{
     ArtifactId, Benchmark, BenchmarkJob, BenchmarkJobConclusion, BenchmarkJobKind,
     BenchmarkRequest, BenchmarkRequestIndex, BenchmarkRequestInsertResult, BenchmarkRequestStatus,
     BenchmarkRequestWithErrors, BenchmarkSet, CodegenBackend, CollectionId, CollectorConfig,
-    Commit, CommitType, CompileBenchmark, Date, PendingBenchmarkRequests, Profile, Target,
+    Commit, CommitType, CompileBenchmark, Date, Parallel, PendingBenchmarkRequests, Profile,
+    Target,
 };
 use crate::{ArtifactIdNumber, Index};
 use chrono::{DateTime, TimeZone, Utc};
@@ -448,6 +449,25 @@ static MIGRATIONS: &[Migration] = &[
         ALTER TABLE runtime_pstat_series_with_target RENAME TO runtime_pstat_series;
     "#,
     ),
+    // Add parallel as an unique constraint, defaulting to '1'
+    Migration::without_foreign_key_constraints(
+        r#"
+        create table pstat_series_with_parallel(
+            id integer primary key not null,
+            crate text not null references benchmark(name) on delete cascade on update cascade,
+            profile text not null,
+            scenario text not null,
+            backend text not null,
+            target text not null default 'x86_64-unknown-linux-gnu',
+            metric text not null,
+            parallel integer not null default 1,
+            UNIQUE(crate, profile, scenario, backend, target, metric, parallel)
+        );
+        insert into pstat_series_with_parallel select id, crate, profile, scenario, backend, 'x86_64-unknown-linux-gnu', metric, 1 from pstat_series;
+        drop table pstat_series;
+        alter table pstat_series_with_parallel rename to pstat_series;
+    "#,
+    ),
 ];
 
 #[async_trait::async_trait]
@@ -575,7 +595,7 @@ impl Connection for SqliteConnection {
         let pstat_series = self
             .raw()
             .prepare(
-                "select id, crate, profile, scenario, backend, target, metric from pstat_series;",
+                "select id, crate, profile, scenario, backend, target, metric, parallel from pstat_series;",
             )
             .unwrap()
             .query_map(params![], |row| {
@@ -588,6 +608,7 @@ impl Connection for SqliteConnection {
                         CodegenBackend::from_str(row.get::<_, String>(4)?.as_str()).unwrap(),
                         Target::from_str(row.get::<_, String>(5)?.as_str()).unwrap(),
                         row.get::<_, String>(6)?.as_str().into(),
+                        Parallel(row.get::<_, i32>(7)? as u32),
                     ),
                 ))
             })
@@ -724,27 +745,30 @@ impl Connection for SqliteConnection {
         backend: CodegenBackend,
         target: Target,
         metric: &str,
+        parallel: Parallel,
         value: f64,
     ) {
         let profile = profile.to_string();
         let scenario = scenario.to_string();
         let backend = backend.to_string();
         let target = target.to_string();
-        self.raw_ref().execute("insert or ignore into pstat_series (crate, profile, scenario, backend, target, metric) VALUES (?, ?, ?, ?, ?, ?)", params![
+        self.raw_ref().execute("insert or ignore into pstat_series (crate, profile, scenario, backend, target, metric, parallel) VALUES (?, ?, ?, ?, ?, ?, ?)", params![
             &benchmark,
             &profile,
             &scenario,
             &backend,
             &target,
             &metric,
+            &parallel.0,
         ]).unwrap();
-        let sid: i32 = self.raw_ref().query_row("select id from pstat_series where crate = ? and profile = ? and scenario = ? and backend = ? and target = ? and metric = ?", params![
+        let sid: i32 = self.raw_ref().query_row("select id from pstat_series where crate = ? and profile = ? and scenario = ? and backend = ? and target = ? and metric = ? and parallel = ?", params![
             &benchmark,
             &profile,
             &scenario,
             &backend,
             &target,
             &metric,
+            &parallel.0,
         ], |r| r.get(0)).unwrap();
         self.raw_ref()
             .execute(
@@ -1082,7 +1106,7 @@ impl Connection for SqliteConnection {
         Ok(self
             .raw_ref()
             .prepare_cached(
-                "SELECT DISTINCT crate, profile, scenario, backend, target
+                "SELECT DISTINCT crate, profile, scenario, backend, target, parallel
                 FROM pstat_series
                 WHERE id IN (
                     SELECT DISTINCT series
@@ -1097,6 +1121,7 @@ impl Connection for SqliteConnection {
                     scenario: row.get::<_, String>(2)?.parse().unwrap(),
                     backend: row.get::<_, String>(3)?.parse().unwrap(),
                     target: row.get::<_, String>(4)?.parse().unwrap(),
+                    parallel: Parallel(row.get::<_, i32>(5)? as u32),
                 })
             })?
             .collect::<Result<_, _>>()?)

--- a/database/src/selector.rs
+++ b/database/src/selector.rs
@@ -29,7 +29,7 @@ use std::{
 
 use crate::{
     interpolate::Interpolate, metric::Metric, ArtifactId, ArtifactIdIter, Benchmark,
-    CodegenBackend, Connection, Index, Lookup, Profile, Scenario, Target,
+    CodegenBackend, Connection, Index, Lookup, Parallel, Profile, Scenario, Target,
 };
 
 #[derive(Debug)]
@@ -193,6 +193,7 @@ pub struct CompileBenchmarkQuery {
     profile: Selector<Profile>,
     backend: Selector<CodegenBackend>,
     metric: Selector<crate::Metric>,
+    parallel: Selector<Parallel>,
     target: Selector<Target>,
 }
 
@@ -217,6 +218,11 @@ impl CompileBenchmarkQuery {
         self
     }
 
+    pub fn parallel(mut self, selector: Selector<Parallel>) -> Self {
+        self.parallel = selector;
+        self
+    }
+
     pub fn target(mut self, selector: Selector<Target>) -> Self {
         self.target = selector;
         self
@@ -233,6 +239,7 @@ impl CompileBenchmarkQuery {
             profile: Selector::All,
             scenario: Selector::All,
             backend: Selector::All,
+            parallel: Selector::All,
             metric: Selector::One(metric.as_str().into()),
             target: Selector::All,
         }
@@ -246,6 +253,7 @@ impl Default for CompileBenchmarkQuery {
             scenario: Selector::All,
             profile: Selector::All,
             backend: Selector::All,
+            parallel: Selector::All,
             metric: Selector::All,
             target: Selector::All,
         }
@@ -263,21 +271,23 @@ impl BenchmarkQuery for CompileBenchmarkQuery {
     ) -> Result<Vec<SeriesResponse<Self::TestCase, StatisticSeries>>, String> {
         let mut statistic_descriptions: Vec<_> = index
             .compile_statistic_descriptions()
-            .filter(|(&(b, p, s, backend, target, metric), _)| {
+            .filter(|(&(b, p, s, backend, target, metric, parallel), _)| {
                 self.benchmark.matches(b)
                     && self.profile.matches(p)
                     && self.scenario.matches(s)
                     && self.backend.matches(backend)
                     && self.target.matches(target)
                     && self.metric.matches(metric)
+                    && self.parallel.matches(parallel)
             })
             .map(
-                |(&(benchmark, profile, scenario, backend, target, metric), sid)| {
+                |(&(benchmark, profile, scenario, backend, target, metric, parallel), sid)| {
                     (
                         CompileTestCase {
                             benchmark,
                             profile,
                             scenario,
+                            parallel,
                             backend,
                             target,
                         },
@@ -334,6 +344,7 @@ pub struct CompileTestCase {
     pub benchmark: Benchmark,
     pub profile: Profile,
     pub scenario: Scenario,
+    pub parallel: Parallel,
     pub backend: CodegenBackend,
     pub target: Target,
 }

--- a/site/frontend/src/components/perfetto-link.vue
+++ b/site/frontend/src/components/perfetto-link.vue
@@ -15,6 +15,7 @@ const link = computed(() => {
     props.artifact.commit,
     `${props.testCase.benchmark}`,
     props.testCase.scenario,
+    props.testCase.parallel.toString(),
     props.testCase.profile.toLowerCase(),
     props.testCase.backend,
     props.testCase.target

--- a/site/frontend/src/graph/api.ts
+++ b/site/frontend/src/graph/api.ts
@@ -12,9 +12,19 @@ export async function loadGraphs(
     stat: selector.stat,
     benchmark: selector.benchmark,
     scenario: selector.scenario,
+    parallel: selector.parallel,
     profile: selector.profile,
     backend: selector.backend,
     target: selector.target,
   };
-  return await getJson<CompileGraphData>(GRAPH_DATA_URL, params);
+  const dict: Dict<string> = Object.entries(params).reduce(
+    (acc, [key, value]) => {
+      if (value !== null && value !== undefined) {
+        acc[key] = value;
+      }
+      return acc;
+    },
+    {} as Dict<string>
+  );
+  return await getJson<CompileGraphData>(GRAPH_DATA_URL, dict);
 }

--- a/site/frontend/src/graph/data.ts
+++ b/site/frontend/src/graph/data.ts
@@ -8,6 +8,7 @@ export interface GraphsSelector {
   stat: string;
   benchmark: string | null;
   scenario: string | null;
+  parallel: string | null;
   profile: string | null;
   backend: string | null;
   target: string | null;
@@ -21,8 +22,8 @@ export interface Series {
 // Graph data received from the server
 export interface CompileGraphData {
   commits: Array<[number, string]>;
-  // benchmark -> profile -> scenario -> series
-  benchmarks: Dict<Dict<Dict<Series>>>;
+  // benchmark -> profile -> parallel -> scenario -> series
+  benchmarks: Dict<Dict<Dict<Dict<Series>>>>;
 }
 
 export interface RuntimeGraphData {

--- a/site/frontend/src/graph/render.ts
+++ b/site/frontend/src/graph/render.ts
@@ -376,10 +376,14 @@ function genPlotOpts({
 
 function normalizeData(data: CompileGraphData) {
   function optInterpolated(profile) {
-    for (const scenario in profile) {
-      profile[scenario].interpolated_indices = new Set(
-        profile[scenario].interpolated_indices
-      );
+    for (const parallel in profile) {
+      let par = profile[parallel];
+      for (const scenario in par) {
+        par[scenario].interpolated_indices = new Set(
+          par[scenario].interpolated_indices
+        );
+      }
+      profile[parallel] = par;
     }
 
     return profile;
@@ -430,10 +434,7 @@ export function renderPlots(
     let i = 0;
 
     for (let profile in profiles) {
-      let scenarios = profiles[profile];
-      let scenarioNames = Object.keys(scenarios);
-      scenarioNames.sort();
-
+      let parallels = profiles[profile];
       let yAxis = selector.stat;
       let yAxisUnit = null;
 
@@ -486,23 +487,33 @@ export function renderPlots(
       let plotData = [xVals];
 
       let otherColorIdx = 0;
+      let indices = null;
 
-      for (let scenarioName of scenarioNames) {
-        let yVals = scenarios[scenarioName].points;
-        let color =
-          commonCacheStateColors[scenarioName] ||
-          otherCacheStateColors[otherColorIdx++];
+      for (let parallel in parallels) {
+        let scenarios = parallels[parallel];
+        let scenarioNames = Object.keys(scenarios);
+        scenarioNames.sort();
 
-        plotData.push(yVals);
+        for (let scenarioName of scenarioNames) {
+          let yVals = scenarios[scenarioName].points;
+          if (indices === null) {
+            indices = scenarios[scenarioName].interpolated_indices;
+          }
+          let color =
+            parallel == "1"
+              ? commonCacheStateColors[scenarioName] ||
+                otherCacheStateColors[otherColorIdx++]
+              : otherCacheStateColors[otherColorIdx++];
 
-        seriesOpts.push({
-          label: scenarioName,
-          width: devicePixelRatio,
-          stroke: color,
-        });
+          plotData.push(yVals);
+
+          seriesOpts.push({
+            label: scenarioName + "_par" + parallel,
+            width: devicePixelRatio,
+            stroke: color,
+          });
+        }
       }
-
-      let indices = scenarios[Object.keys(scenarios)[0]].interpolated_indices;
 
       let plotOpts = genPlotOpts({
         width,

--- a/site/frontend/src/pages/bootstrap/data-selector.vue
+++ b/site/frontend/src/pages/bootstrap/data-selector.vue
@@ -16,13 +16,13 @@ const startRef = ref<HTMLInputElement | null>(null);
 const endRef = ref<HTMLInputElement | null>(null);
 
 onMounted(() => {
-  startRef.value.value = props.start;
-  endRef.value.value = props.end;
+  if (startRef.value) startRef.value.value = props.start;
+  if (endRef.value) endRef.value.value = props.end;
 });
 
 function submitSettings() {
-  const start = startRef.value.value;
-  const end = endRef.value.value;
+  const start = startRef.value?.value ?? "";
+  const end = endRef.value?.value ?? "";
 
   const params = {start, end};
   emit("change", params);

--- a/site/frontend/src/pages/compare/compile/aggregations.vue
+++ b/site/frontend/src/pages/compare/compile/aggregations.vue
@@ -89,6 +89,18 @@ const totalAfter = computed(() =>
             </div>
           </div>
           <div class="aggregation-section">
+            <div class="header">Parallel</div>
+            <div class="groups">
+              <div class="group" v-for="parallel in ['1', '4']">
+                <div class="group-header">par{{ parallel }}</div>
+                <SummaryTable
+                  :summary="calculateSummary('parallel', parallel)"
+                  :withLegend="false"
+                ></SummaryTable>
+              </div>
+            </div>
+          </div>
+          <div class="aggregation-section">
             <div class="header">Category</div>
             <div class="groups">
               <div class="group" v-for="category in ['primary', 'secondary']">

--- a/site/frontend/src/pages/compare/compile/benchmarks.vue
+++ b/site/frontend/src/pages/compare/compile/benchmarks.vue
@@ -1,5 +1,5 @@
 <script setup lang="tsx">
-import {computed, h} from "vue";
+import {computed} from "vue";
 import ComparisonsTable from "./table/comparisons-table.vue";
 import {TestCaseComparison} from "../data";
 import {CompareResponse} from "../types";

--- a/site/frontend/src/pages/compare/compile/common.ts
+++ b/site/frontend/src/pages/compare/compile/common.ts
@@ -16,6 +16,10 @@ export type CompileBenchmarkFilter = {
     incrUnchanged: boolean;
     incrPatched: boolean;
   };
+  parallel: {
+    par1: boolean;
+    par4: boolean;
+  };
   backend: {
     llvm: boolean;
     cranelift: boolean;
@@ -51,6 +55,10 @@ export const defaultCompileFilter: CompileBenchmarkFilter = {
     incrFull: true,
     incrUnchanged: true,
     incrPatched: true,
+  },
+  parallel: {
+    par1: true,
+    par4: true,
   },
   backend: {
     llvm: true,
@@ -98,6 +106,7 @@ export interface CompileBenchmarkComparison {
   benchmark: string;
   profile: Profile;
   scenario: string;
+  parallel: number;
   backend: CodegenBackend;
   target: Target;
   comparison: StatComparison;
@@ -107,6 +116,7 @@ export interface CompileTestCase {
   benchmark: string;
   profile: Profile;
   scenario: string;
+  parallel: string;
   backend: CodegenBackend;
   target: Target;
   category: Category;
@@ -146,6 +156,17 @@ export function computeCompileComparisonsWithNonRelevant(
     }
   }
 
+  function parallelFilter(parallel: string): boolean {
+    if (parallel === "1") {
+      return filter.parallel.par1;
+    } else if (parallel === "4") {
+      return filter.parallel.par4;
+    } else {
+      // Unknown, but by default we should show things
+      return true;
+    }
+  }
+
   function backendFilter(backend: string): boolean {
     if (backend === "llvm") {
       return filter.backend.llvm;
@@ -158,7 +179,8 @@ export function computeCompileComparisonsWithNonRelevant(
   }
 
   function artifactFilter(metadata: CompileBenchmarkMetadata | null): boolean {
-    if (metadata?.binary === null) return true;
+    // Loose equality to prevent metadata.binary null access later
+    if (metadata?.binary == null) return true;
 
     const isBinary = metadata.binary;
     const isLibrary = !isBinary;
@@ -188,6 +210,7 @@ export function computeCompileComparisonsWithNonRelevant(
     return (
       profileFilter(comparison.testCase.profile) &&
       scenarioFilter(comparison.testCase.scenario) &&
+      parallelFilter(comparison.testCase.parallel) &&
       backendFilter(comparison.testCase.backend) &&
       targetMatchesFilter(comparison.testCase.target, filter.target) &&
       categoryFilter(comparison.testCase.category) &&
@@ -204,6 +227,7 @@ export function computeCompileComparisonsWithNonRelevant(
           benchmark: c.benchmark,
           profile: c.profile,
           scenario: c.scenario,
+          parallel: c.parallel.toString(),
           backend: c.backend,
           target: c.target,
           category: (benchmarkMap[c.benchmark] || {}).category || "secondary",
@@ -227,7 +251,7 @@ export function computeCompileComparisonsWithNonRelevant(
 export function createCompileBenchmarkMap(
   data: CompareResponse
 ): CompileBenchmarkMap {
-  const benchmarks = {};
+  const benchmarks: CompileBenchmarkMap = {};
   for (const benchmark of data.compile_benchmark_metadata) {
     benchmarks[benchmark.name] = {...benchmark};
   }
@@ -235,7 +259,7 @@ export function createCompileBenchmarkMap(
 }
 
 export function testCaseKey(testCase: CompileTestCase): string {
-  return `${testCase.benchmark};${testCase.profile};${testCase.scenario};${testCase.backend};${testCase.category}`;
+  return `${testCase.benchmark};${testCase.profile};${testCase.scenario};${testCase.parallel};${testCase.backend};${testCase.category}`;
 }
 
 // Transform compile comparisons to compare LLVM vs Cranelift, instead of
@@ -252,10 +276,11 @@ export function transformDataForBackendComparison(
       profile: Profile;
       target: Target;
       scenario: string;
+      parallel: number;
     }
   > = new Map();
   for (const comparison of comparisons) {
-    const key = `${comparison.benchmark};${comparison.profile};${comparison.scenario};${comparison.target}`;
+    const key = `${comparison.benchmark};${comparison.profile};${comparison.scenario};${comparison.parallel};${comparison.target}`;
     if (!benchmarkMap.has(key)) {
       benchmarkMap.set(key, {
         llvm: null,
@@ -263,10 +288,11 @@ export function transformDataForBackendComparison(
         benchmark: comparison.benchmark,
         profile: comparison.profile,
         scenario: comparison.scenario,
+        parallel: comparison.parallel,
         target: comparison.target,
       });
     }
-    const record = benchmarkMap.get(key);
+    const record = benchmarkMap.get(key)!;
     if (comparison.backend === "llvm") {
       record.llvm = comparison.comparison.statistics[0];
     } else if (comparison.backend === "cranelift") {
@@ -279,11 +305,12 @@ export function transformDataForBackendComparison(
       benchmark: entry.benchmark,
       profile: entry.profile,
       scenario: entry.scenario,
+      parallel: entry.parallel,
       // Treat LLVM as the baseline
       backend: "llvm",
       target: entry.target,
       comparison: {
-        statistics: [entry.llvm, entry.cranelift],
+        statistics: [entry.llvm ?? 0, entry.cranelift ?? 0],
         is_relevant: true,
         significance_factor: 1.0,
         significance_threshold: 1.0,

--- a/site/frontend/src/pages/compare/compile/compile-page.vue
+++ b/site/frontend/src/pages/compare/compile/compile-page.vue
@@ -86,6 +86,10 @@ function loadFilterFromUrl(
         defaultFilter.scenario.incrPatched
       ),
     },
+    parallel: {
+      par1: getBoolOrDefault(urlParams, "par1", defaultFilter.parallel.par1),
+      par4: getBoolOrDefault(urlParams, "par4", defaultFilter.parallel.par4),
+    },
     backend: {
       llvm: getBoolOrDefault(
         urlParams,
@@ -212,6 +216,18 @@ function storeFilterToUrl(
     "incrPatched",
     filter.scenario.incrPatched,
     defaultFilter.scenario.incrPatched
+  );
+  storeOrResetBool(
+    urlParams,
+    "par1",
+    filter.parallel.par1,
+    defaultFilter.parallel.par1
+  );
+  storeOrResetBool(
+    urlParams,
+    "par4",
+    filter.parallel.par4,
+    defaultFilter.parallel.par4
   );
   storeOrResetBool(
     urlParams,

--- a/site/frontend/src/pages/compare/compile/export.ts
+++ b/site/frontend/src/pages/compare/compile/export.ts
@@ -10,6 +10,7 @@ export function exportToMarkdown(
       "Benchmark",
       "Profile",
       "Scenario",
+      "Parallel",
       "% Change",
       "Significance Factor",
     ];
@@ -32,6 +33,7 @@ export function exportToMarkdown(
         comparison.testCase.benchmark,
         comparison.testCase.profile,
         comparison.testCase.scenario,
+        comparison.testCase.parallel.toString(),
         `${comparison.percent.toFixed(2)}%`,
         `${comparison.significanceFactor.toFixed(2)}x`,
       ];

--- a/site/frontend/src/pages/compare/compile/filters.vue
+++ b/site/frontend/src/pages/compare/compile/filters.vue
@@ -194,6 +194,40 @@ const opened = createPersistedRef(PREF_FILTERS_OPENED);
           <div class="section section-list-wrapper">
             <div class="section-heading">
               <div style="width: 160px">
+                <span>Parallels</span>
+                <Tooltip
+                  >The different parallel frontend options (-Zthreads=N).
+                </Tooltip>
+              </div>
+            </div>
+            <ul class="states-list">
+              <li>
+                <label>
+                  <input
+                    type="checkbox"
+                    id="build-par1"
+                    v-model="filter.parallel.par1"
+                  />
+                  <span class="label">par1</span>
+                </label>
+                <Tooltip>Single-threaded rustc frontend. </Tooltip>
+              </li>
+              <li>
+                <label>
+                  <input
+                    type="checkbox"
+                    id="build-par4"
+                    v-model="filter.parallel.par4"
+                  />
+                  <span class="label">par4</span>
+                </label>
+                <Tooltip>Parallel rustc frontend with 4 threads. </Tooltip>
+              </li>
+            </ul>
+          </div>
+          <div class="section section-list-wrapper">
+            <div class="section-heading">
+              <div style="width: 160px">
                 <span>Backends</span>
                 <Tooltip
                   >The different codegen backends used to generate executable

--- a/site/frontend/src/pages/compare/compile/table/benchmark-detail-graph.vue
+++ b/site/frontend/src/pages/compare/compile/table/benchmark-detail-graph.vue
@@ -38,6 +38,7 @@ function createGraphsSelector(): CompileDetailGraphsSelector {
     benchmark: props.testCase.benchmark,
     profile: props.testCase.profile,
     scenario: props.testCase.scenario,
+    parallel: props.testCase.parallel.toString(),
     backend: props.testCase.backend,
     stat: props.metric,
     start,
@@ -66,7 +67,9 @@ async function renderGraphs(detail: CompileDetailGraphs) {
           // The server returns profiles capitalized, so we need to match that
           // here, so that the graph code can find the expected profile.
           [capitalize(selector.profile)]: {
-            [selector.scenario]: detail.graphs[index],
+            [selector.parallel]: {
+              [selector.scenario]: detail.graphs[index],
+            },
           },
         },
       },
@@ -75,6 +78,7 @@ async function renderGraphs(detail: CompileDetailGraphs) {
       benchmark: selector.benchmark,
       profile: selector.profile,
       scenario: selector.scenario,
+      parallel: selector.parallel,
       stat: selector.stat,
       start: selector.start,
       end: selector.end,
@@ -122,6 +126,9 @@ async function renderGraph(
   date: Date | null,
   chartRef: Ref<HTMLElement | null>
 ) {
+  if (chartRef.value === null) {
+    return;
+  }
   const opts: GraphRenderOpts = {
     width: Math.min(window.innerWidth - 40, 465),
     height: 300,
@@ -192,15 +199,15 @@ function getGraphRange(
   // If this is a try commit, we don't know its future, so always we just display
   // the last `DAY_RANGE` days.
   if (artifact.type === "try") {
-    const date = new Date(artifact.date);
+    let date = artifact.date ? new Date(artifact.date) : new Date();
     return {
       start: formatDate(getPastDate(date, DAY_RANGE)),
       end: artifact.commit,
       date: null,
     };
   } else {
-    let [start_date, end_date] = [baseArtifact, artifact].map(
-      (c) => new Date(c.date)
+    let [start_date, end_date] = [baseArtifact, artifact].map((c) =>
+      c.date ? new Date(c.date) : new Date()
     );
     // If this is a master commit, we attempt to display more than the full history for commit
     // ranges. If the commit range is not larger than the `dayRange`, the display will likely be

--- a/site/frontend/src/pages/compare/compile/table/benchmark-detail.vue
+++ b/site/frontend/src/pages/compare/compile/table/benchmark-detail.vue
@@ -35,6 +35,7 @@ function createSectionsSelector(): CompileDetailSectionsSelector {
     benchmark: props.testCase.benchmark,
     profile: props.testCase.profile,
     scenario: props.testCase.scenario,
+    parallel: props.testCase.parallel.toString(),
     backend: props.testCase.backend,
     target: props.testCase.target,
     start: props.baseArtifact.commit,
@@ -54,8 +55,9 @@ function detailedQueryLink(
   commit: ArtifactDescription,
   baseCommit?: ArtifactDescription
 ): string {
-  const {benchmark, profile, scenario, backend, target} = props.testCase;
-  let link = `/detailed-query.html?commit=${commit.commit}&benchmark=${benchmark}-${profile}&scenario=${scenario}&backend=${backend}&target=${target}`;
+  const {benchmark, profile, scenario, parallel, backend, target} =
+    props.testCase;
+  let link = `/detailed-query.html?commit=${commit.commit}&benchmark=${benchmark}-${profile}&scenario=${scenario}&parallel=${parallel}&backend=${backend}&target=${target}`;
   if (baseCommit !== undefined) {
     link += `&base_commit=${baseCommit.commit}`;
   }
@@ -68,17 +70,19 @@ function graphLink(
   testCase: CompileTestCase
 ): string {
   // Move to `30 days ago` to display history of the test case
-  const start = formatDate(getPastDate(new Date(commit.date), 30));
+  const start = formatDate(
+    getPastDate(commit.date ? new Date(commit.date) : new Date(), 30)
+  );
   const end = commit.commit;
-  const {benchmark, profile, scenario, target, backend} = testCase;
-  return `/index.html?start=${start}&end=${end}&benchmark=${benchmark}&profile=${profile}&scenario=${scenario}&target=${target}&backend=${backend}&stat=${metric}`;
+  const {benchmark, profile, scenario, parallel, target, backend} = testCase;
+  return `/index.html?start=${start}&end=${end}&benchmark=${benchmark}&profile=${profile}&scenario=${scenario}&parallel=${parallel}&target=${target}&backend=${backend}&stat=${metric}`;
 }
 
 const metadata = computed(
   (): CompileBenchmarkMetadata =>
     props.benchmarkMap[props.testCase.benchmark] ?? null
 );
-const cargoProfile = computed((): CargoProfileMetadata => {
+const cargoProfile = computed((): CargoProfileMetadata | undefined => {
   if (
     props.testCase.profile === "opt" &&
     metadata?.value.release_profile !== null
@@ -120,6 +124,10 @@ onMounted(() => {
               <td>{{ testCase.scenario }}</td>
             </tr>
             <tr>
+              <td>Parallel</td>
+              <td>{{ testCase.parallel }}</td>
+            </tr>
+            <tr>
               <td>Category</td>
               <td>{{ testCase.category }}</td>
             </tr>
@@ -136,15 +144,15 @@ onMounted(() => {
             </tr>
             <tr v-if="(cargoProfile?.lto ?? null) !== null">
               <td>LTO</td>
-              <td>{{ cargoProfile.lto }}</td>
+              <td>{{ cargoProfile?.lto }}</td>
             </tr>
             <tr v-if="(cargoProfile?.debug ?? null) !== null">
               <td>Debuginfo</td>
-              <td>{{ cargoProfile.debug }}</td>
+              <td>{{ cargoProfile?.debug }}</td>
             </tr>
             <tr v-if="(cargoProfile?.codegen_units ?? null) !== null">
               <td>Codegen units</td>
-              <td>{{ cargoProfile.codegen_units }}</td>
+              <td>{{ cargoProfile?.codegen_units }}</td>
             </tr>
           </tbody>
         </table>
@@ -224,8 +232,8 @@ onMounted(() => {
               (sectionsDetail?.before ?? null) !== null &&
               (sectionsDetail?.after ?? null) !== null
             "
-            :before="sectionsDetail.before"
-            :after="sectionsDetail.after"
+            :before="sectionsDetail?.before"
+            :after="sectionsDetail?.after"
           />
           <span v-else-if="sectionsDetail === null">Loading…</span>
           <span v-else>Not available</span>

--- a/site/frontend/src/pages/compare/compile/table/comparisons-table.vue
+++ b/site/frontend/src/pages/compare/compile/table/comparisons-table.vue
@@ -27,7 +27,7 @@ function prettifyRawNumber(number: number): string {
 
 // Modify this when changing the number of columns in the table!
 const columnCount = computed(() => {
-  const base = 8;
+  const base = 9;
   if (props.showRawData) {
     return base + 2;
   }
@@ -61,6 +61,7 @@ const unit = computed(() => {
           <th>Benchmark</th>
           <th>Profile</th>
           <th>Scenario</th>
+          <th>Parallel</th>
           <th v-if="showBackend">Backend</th>
           <th>Target</th>
           <th>% Change</th>
@@ -101,6 +102,7 @@ const unit = computed(() => {
                 {{ comparison.testCase.profile }}
               </td>
               <td>{{ comparison.testCase.scenario }}</td>
+              <td>{{ comparison.testCase.parallel }}</td>
               <td v-if="showBackend">{{ comparison.testCase.backend }}</td>
               <td :title="comparison.testCase.target">
                 {{ formatTarget(comparison.testCase.target) }}

--- a/site/frontend/src/pages/compare/compile/table/detail-resolver.ts
+++ b/site/frontend/src/pages/compare/compile/table/detail-resolver.ts
@@ -12,6 +12,7 @@ export interface CompileDetailGraphsSelector {
   stat: string;
   benchmark: string;
   scenario: string;
+  parallel: string;
   profile: string;
   backend: string;
   target: string;
@@ -32,6 +33,7 @@ export interface CompileDetailSectionsSelector {
   end: string;
   benchmark: string;
   scenario: string;
+  parallel: string;
   profile: string;
   backend: string;
   target: string;
@@ -66,7 +68,7 @@ export const COMPILE_DETAIL_GRAPHS_RESOLVER: CachedDataLoader<
   CompileDetailGraphs
 > = new CachedDataLoader(
   (key: CompileDetailGraphsSelector) =>
-    `${key.benchmark};${key.profile};${key.scenario};${key.backend};${key.start};${key.end};${key.stat};${key.kinds};${key.target}`,
+    `${key.benchmark};${key.profile};${key.scenario};${key.parallel};${key.backend};${key.start};${key.end};${key.stat};${key.kinds};${key.target}`,
   loadGraphsDetail
 );
 
@@ -79,6 +81,7 @@ async function loadGraphsDetail(
     stat: selector.stat,
     benchmark: selector.benchmark,
     scenario: selector.scenario,
+    parallel: selector.parallel,
     profile: selector.profile,
     backend: selector.backend,
     target: selector.target,
@@ -96,7 +99,7 @@ export const COMPILE_DETAIL_SECTIONS_RESOLVER: CachedDataLoader<
   CompileDetailSections
 > = new CachedDataLoader(
   (key: CompileDetailSectionsSelector) =>
-    `${key.benchmark};${key.profile};${key.scenario};${key.backend};${key.target};${key.start};${key.end}`,
+    `${key.benchmark};${key.profile};${key.scenario};${key.parallel};${key.backend};${key.target};${key.start};${key.end}`,
   loadSectionsDetail
 );
 
@@ -108,6 +111,7 @@ async function loadSectionsDetail(
     end: selector.end,
     benchmark: selector.benchmark,
     scenario: selector.scenario,
+    parallel: selector.parallel,
     profile: selector.profile,
     backend: selector.backend,
     target: selector.target,

--- a/site/frontend/src/pages/compare/compile/table/shortcuts/cachegrind-cmd.vue
+++ b/site/frontend/src/pages/compare/compile/table/shortcuts/cachegrind-cmd.vue
@@ -4,7 +4,7 @@
  **/
 
 import {CompileTestCase} from "../../common";
-import {computed} from "vue";
+import {computed, ref} from "vue";
 import {normalizeProfile} from "./utils";
 import {cargo_collector_command} from "../../../../../utils/cargo";
 
@@ -34,16 +34,39 @@ function normalizeScenario(scenario: string): string {
   }
   return "<invalid scenario>";
 }
+
+const codeBlock = ref<HTMLElement | null>(null);
+const buttonText = ref("Copy");
+
+const copyCode = async () => {
+  if (codeBlock.value) {
+    const textToCopy = codeBlock.value.innerText;
+    try {
+      await navigator.clipboard.writeText(textToCopy);
+      buttonText.value = "Copied!";
+      setTimeout(() => {
+        buttonText.value = "Copy";
+      }, 2000);
+    } catch (err) {
+      console.error("Copy error:", err);
+      buttonText.value = "Error";
+    }
+  }
+};
 </script>
 
 <template>
-  <pre><code>{{ cargo_collector_command() }} \
+  <button style="margin-left: 10px" @click="copyCode">
+    {{ buttonText }}
+  </button>
+  <pre><code ref="codeBlock">{{ cargo_collector_command() }} \
     profile_local cachegrind \
     +{{ firstCommit }} \<template v-if="props.baselineCommit !== undefined">
     --rustc2 +{{ props.commit }} \</template>
     --exact-match {{ testCase.benchmark }} \
     --profiles {{ normalizeProfile(testCase.profile) }} \
-    --scenarios {{ normalizeScenario(testCase.scenario) }}</code></pre>
+    --scenarios {{ normalizeScenario(testCase.scenario) }} \
+    --parallels {{ testCase.parallel }}</code></pre>
 </template>
 
 <style scoped lang="scss">

--- a/site/frontend/src/pages/compare/runtime/benchmark-detail-graph.vue
+++ b/site/frontend/src/pages/compare/runtime/benchmark-detail-graph.vue
@@ -66,6 +66,7 @@ async function renderGraphs(detail: RuntimeDetailGraphs) {
       end: selector.end,
       profile: null,
       scenario: null,
+      parallel: null,
       target: selector.target,
       backend: null,
       kind,
@@ -110,6 +111,9 @@ async function renderGraph(
   date: Date | null,
   chartRef: Ref<HTMLElement | null>
 ) {
+  if (chartRef.value === null) {
+    return;
+  }
   const opts: GraphRenderOpts = {
     width: Math.min(window.innerWidth - 40, 465),
     height: 300,
@@ -181,15 +185,15 @@ function getGraphRange(
   // If this is a try commit, we don't know its future, so always we just display
   // the last `DAY_RANGE` days.
   if (artifact.type === "try") {
-    const date = new Date(artifact.date);
+    const date = artifact.date ? new Date(artifact.date) : new Date();
     return {
       start: formatDate(getPastDate(date, DAY_RANGE)),
       end: artifact.commit,
       date: null,
     };
   } else {
-    let [start_date, end_date] = [baseArtifact, artifact].map(
-      (c) => new Date(c.date)
+    let [start_date, end_date] = [baseArtifact, artifact].map((c) =>
+      c.date ? new Date(c.date) : new Date()
     );
     // If this is a master commit, we attempt to display more than the full history for commit
     // ranges. If the commit range is not larger than the `dayRange`, the display will likely be

--- a/site/frontend/src/pages/compare/shared.ts
+++ b/site/frontend/src/pages/compare/shared.ts
@@ -2,7 +2,7 @@ import {Target} from "./compile/common";
 
 export function formatDate(dateString: string): string {
   const date = new Date(dateString);
-  function padStr(i) {
+  function padStr(i: number) {
     return i < 10 ? "0" + i : "" + i;
   }
   return `${date.getUTCFullYear()}-${padStr(date.getUTCMonth() + 1)}-${padStr(
@@ -62,7 +62,7 @@ export function formatPercentChange(
   if (!isValidValue(before) || !isValidValue(after)) {
     return invalidPlaceholder;
   }
-  return `${(((after - before) / before) * 100).toFixed(3)}%`;
+  return `${(((after! - before!) / before!) * 100).toFixed(3)}%`;
 }
 
 // Checks if the value is not undefined and not zero
@@ -116,13 +116,13 @@ export function targetMatchesFilter(
 
 // Store the bool value into URL parameters, or reset it if it has the default
 // value.
-export function storeOrResetBool<T extends boolean | string>(
+export function storeOrResetBool<T extends boolean | string | null>(
   urlParams: Dict<string>,
   name: string,
   value: T,
   defaultValue: T
 ) {
-  if (value === defaultValue) {
+  if (value === defaultValue || value === null) {
     if (urlParams.hasOwnProperty(name)) {
       delete urlParams[name];
     }

--- a/site/frontend/src/pages/compare/tabs.vue
+++ b/site/frontend/src/pages/compare/tabs.vue
@@ -1,5 +1,5 @@
 <script setup lang="tsx">
-import {h, ref, Ref} from "vue";
+import {ref, Ref} from "vue";
 import {CompareResponse, Tab} from "./types";
 import {
   diffClass,

--- a/site/frontend/src/pages/detailed-query/page.vue
+++ b/site/frontend/src/pages/detailed-query/page.vue
@@ -1,5 +1,5 @@
 <script setup lang="tsx">
-import {h, ref, Ref, computed} from "vue";
+import {ref, Ref, computed} from "vue";
 import {getUrlParams, changeUrl} from "../../utils/navigation";
 import {postMsgpack} from "../../utils/requests";
 import {SELF_PROFILE_DATA_URL} from "../../urls";
@@ -15,7 +15,14 @@ import {
   TableRowData,
 } from "./utils";
 
-const loading = ref(true);
+enum Status {
+  Loading = "LOADING",
+  Ready = "READY",
+  Failed = "FAILED",
+}
+
+const status = ref<Status>(Status.Loading);
+const errorMsg = ref("");
 const data: Ref<SelfProfileResponse | null> = ref(null);
 const selector: Ref<Selector | null> = ref(null);
 const showIncr = ref(true);
@@ -189,7 +196,8 @@ function storeSortToUrl() {
 
 async function loadData() {
   const params = getUrlParams();
-  const {commit, base_commit, benchmark, scenario, backend, target} = params;
+  const {commit, base_commit, benchmark, scenario, parallel, backend, target} =
+    params;
 
   // Load sort state from URL
   loadSortFromUrl(params);
@@ -206,19 +214,29 @@ async function loadData() {
     base_commit: base_commit ?? null,
     benchmark: benchmarkSeparate,
     scenario,
+    parallel,
     profile,
     backend,
     target,
   };
   selector.value = currentSelector;
-
-  const response = await postMsgpack<SelfProfileResponse>(
-    SELF_PROFILE_DATA_URL,
-    currentSelector
-  );
-  data.value = response;
-  populateUIData(response, currentSelector);
-  loading.value = false;
+  try {
+    const response = await postMsgpack<SelfProfileResponse>(
+      SELF_PROFILE_DATA_URL,
+      currentSelector,
+      false
+    );
+    data.value = response;
+    populateUIData(response, currentSelector);
+    status.value = Status.Ready;
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      errorMsg.value = error.message;
+    } else {
+      errorMsg.value = String(error);
+    }
+    status.value = Status.Failed;
+  }
 }
 
 function populateUIData(responseData: SelfProfileResponse, state: Selector) {
@@ -298,12 +316,16 @@ function DeltaComponent({delta}: {delta: DeltaData | null}) {
 }
 
 loadData();
+const LoadingStatus = Status;
 </script>
 
 <template>
   <div>
-    <div v-if="loading">
+    <div v-if="status === LoadingStatus.Loading">
       <p>Loading...</p>
+    </div>
+    <div v-else-if="status === LoadingStatus.Failed">
+      <p>{{ errorMsg }}</p>
     </div>
     <div v-else id="content">
       <h3 id="title">

--- a/site/frontend/src/pages/detailed-query/utils.ts
+++ b/site/frontend/src/pages/detailed-query/utils.ts
@@ -10,6 +10,7 @@ export interface Selector {
   benchmark: string;
   profile: string;
   scenario: string;
+  parallel: string;
   backend: string;
   target: string;
 }
@@ -81,6 +82,7 @@ export function perfettoProfilerData(
   commit: string,
   benchmark: string,
   scenario: string,
+  parallel: string,
   profile: string,
   backend: string,
   target: string
@@ -89,11 +91,12 @@ export function perfettoProfilerData(
     commit,
     benchmark,
     scenario,
+    parallel,
     profile,
     backend,
     target
   );
-  const traceTitle = `${benchmark}-${scenario} (${commit})`;
+  const traceTitle = `${benchmark}-${scenario}-par${parallel} (${commit})`;
   return {link, traceTitle};
 }
 
@@ -113,7 +116,7 @@ export function createTitleData(selector: Selector | null): {
   let selfHref = "";
 
   if (state.base_commit) {
-    const args = `&scenario=${state.scenario}&benchmark=${state.benchmark}-${state.profile}&backend=${state.backend}&target=${state.target}`;
+    const args = `&scenario=${state.scenario}&parallel=${state.parallel}&benchmark=${state.benchmark}-${state.profile}&backend=${state.backend}&target=${state.target}`;
     selfHref = `/detailed-query.html?commit=${state.commit}${args}`;
     baseHref = `/detailed-query.html?commit=${state.base_commit}${args}`;
   }
@@ -178,11 +181,12 @@ export function createDownloadLinksData(selector: Selector | null): {
       : "???";
 
   const createLinks = (commit: string) => ({
-    raw: `/perf/download-raw-self-profile?commit=${commit}&benchmark=${state.benchmark}&profile=${state.profile}&scenario=${state.scenario}&backend=${state.backend}&target=${state.target}`,
+    raw: `/perf/download-raw-self-profile?commit=${commit}&benchmark=${state.benchmark}&profile=${state.profile}&scenario=${state.scenario}&parallel=${state.parallel}&backend=${state.backend}&target=${state.target}`,
     flamegraph: processedSelfProfileRelativeUrl(
       commit,
       state.benchmark,
       state.scenario,
+      state.parallel.toString(),
       state.profile,
       state.backend,
       state.target,
@@ -192,6 +196,7 @@ export function createDownloadLinksData(selector: Selector | null): {
       commit,
       state.benchmark,
       state.scenario,
+      state.parallel.toString(),
       state.profile,
       state.backend,
       state.target,
@@ -201,6 +206,7 @@ export function createDownloadLinksData(selector: Selector | null): {
       commit,
       state.benchmark,
       state.scenario,
+      state.parallel.toString(),
       state.profile,
       state.backend,
       state.target,
@@ -210,6 +216,7 @@ export function createDownloadLinksData(selector: Selector | null): {
       commit,
       state.benchmark,
       state.scenario,
+      state.parallel.toString(),
       state.profile,
       state.backend,
       state.target
@@ -219,6 +226,7 @@ export function createDownloadLinksData(selector: Selector | null): {
         commit,
         state.benchmark,
         state.scenario,
+        state.parallel.toString(),
         state.profile,
         state.backend,
         state.target
@@ -230,7 +238,7 @@ export function createDownloadLinksData(selector: Selector | null): {
   const newLinks = createLinks(state.commit);
 
   const diffLink = state.base_commit
-    ? `/perf/processed-self-profile?commit=${state.commit}&base_commit=${state.base_commit}&benchmark=${state.benchmark}&profile=${state.profile}&scenario=${state.scenario}&backend=${state.backend}&target=${state.target}&type=codegen-schedule`
+    ? `/perf/processed-self-profile?commit=${state.commit}&base_commit=${state.base_commit}&benchmark=${state.benchmark}&profile=${state.profile}&scenario=${state.scenario}&parallel=${state.parallel}&backend=${state.backend}&target=${state.target}&type=codegen-schedule`
     : "";
 
   function cachegrindCommand(
@@ -246,6 +254,7 @@ export function createDownloadLinksData(selector: Selector | null): {
     cmd += ` --exact-match ${state.benchmark}`;
     cmd += ` --profiles ${profile(state.profile)}`;
     cmd += ` --scenarios ${scenarioFilter(state.scenario)}`;
+    cmd += ` --parallels ${state.parallel}`;
     return cmd;
   }
 

--- a/site/frontend/src/pages/graphs/page.vue
+++ b/site/frontend/src/pages/graphs/page.vue
@@ -19,6 +19,7 @@ function loadSelectorFromUrl(urlParams: Dict<string>): GraphsSelector {
   const stat = urlParams["stat"] ?? "instructions:u";
   const benchmark = urlParams["benchmark"] ?? null;
   const scenario = urlParams["scenario"] ?? null;
+  const parallel = urlParams["parallel"] ?? null;
   const profile = urlParams["profile"] ?? null;
   const target = urlParams["target"] ?? null;
   const backend = urlParams["backend"] ?? null;
@@ -29,6 +30,7 @@ function loadSelectorFromUrl(urlParams: Dict<string>): GraphsSelector {
     stat,
     benchmark,
     scenario,
+    parallel,
     profile,
     backend,
     target,
@@ -50,14 +52,15 @@ function filterBenchmarks(
 
 /*
  * Returns true if a specific subset of charts is selected by benchmark
- * name, profile or scenario. In that case, the regular aligned grid of charts
+ * name, profile, scenario or parallel. In that case, the regular aligned grid of charts
  * will not be shown.
  */
 function hasSpecificSelection(selector: GraphsSelector): boolean {
   return (
     selector.benchmark !== null ||
     selector.profile !== null ||
-    selector.scenario !== null
+    selector.scenario !== null ||
+    selector.parallel !== null
   );
 }
 
@@ -75,6 +78,9 @@ async function loadGraphData(selector: GraphsSelector, loading: Ref<boolean>) {
     .map((benchmark) => Object.keys(graphData.benchmarks[benchmark]).length)
     .reduce((sum, item) => sum + item, 0);
 
+  if (wrapperRef.value == null) {
+    return;
+  }
   const parentWidth = wrapperRef.value.clientWidth;
   let columns = countGraphs === 1 ? 1 : 4;
 
@@ -98,7 +104,10 @@ async function loadGraphData(selector: GraphsSelector, loading: Ref<boolean>) {
 
   // If we select a smaller subset of benchmarks, then just show them.
   if (hasSpecificSelection(selector)) {
-    renderPlots(graphData, selector, document.getElementById("charts"), opts);
+    let plotElem = document.getElementById("charts");
+    if (plotElem) {
+      renderPlots(graphData, selector, plotElem, opts);
+    }
   } else {
     // If we select all of them, we expect that there will be a regular grid.
 
@@ -109,7 +118,10 @@ async function loadGraphData(selector: GraphsSelector, loading: Ref<boolean>) {
       graphData,
       (benchName) => !benchName.endsWith("-tiny")
     );
-    renderPlots(withoutTiny, selector, document.getElementById("charts"), opts);
+    let plotElem = document.getElementById("charts");
+    if (plotElem) {
+      renderPlots(withoutTiny, selector, plotElem, opts);
+    }
 
     // Then, render only the size-related ones in their own dedicated section as they are less
     // important than having the better grouping. So, we only include the benchmarks ending in
@@ -117,12 +129,10 @@ async function loadGraphData(selector: GraphsSelector, loading: Ref<boolean>) {
     const onlyTiny = filterBenchmarks(graphData, (benchName) =>
       benchName.endsWith("-tiny")
     );
-    renderPlots(
-      onlyTiny,
-      selector,
-      document.getElementById("size-charts"),
-      opts
-    );
+    let sizeCharts = document.getElementById("size-charts");
+    if (sizeCharts) {
+      renderPlots(onlyTiny, selector, sizeCharts, opts);
+    }
   }
 }
 
@@ -141,7 +151,7 @@ function updateSelection(params: SelectionParams) {
 const info: BenchmarkInfo = await loadBenchmarkInfo();
 
 const loading = ref(true);
-const wrapperRef = ref(null);
+const wrapperRef = ref<HTMLDivElement | null>(null);
 
 const selector: GraphsSelector = loadSelectorFromUrl(getUrlParams());
 
@@ -155,7 +165,7 @@ loadGraphData(selector, loading);
     :kind="selector.kind"
     :stat="selector.stat"
     :info="info"
-    :target="selector.target"
+    :target="selector.target ?? ''"
     @change="updateSelection"
   ></DataSelector>
   <div>

--- a/site/frontend/src/pages/status/collector.vue
+++ b/site/frontend/src/pages/status/collector.vue
@@ -1,5 +1,5 @@
 <script setup lang="tsx">
-import {h, ref, Ref} from "vue";
+import {ref, Ref} from "vue";
 import {
   parseISO,
   differenceInHours,
@@ -40,7 +40,8 @@ const ACTIVE_FILTERS: Ref<Record<BenchmarkJobStatus, boolean>> = ref({
 const showJobs: Ref<boolean> = ref(true);
 
 function filterJobByStatus(status: string) {
-  ACTIVE_FILTERS.value[status] = !ACTIVE_FILTERS.value[status];
+  let stat = status as BenchmarkJobStatus;
+  ACTIVE_FILTERS.value[stat] = !ACTIVE_FILTERS.value[stat];
 }
 
 function formatJobStatus(status: BenchmarkJobStatus): string {
@@ -117,8 +118,8 @@ function formatProfile(job: BenchmarkJob): string {
     return "";
   }
 }
-function timeSince(timestamp: string): string {
-  const date = parseDateIsoStringOrNull(timestamp);
+function timeSince(timestamp: string | null): string {
+  const date = parseDateIsoStringOrNull(timestamp ?? undefined);
   if (date === null) {
     return "";
   }
@@ -130,7 +131,7 @@ function timeSince(timestamp: string): string {
 // Takes a date like `2025-09-10T08:22:47.161348Z` and shows just the time
 // portion (`08:22:47`).
 function formatTime(dateString: string | null): string {
-  const date = parseDateIsoStringOrNull(dateString);
+  const date = parseDateIsoStringOrNull(dateString ?? undefined);
   if (date === null) {
     return "";
   }
@@ -141,9 +142,9 @@ function jobDuration(job: BenchmarkJob): string {
   if (!isJobComplete(job)) {
     return "";
   }
-  const start = parseDateIsoStringOrNull(job.startedAt);
-  const end = parseDateIsoStringOrNull(job.completedAt);
-  const diff = differenceInSeconds(end, start);
+  const start = parseDateIsoStringOrNull(job.startedAt ?? undefined);
+  const end = parseDateIsoStringOrNull(job.completedAt ?? undefined);
+  const diff = start && end ? differenceInSeconds(end, start) : 0;
   return `Job took ${formatSecondsAsDuration(diff)}`;
 }
 

--- a/site/frontend/src/pages/status/page.vue
+++ b/site/frontend/src/pages/status/page.vue
@@ -1,5 +1,5 @@
 <script setup lang="tsx">
-import {h, ref, Ref} from "vue";
+import {ref, Ref} from "vue";
 import {differenceInSeconds} from "date-fns";
 
 import {getJson} from "../../utils/requests";
@@ -192,13 +192,11 @@ function RequestProgress({
   } else if (request.status === "Queued") {
     return "";
   } else {
-    return (
-      <progress
-        title={`${completed} out of ${jobs.length} job(s) completed`}
+    return `<progress
+        title={'${completed} out of ${jobs.length} job(s) completed'}
         max={jobs.length}
         value={completed}
-      ></progress>
-    );
+      ></progress>`;
   }
 }
 

--- a/site/frontend/src/self-profile.ts
+++ b/site/frontend/src/self-profile.ts
@@ -4,6 +4,7 @@ export function chromeProfileUrl(
   commit: string,
   benchmark: string,
   scenario: string,
+  parallel: string,
   profile: string,
   backend: string,
   target: string
@@ -12,6 +13,7 @@ export function chromeProfileUrl(
     commit,
     benchmark,
     scenario,
+    parallel,
     profile,
     backend,
     target,
@@ -24,10 +26,11 @@ export function processedSelfProfileRelativeUrl(
   commit: string,
   benchmark: string,
   scenario: string,
+  parallel: string,
   profile: string,
   backend: string,
   target: string,
   type: string
 ): string {
-  return `/perf/processed-self-profile?commit=${commit}&benchmark=${benchmark}&profile=${profile}&scenario=${scenario}&backend=${backend}&target=${target}&type=${type}`;
+  return `/perf/processed-self-profile?commit=${commit}&benchmark=${benchmark}&profile=${profile}&scenario=${scenario}&parallel=${parallel}&backend=${backend}&target=${target}&type=${type}`;
 }

--- a/site/frontend/src/utils/requests.ts
+++ b/site/frontend/src/utils/requests.ts
@@ -69,7 +69,11 @@ export async function getJson<T>(
   return json as T;
 }
 
-export async function postMsgpack<T>(path: string, body: any): Promise<T> {
+export async function postMsgpack<T>(
+  path: string,
+  body: any,
+  doAlert: boolean = true
+): Promise<T> {
   const response = await fetch(path, {
     method: "POST",
     body: JSON.stringify(body),
@@ -80,7 +84,9 @@ export async function postMsgpack<T>(path: string, body: any): Promise<T> {
     return decode(new Uint8Array(buffer));
   } else {
     const text = await response.text();
-    alert(text);
+    if (doAlert) {
+      alert(text);
+    }
     throw new Error(`Invalid response from server: ${text}`);
   }
 }

--- a/site/frontend/tsconfig.json
+++ b/site/frontend/tsconfig.json
@@ -8,6 +8,7 @@
     "esModuleInterop": true,
     "jsx": "preserve",
     "jsxFactory": "h",
+    "jsxImportSource": "vue",
     "noUnusedLocals": true,
     "noUnusedParameters": true
   }

--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -93,6 +93,7 @@ pub mod graph {
         pub benchmark: String,
         pub profile: String,
         pub scenario: String,
+        pub parallel: String,
         pub metric: String,
         pub start: Bound,
         pub end: Bound,
@@ -118,6 +119,7 @@ pub mod graphs {
         pub kind: GraphKind,
         pub benchmark: Option<String>,
         pub scenario: Option<String>,
+        pub parallel: Option<String>,
         pub profile: Option<String>,
         pub backend: Option<String>,
         pub target: Option<String>,
@@ -142,11 +144,15 @@ pub mod graphs {
         pub interpolated_indices: HashSet<u16>,
     }
 
+    pub type ParallelSeries = HashMap<String, Series>;
+    pub type ScenarioSeries = HashMap<String, ParallelSeries>;
+    pub type ProfileSeries = HashMap<database::Profile, ScenarioSeries>;
+
     #[derive(Debug, PartialEq, Clone, Serialize)]
     pub struct Response {
         // (UTC timestamp in seconds, sha)
         pub commits: Vec<(i64, String)>,
-        pub benchmarks: HashMap<String, HashMap<database::Profile, HashMap<String, Series>>>,
+        pub benchmarks: HashMap<String, ProfileSeries>,
     }
 }
 
@@ -163,6 +169,7 @@ pub mod detail_graphs {
         pub stat: String,
         pub benchmark: String,
         pub scenario: String,
+        pub parallel: String,
         pub profile: String,
         pub backend: String,
         pub target: String,
@@ -187,6 +194,7 @@ pub mod detail_sections {
         pub end: Bound,
         pub benchmark: String,
         pub scenario: String,
+        pub parallel: String,
         pub profile: String,
         pub backend: String,
         pub target: String,
@@ -342,6 +350,7 @@ pub mod comparison {
         pub benchmark: String,
         pub profile: String,
         pub scenario: String,
+        pub parallel: String,
         pub backend: String,
         pub target: String,
         pub comparison: StatComparison,
@@ -456,6 +465,7 @@ pub mod self_profile_raw {
         pub profile: String,
         #[serde(alias = "run_name")]
         pub scenario: String,
+        pub parallel: String,
         pub backend: String,
         pub target: String,
     }
@@ -479,6 +489,7 @@ pub mod self_profile_processed {
         pub benchmark: String,
         #[serde(alias = "run_name")]
         pub scenario: String,
+        pub parallel: String,
         pub profile: String,
         pub backend: String,
         pub target: String,
@@ -501,6 +512,7 @@ pub mod self_profile {
         pub profile: String,
         #[serde(alias = "run_name")]
         pub scenario: String,
+        pub parallel: String,
         // These fields are kept optional for backwards compatibility
         // They can be made required in Q3 2026
         #[serde(default)]

--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -13,7 +13,7 @@ use database::{
     selector::{self, BenchmarkQuery, CompileBenchmarkQuery, RuntimeBenchmarkQuery, TestCase},
     Target,
 };
-use database::{ArtifactId, Benchmark, Lookup, Profile, Scenario};
+use database::{ArtifactId, Benchmark, Lookup, Parallel, Profile, Scenario};
 use serde::Serialize;
 
 use crate::api::comparison::CompileBenchmarkMetadata;
@@ -152,6 +152,7 @@ pub async fn handle_compare(
             benchmark: comparison.benchmark.to_string(),
             profile: comparison.profile.to_string(),
             scenario: comparison.scenario.to_string(),
+            parallel: comparison.parallel.0.to_string(),
             backend: comparison.backend.to_string(),
             target: comparison.target.to_string(),
             comparison: comparison.comparison.into(),
@@ -743,6 +744,7 @@ async fn compare_given_commits(
         |test_case, comparison| CompileTestResultComparison {
             profile: test_case.profile,
             scenario: test_case.scenario,
+            parallel: test_case.parallel,
             benchmark: test_case.benchmark,
             backend: test_case.backend,
             target: test_case.target,
@@ -1319,6 +1321,7 @@ pub struct CompileTestResultComparison {
     benchmark: Benchmark,
     profile: Profile,
     scenario: Scenario,
+    parallel: Parallel,
     backend: CodegenBackend,
     target: Target,
     comparison: TestResultComparison,
@@ -1335,6 +1338,7 @@ impl cmp::PartialEq for CompileTestResultComparison {
         self.benchmark == other.benchmark
             && self.profile == other.profile
             && self.scenario == other.scenario
+            && self.parallel == other.parallel
             && self.backend == other.backend
     }
 }
@@ -1346,6 +1350,7 @@ impl std::hash::Hash for CompileTestResultComparison {
         self.benchmark.hash(state);
         self.profile.hash(state);
         self.scenario.hash(state);
+        self.parallel.hash(state);
         self.backend.hash(state);
     }
 }

--- a/site/src/request_handlers/graph.rs
+++ b/site/src/request_handlers/graph.rs
@@ -14,7 +14,7 @@ use database::interpolate::IsInterpolated;
 use database::selector::{
     CompileBenchmarkQuery, CompileTestCase, RuntimeBenchmarkQuery, Selector, SeriesResponse,
 };
-use database::{self, ArtifactId, CodegenBackend, Profile, Scenario, Target};
+use database::{self, ArtifactId, CodegenBackend, Parallel, Profile, Scenario, Target};
 
 /// Returns data for before/after graphs when comparing a single test result comparison
 /// for a compile-time benchmark.
@@ -39,7 +39,8 @@ pub async fn handle_compile_detail_graphs(
                 .scenario(Selector::One(scenario))
                 .backend(Selector::One(request.backend.parse()?))
                 .target(Selector::One(request.target.parse()?))
-                .metric(Selector::One(request.stat.parse()?)),
+                .metric(Selector::One(request.stat.parse()?))
+                .parallel(Selector::One(request.parallel.parse()?)),
             artifact_ids.clone(),
         )
         .await?
@@ -86,16 +87,19 @@ pub async fn handle_compile_detail_sections(
         ))?;
 
     let scenario: Scenario = request.scenario.parse()?;
+    let parallel: Parallel = request.parallel.parse()?;
     let profile: Profile = request.profile.parse()?;
     let backend: CodegenBackend = request.backend.parse()?;
     let target: Target = request.target.parse()?;
 
+    #[allow(clippy::too_many_arguments)]
     async fn calculate_sections(
         ctxt: &SiteCtxt,
         aid: ArtifactId,
         benchmark: &str,
         profile: Profile,
         scenario: Scenario,
+        parallel: Parallel,
         backend: CodegenBackend,
         target: Target,
     ) -> Option<CompilationSections> {
@@ -104,6 +108,7 @@ pub async fn handle_compile_detail_sections(
             benchmark: benchmark.into(),
             profile,
             scenario,
+            parallel,
             backend,
             target,
         };
@@ -129,6 +134,7 @@ pub async fn handle_compile_detail_sections(
                 &request.benchmark,
                 profile,
                 scenario,
+                parallel,
                 backend,
                 target
             ),
@@ -138,6 +144,7 @@ pub async fn handle_compile_detail_sections(
                 &request.benchmark,
                 profile,
                 scenario,
+                parallel,
                 backend,
                 target
             )
@@ -205,6 +212,7 @@ pub async fn handle_graphs(
             kind: graphs::GraphKind::Raw,
             benchmark: None,
             scenario: None,
+            parallel: None,
             profile: None,
             backend: None,
             target: None,
@@ -248,6 +256,10 @@ async fn create_graphs(
         .unwrap();
     let profile_selector = create_selector(&request.profile)
         .unwrap_or_else(|| Ok(Selector::Subset(Profile::default_profiles())))?;
+    let parallel_selector = request
+        .parallel
+        .map(|v| Selector::One(v.parse::<Parallel>().unwrap()))
+        .unwrap_or_else(|| Selector::Subset(Parallel::default_opts()));
     let scenario_selector = create_selector(&request.scenario).unwrap_or(Ok(Selector::All))?;
     let target_selector = create_selector(&request.target)
         .unwrap_or(Ok(Selector::One(Target::X86_64UnknownLinuxGnu)))?;
@@ -259,6 +271,7 @@ async fn create_graphs(
             CompileBenchmarkQuery::default()
                 .benchmark(benchmark_selector)
                 .profile(profile_selector)
+                .parallel(parallel_selector)
                 .scenario(scenario_selector)
                 .backend(backend_selector)
                 .target(target_selector)
@@ -285,12 +298,15 @@ async fn create_graphs(
         let benchmark = response.test_case.benchmark.to_string();
         let profile = response.test_case.profile;
         let scenario = response.test_case.scenario.to_string();
+        let parallel = response.test_case.parallel;
         let graph_series = graph_series(response.series.into_iter(), request.kind);
 
         benchmarks
             .entry(benchmark)
             .or_insert_with(HashMap::new)
             .entry(profile)
+            .or_insert_with(HashMap::new)
+            .entry(format!("{}", parallel.0))
             .or_insert_with(HashMap::new)
             .insert(scenario, graph_series);
     }
@@ -332,15 +348,16 @@ fn create_summary(
     >],
     graph_kind: GraphKind,
     profile: Option<Profile>,
-) -> ServerResult<HashMap<Profile, HashMap<String, graphs::Series>>> {
+) -> ServerResult<HashMap<Profile, HashMap<String, HashMap<String, graphs::Series>>>> {
     let mut baselines = HashMap::new();
     let mut summary_benchmark = HashMap::new();
     let summary_query_cases = iproduct!(
         ctxt.summary_scenarios(),
-        profile.map_or_else(Profile::default_profiles, |p| vec![p])
+        profile.map_or_else(Profile::default_profiles, |p| vec![p]),
+        Parallel::default_opts()
     );
-    for (scenario, profile) in summary_query_cases {
-        let baseline = match baselines.entry((profile, scenario)) {
+    for (scenario, profile, parallel) in summary_query_cases {
+        let baseline = match baselines.entry((profile, scenario, parallel)) {
             std::collections::hash_map::Entry::Occupied(o) => *o.get(),
             std::collections::hash_map::Entry::Vacant(v) => {
                 let baseline_responses = interpolated_responses
@@ -348,7 +365,8 @@ fn create_summary(
                     .filter(|sr| {
                         let p = sr.test_case.profile;
                         let s = sr.test_case.scenario;
-                        p == profile && s == Scenario::Empty
+                        let par = sr.test_case.parallel;
+                        p == profile && s == Scenario::Empty && par.single()
                     })
                     .map(|sr| sr.series.iter().cloned())
                     .collect();
@@ -365,7 +383,8 @@ fn create_summary(
             .filter(|sr| {
                 let p = sr.test_case.profile;
                 let s = sr.test_case.scenario;
-                p == profile && s == scenario
+                let par = sr.test_case.parallel;
+                p == profile && s == scenario && par == parallel
             })
             .map(|sr| sr.series.iter().cloned())
             .collect();
@@ -377,6 +396,8 @@ fn create_summary(
 
         summary_benchmark
             .entry(profile)
+            .or_insert_with(HashMap::new)
+            .entry(format!("{}", parallel.0))
             .or_insert_with(HashMap::new)
             .insert(scenario.to_string(), graph_series);
     }

--- a/site/src/request_handlers/self_profile.rs
+++ b/site/src/request_handlers/self_profile.rs
@@ -34,18 +34,20 @@ pub async fn handle_self_profile_processed_download(
 
     let title = if let Some(diff_against) = diff_against.as_ref() {
         format!(
-            "{} vs {}: {} {}",
+            "{} vs {}: {} {} par{}",
             &diff_against[..std::cmp::min(7, diff_against.len())],
             &body.commit[..std::cmp::min(7, body.commit.len())],
             body.benchmark,
-            body.scenario
+            body.scenario,
+            body.parallel
         )
     } else {
         format!(
-            "{}: {} {}",
+            "{}: {} {} par{}",
             &body.commit[..std::cmp::min(7, body.commit.len())],
             body.benchmark,
-            body.scenario
+            body.scenario,
+            body.parallel
         )
     };
 
@@ -58,6 +60,7 @@ pub async fn handle_self_profile_processed_download(
             &diff_against,
             &body.profile,
             &body.scenario,
+            &body.parallel,
             &body.backend,
             &body.target,
         )
@@ -99,6 +102,7 @@ pub async fn handle_self_profile_processed_download(
             &body.commit,
             &body.profile,
             &body.scenario,
+            &body.parallel,
             &body.backend,
             &body.target,
         )
@@ -184,12 +188,14 @@ pub async fn handle_self_profile_processed_download(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn get_self_profile_id(
     ctxt: &SiteCtxt,
     benchmark: &str,
     commit: &str,
     profile: &str,
     scenario: &str,
+    parallel: &str,
     backend: &str,
     target: &str,
 ) -> anyhow::Result<SelfProfileId> {
@@ -199,6 +205,9 @@ async fn get_self_profile_id(
     let scenario = scenario
         .parse::<database::Scenario>()
         .map_err(|e| anyhow::anyhow!("invalid scenario: {e:?}"))?;
+    let parallel = parallel
+        .parse::<database::Parallel>()
+        .map_err(|e| anyhow::anyhow!("invalid parallel: {e:?}"))?;
     let backend = backend
         .parse::<CodegenBackend>()
         .map_err(|e| anyhow::anyhow!("invalid codegen backend: {e:?}"))?;
@@ -240,6 +249,7 @@ async fn get_self_profile_id(
             benchmark,
             profile,
             scenario,
+            parallel,
             backend,
             target,
         },
@@ -367,6 +377,7 @@ pub async fn handle_self_profile_raw_download(
         &body.commit,
         &body.profile,
         &body.scenario,
+        &body.parallel,
         &body.backend,
         &body.target,
     )
@@ -427,6 +438,10 @@ pub async fn handle_self_profile(
         .scenario
         .parse::<database::Scenario>()
         .map_err(|e| format!("invalid scenario: {e:?}"))?;
+    let parallel = body
+        .parallel
+        .parse::<database::Parallel>()
+        .map_err(|e| format!("invalid parallel: {e:?}"))?;
     let index = ctxt.index.load();
 
     let backend: CodegenBackend = if let Some(backend) = body.backend {
@@ -446,9 +461,10 @@ pub async fn handle_self_profile(
         .benchmark(selector::Selector::One(benchmark.to_string()))
         .profile(selector::Selector::One(profile))
         .scenario(selector::Selector::One(scenario))
+        .parallel(selector::Selector::One(parallel))
         .backend(selector::Selector::One(backend))
         .target(selector::Selector::One(target))
-        .metric(selector::Selector::One(Metric::CpuClock));
+        .metric(selector::Selector::One(Metric::WallTime));
 
     // Helper for finding an `ArtifactId` based on a commit sha
     let find_aid = |commit: &str| {
@@ -484,6 +500,7 @@ pub async fn handle_self_profile(
             },
             profile.as_str(),
             &scenario.to_string(),
+            &parallel.0.to_string(),
             backend.as_str(),
             target.as_str(),
         )
@@ -502,6 +519,7 @@ pub async fn handle_self_profile(
                 },
                 profile.as_str(),
                 &scenario.to_string(),
+                &parallel.0.to_string(),
                 backend.as_str(),
                 target.as_str(),
             )


### PR DESCRIPTION
-Zthreads=N support implemented as an additional dimension 'Parallel'.
Default values for parallels: `[1,4]`.

Aggregations sample:
<img width="1331" height="1045" alt="Aggregations" src="https://github.com/user-attachments/assets/4014cfeb-9428-435d-b1f5-c3aac34d5749" />

Primary benchmarks sample:
<img width="1322" height="880" alt="PrimaryBenchs" src="https://github.com/user-attachments/assets/00302ca3-6025-4b0e-b07b-d0b91866fefa" />

Secondary benchmarks sample:
<img width="1330" height="852" alt="SecondaryBenchs" src="https://github.com/user-attachments/assets/f9b19151-dbf8-4810-96e3-74207c8fcd01" />

Graphs sample (graphs have "scenario_parallel" names like "full_par1 / full_par4"):
<img width="2385" height="1022" alt="Graphs" src="https://github.com/user-attachments/assets/45b279d9-d91e-461e-8b5c-32922890730d" />

Filters with par1/par4 added:
<img width="1332" height="485" alt="Filters" src="https://github.com/user-attachments/assets/e0636c97-afd0-4020-813d-cd625bbffdf1" />

<img width="1206" height="236" alt="LocalProfilingCmd" src="https://github.com/user-attachments/assets/bcee3154-934e-4c8d-8636-24c6fac8db0a" />
