### PR TITLE
github-actions: scope workflow permissions and disable credential persistence

### DIFF
--- a/.github/workflows/beta-stable-benchmarks.yml
+++ b/.github/workflows/beta-stable-benchmarks.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: "0 12 * * 1" # Every Monday at 12:00 UTC
 
+permissions:     
+  contents: read
+    
 jobs:
   test-stable:
     name: Test stable benchmarks

--- a/.github/workflows/beta-stable-benchmarks.yml
+++ b/.github/workflows/beta-stable-benchmarks.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout the source code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install beta toolchain
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Install toolchain
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: "0 12 * * 1" # Every Monday at 12:00 UTC
 
+permissions:
+  contents: read
+
 env:
   AWS_ACCESS_KEY_ID: AKIA46X5W6CZBLO3VBND
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - uses: docker/setup-buildx-action@v2
       - name: Build Docker image

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
       - master
   workflow_dispatch:
 
+permissions:     
+  contents: read
+
 env:
   AWS_ACCESS_KEY_ID: AKIA46X5W6CZBLO3VBND
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,12 +5,14 @@ on:
     - cron: "0 23 * * *"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   publish_release:
     name: Publish release
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
     steps:
       - name: Set version
         run: |
@@ -20,6 +22,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Install stable toolchain
         run: |


### PR DESCRIPTION
Fixes zizmor's `excessive-permissions` and `artipacked` findings in workflow files.

Changes:
- Scope workflow permissions to least privilege (add `contents: read` where missing)
- Move `contents: write` to the `publish_release` job in `nightly.yml`
- Add `persist-credentials: false` to `actions/checkout` in all workflows using checkout
- Ensure CI, deploy, nightly, and benchmark workflows do not rely on default elevated permissions

Notes:
- `AWS_ACCESS_KEY_ID` remains unchanged in `ci.yml` and `deploy.yml`
  - Noticed as a security concern (hardcoded credentials in the workflow)
  - Left unchanged to avoid breaking existing deployment flow; may require maintainer-side migration to GitHub Secrets