### PR TITLE
github-actions: suppress cache-poisoning findings for intentional GHA cache usage

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,7 @@
+rules:
+  cache-poisoning:
+    ignore:
+      # The GHA cache is used intentionally here for build performance.
+      # The risk is accepted as these workflows only build internal images.
+      - ci.yml
+      - deploy.yml


### PR DESCRIPTION
Follow-up to #2428 (split as requested by @Kobzol).

Adds `.github/zizmor.yml` to suppress the `cache-poisoning` findings in `ci.yml` and `deploy.yml`. The GHA cache configuration (`cache-from`/`cache-to`) is kept to preserve build caching.