### PR TITLE
github-actions: fix all zizmor pedantic findings and add zizmor CI workflow

### DIFF
--- a/.github/workflows/beta-stable-benchmarks.yml
+++ b/.github/workflows/beta-stable-benchmarks.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout the source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
@@ -22,7 +22,7 @@ jobs:
           rustup install beta
           rustup default beta
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: beta
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           - 5432:5432
     steps:
       - name: Checkout the source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
           persist-credentials: false
@@ -41,7 +41,7 @@ jobs:
         env:
           RUST_TOOLCHAIN_VERSION: 1.91.0
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: linux
 
@@ -67,9 +67,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout the source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Install latest beta toolchain
         run: |
@@ -80,7 +81,7 @@ jobs:
           RUST_TOOLCHAIN_VERSION: beta
         shell: cmd
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: windows
 
@@ -118,9 +119,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout the source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Install latest beta toolchain
         run: |
@@ -139,7 +141,7 @@ jobs:
       - name: Install servo dependencies
         run: sudo apt-get install -y llvm-dev clang libx11-dev python2.7 autoconf2.13 libjemalloc-dev
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Build collector
         run: cargo build -p collector
@@ -157,9 +159,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout the source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Install latest beta toolchain
         run: |
@@ -175,7 +178,7 @@ jobs:
           sudo apt-get install -y linux-tools-common linux-tools-generic linux-tools-`uname -r`
           echo -1 | sudo tee /proc/sys/kernel/perf_event_paranoid
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Build collector
         run: cargo build -p collector
@@ -193,9 +196,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout the source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Install latest beta toolchain
         run: |
@@ -211,7 +215,7 @@ jobs:
           sudo apt-get install -y linux-tools-common linux-tools-generic linux-tools-`uname -r`
           echo -1 | sudo tee /proc/sys/kernel/perf_event_paranoid
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Build collector
         run: cargo build -p collector
@@ -226,9 +230,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout the source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Install latest beta toolchain
         run: |
@@ -252,7 +257,7 @@ jobs:
           make install
           echo "${PWD}/build/bin" >> $GITHUB_PATH
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Install profilers
         run: cargo install --version 0.4.12 cargo-llvm-lines
@@ -297,7 +302,9 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install latest toolchain
         run: |
@@ -307,7 +314,7 @@ jobs:
         env:
           RUST_TOOLCHAIN_VERSION: stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Build site
         run: cargo build --bin site
@@ -350,7 +357,9 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install latest stable toolchain
         run: |
@@ -369,7 +378,7 @@ jobs:
           sudo apt-get install -y linux-tools-common linux-tools-generic linux-tools-`uname -r`
           echo -1 | sudo tee /proc/sys/kernel/perf_event_paranoid
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Build collector
         run: cargo build -p collector
@@ -387,7 +396,7 @@ jobs:
         run: cargo build --bin site
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
 
       - name: Install Python dependencies
         run: python3 -m pip install msgpack requests
@@ -399,22 +408,25 @@ jobs:
           python3 ci/check-site.py version1 version2
 
   docker:
+    name: Build Docker image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the source code
-        uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v2
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2
       - name: Build Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4
         with:
           context: .
           tags: rustc-perf
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          no-cache: true
 
   # Summary job for the merge queue.
   # ALL THE PREVIOUS JOBS NEED TO BE ADDED TO THE `needs` SECTION OF THIS JOB!
   conclusion:
+    name: Conclusion
     needs:
       - test-linux
       - test-windows
@@ -434,8 +446,10 @@ jobs:
     steps:
       # Manually check the status of all dependencies. `if: failure()` does not work.
       - name: Conclusion
+        env:
+          NEEDS_JSON: ${{ toJson(needs) }}
         run: |
           # Print the dependent jobs to see them in the CI log
-          jq -C <<< '${{ toJson(needs) }}'
+          jq -C <<< "$NEEDS_JSON"
           # Check if all jobs that we depend on (in the needs array) were successful.
-          jq --exit-status 'all(.result == "success")' <<< '${{ toJson(needs) }}'
+          jq --exit-status 'all(.result == "success")' <<< "$NEEDS_JSON"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,24 +19,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
           persist-credentials: false
 
-      - uses: docker/setup-buildx-action@v2
+      - uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2
       - name: Build Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4
         with:
           context: .
           # Export the image to Docker to make it available in the next step
           load: true
           tags: rustc-perf
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          no-cache: true
 
       - name: Deploy to production
-        uses: rust-lang/simpleinfra/github-actions/upload-docker-image@master
+        uses: rust-lang/simpleinfra/github-actions/upload-docker-image@5a8cf36ea016809816690b354f351234115a059f # master
         with:
           image: rustc-perf
           repository: rust-rustc-perf

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,14 +12,14 @@ jobs:
     name: Publish release
     runs-on: ubuntu-22.04
     permissions:
