### PR TITLE
renovate: group dependency updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,9 +1,12 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: [
-    "github>rust-lang/renovate:actions",
+    "github>rust-lang/renovate",
     "docker:disable",
   ],
+  "lockFileMaintenance": {
+    "extends": ["schedule:monthly"]
+  },
   "packageRules": [
     {
       "matchManagers": ["github-actions"],


### PR DESCRIPTION
This makes the renovate file the same as the bors repo, grouping dependencies update monthly.
We'll improve the experience for the `actions` preset with https://github.com/rust-lang/renovate/issues/13