### PR TITLE
renovate: disable individual PRs for breaking changes

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,6 +12,12 @@
     "extends": ["schedule:monthly"]
   },
   "packageRules": [
+    // Disable individual PRs for breaking changes
+    {
+      "matchCategories": ["rust", "js"],
+      "matchJsonata": ["isBreaking == true"],
+      "enabled": false
+    },
     {
       "matchManagers": ["github-actions"],
       "extends": ["schedule:monthly"]


### PR DESCRIPTION
Stop PRs like https://github.com/rust-lang/rustc-perf/pull/2463
Requested in zulip DM.

Documented in https://github.com/rust-lang/renovate/pull/18