### PR TITLE
collector: scope precise_crabgrind feature to Linux

### DIFF
--- a/collector/benchlib/Cargo.toml
+++ b/collector/benchlib/Cargo.toml
@@ -16,9 +16,9 @@ serde_json = { workspace = true }
 
 libc = "0.2"
 flate2 = { version = "1", optional = true }
-crabgrind = { version = "0.1.10", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
+crabgrind = { version = "0.1.10", optional = true }
 perf-event = "0.4.9"
 
 [features]

--- a/collector/benchlib/src/profile.rs
+++ b/collector/benchlib/src/profile.rs
@@ -3,14 +3,14 @@ pub fn profile_function<F: Fn() -> Bench, R, Bench: FnOnce() -> R>(benchmark_con
 
     // With the `precise-cachegrind` feature, we want to enable cachegrind recording
     // only for the actual execution of the profiled function.
-    #[cfg(feature = "precise-cachegrind")]
+    #[cfg(all(target_os = "linux", feature = "precise-cachegrind"))]
     {
         crabgrind::cachegrind::start_instrumentation();
     }
 
     func();
 
-    #[cfg(feature = "precise-cachegrind")]
+    #[cfg(all(target_os = "linux", feature = "precise-cachegrind"))]
     {
         crabgrind::cachegrind::stop_instrumentation();
     }


### PR DESCRIPTION
crabgrind does not seem to compile on macOS.