### PR TITLE
Show error when comparison comment cannot be posted

### DIFF
--- a/site/src/github/comparison_summary.rs
+++ b/site/src/github/comparison_summary.rs
@@ -83,7 +83,12 @@ async fn calculate_metric_comparison(
     .await
     {
         Ok(Some(c)) => Ok(c),
-        _ => Err("ERROR categorizing benchmark run!".to_owned()),
+        Ok(None) => {
+            Err("Error occured while categorizing benchmark run (missing comparison).".to_string())
+        }
+        Err(error) => Err(format!(
+            "Error occured while categorizing benchmark run:\n\n```{error}```"
+        )),
     }
 }
 


### PR DESCRIPTION
To provide context when [this](https://github.com/rust-lang/rust/pull/153721#issuecomment-4422875829) happens.
