### PR TITLE
Sort perf builds in the same order as the PR description

### DIFF
--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -40,13 +40,8 @@ pub async fn unroll_rollup(
 
     // Sort rolled up commits by their PR number in ascending order, so that they have the
     // same ordering as in the rollup PR description.
-    let mut unrolled_builds: Vec<UnrolledCommit> =
-        enqueue_unrolled_try_builds(&gh_client, rollup_merges, previous_master).await?;
-    // The number should really be an integer, but if not, we will just sort the "non-integer" PRs
-    // first.
-    unrolled_builds.sort_by_cached_key(|commit| commit.original_pr_number.parse::<u64>().ok());
-
-    let mapping = unrolled_builds
+    let mapping = enqueue_unrolled_try_builds(&gh_client, rollup_merges, previous_master)
+        .await?
         .into_iter()
         .fold(String::new(), |mut string, c| {
             use std::fmt::Write;

--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -38,8 +38,6 @@ pub async fn unroll_rollup(
         format!("[{display}]({})", commit_link(s))
     };
 
-    // Sort rolled up commits by their PR number in ascending order, so that they have the
-    // same ordering as in the rollup PR description.
     let mapping = enqueue_unrolled_try_builds(&gh_client, rollup_merges, previous_master)
         .await?
         .into_iter()

--- a/site/src/request_handlers/github.rs
+++ b/site/src/request_handlers/github.rs
@@ -52,7 +52,6 @@ async fn handle_push(ctxt: Arc<SiteCtxt>, push: github::Push) -> ServerResult<gi
     tokio::spawn(async move {
         let rollup_merges = commits
             .iter()
-            .rev()
             .filter(|c| c.message.starts_with("Rollup merge of #"));
         let result =
             unroll_rollup(gh_client, rollup_merges, &previous_master, rollup_pr_number).await;


### PR DESCRIPTION
I want this so the `iffy` jobs are at the top of the list, just like in the PR description. 
This is not currently the case, for example see https://github.com/rust-lang/rust/pull/158455

I have not tested this change, and I'm not even sure that removing the `.rev()` is correct.
Is there any way to test this other than in prod?
r? @Kobzol 