### PR TITLE
github-actions: add zizmor CI workflow to prevent security regressions

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,28 @@
+name: Security audit with zizmor
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["**"]
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Install zizmor
+        run: pip install zizmor
+
+      - name: Run zizmor
+        run: zizmor --pedantic .github/workflows/
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Follow-up to #2428 (split as requested by @Kobzol).

Adds a zizmor CI workflow that runs on every PR to prevent security regressions.
Passes `GITHUB_TOKEN` for full audit coverage including `impostor-commit`, `ref-confusion`, and `known-vulnerable-actions`.

Note: this workflow will run cleanly once #2432 is merged.