### PR TITLE
renovate: don't update benchmarks

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,6 +4,10 @@
     "github>rust-lang/renovate",
     "docker:disable",
   ],
+  ignorePaths: [
+    "collector/compile-benchmarks/**",
+    "collector/runtime-benchmarks/**",
+  ],
   "lockFileMaintenance": {
     "extends": ["schedule:monthly"]
   },


### PR DESCRIPTION
Prevent renovate to raise PRs like https://github.com/rust-lang/rustc-perf/pull/2456