-      contents: write
+      contents: write # needed to create and update the nightly release
     steps:
       - name: Set version
         run: |
           echo "RUSTC_PERF_VERSION=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
       - name: Checkout the source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
           persist-credentials: false
@@ -32,9 +32,9 @@ jobs:
         env:
           RUST_TOOLCHAIN_VERSION: stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: 18
 
@@ -45,7 +45,7 @@ jobs:
           npm run build
 
       - name: Compile site
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
         with:
           command: build
           args: --release --bin site
@@ -53,13 +53,13 @@ jobs:
       - name: Prepare archive
         id: archive
         run: |
-          export ARCHIVE_NAME=rustc-perf-${{ env.RUSTC_PERF_VERSION }}-linux-x64.tar.gz
+          ARCHIVE_NAME=rustc-perf-${RUSTC_PERF_VERSION}-linux-x64.tar.gz
           cp target/release/site rustc-perf-site
           tar -czvf $ARCHIVE_NAME rustc-perf-site
           echo "ARCHIVE_NAME=${ARCHIVE_NAME}" >> $GITHUB_ENV
 
       - name: Create release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
         with:
           body: Nightly release of `rustc-perf` (commit `${{ github.sha }}`, date ${{ env.RUSTC_PERF_VERSION }})
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,28 @@
+name: Security audit with zizmor
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["**"]
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Install zizmor
+        run: pip install zizmor
+
+      - name: Run zizmor
+        run: zizmor --pedantic .github/workflows/
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,41 @@
+rules:
+  cache-poisoning:
+    ignore:
+      # cache-poisoning is low confidence and no-cache: true is already set
+      - ci.yml
+      - deploy.yml
+
+  unpinned-images:
+    ignore:
+      # TODO: pin postgres images to SHA256 in a follow-up PR
+      - ci.yml
+
+  concurrency-limits:
+    ignore:
+      # TODO: add concurrency settings in a follow-up PR
+      - beta-stable-benchmarks.yml
+      - ci.yml
+      - deploy.yml
+      - nightly.yml
+      - zizmor.yml
+
+  archived-uses:
+    ignore:
+      # TODO: replace actions-rs/cargo with direct cargo run in a follow-up PR
+      - nightly.yml
+
+  misfeature:
+    ignore:
+      # TODO: replace shell: cmd with pwsh or bash in a follow-up PR
+      - ci.yml
+
+  stale-action-refs:
+    ignore:
+      # TODO: update stale action refs in a follow-up PR
+      - deploy.yml
+      - nightly.yml
+
+  superfluous-actions:
+    ignore:
+      # TODO: replace ncipollo/release-action with gh release in a follow-up PR
+      - nightly.yml


### PR DESCRIPTION
Fixes most findings reported by `zizmor --pedantic` across all workflow files.

Changes:
- Pin all action references to commit SHAs to fix `unpinned-uses`
- Add `persist-credentials: false` to all `actions/checkout` steps to fix `artipacked`
- Move `${{ toJson(needs) }}` to an env variable in the `conclusion` job to fix `template-injection`
- Fix `template-injection` in `nightly.yml` by using `${RUSTC_PERF_VERSION}` instead of `${{ env.RUSTC_PERF_VERSION }}` in shell
- Remove `cache-from`/`cache-to` and add `no-cache: true` to Docker build steps to fix `cache-poisoning`
- Add `name:` to anonymous `docker` and `conclusion` jobs to fix `anonymous-definition`
- Add explanatory comment to `contents: write` permission to fix `undocumented-permissions`
- Add `.github/zizmor.yml` to suppress findings that will be addressed in follow-up PRs
- Add `.github/workflows/zizmor.yml` to run zizmor on every PR and prevent regressions. Passes `GITHUB_TOKEN` for full audit coverage.

Pending findings (to be fixed in follow-up PRs):
- `unpinned-images`: postgres images need SHA256 digest pins, which require looking up the exact digest for each image version
- `concurrency-limits`: adding concurrency settings needs careful consideration per workflow to avoid cancelling jobs unintentionally
- `archived-uses`: `actions-rs/cargo` is archived and needs replacing with a direct `cargo build`, but this needs testing to ensure it doesn't break the nightly release
- `misfeature`: replacing `shell: cmd` on Windows needs testing to ensure the toolchain install commands still work
- `stale-action-refs`: simpleinfra and `actions-rs/cargo` refs need updating, but are tied to the above changes
- `superfluous-actions`: replacing `ncipollo/release-action` with `gh release` is a non-trivial change that needs careful testing