### PR TITLE
database: replace postgres-native-tls with tokio-postgres-rustls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,13 +819,13 @@ dependencies = [
  "futures-util",
  "hashbrown 0.17.1",
  "intern",
- "native-tls",
- "postgres-native-tls",
  "reqwest",
  "rusqlite",
+ "rustls",
  "serde",
  "tokio",
  "tokio-postgres",
+ "tokio-postgres-rustls",
  "uuid",
  "x509-cert",
 ]
@@ -1066,7 +1066,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1142,21 +1142,6 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -2133,23 +2118,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe 0.1.6",
- "openssl-sys",
- "schannel",
- "security-framework 2.10.0",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "nix"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2289,54 +2257,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "openssl"
-version = "0.10.70"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
-dependencies = [
- "bitflags 2.13.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -2498,18 +2422,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
-]
-
-[[package]]
-name = "postgres-native-tls"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef4de47bb81477e0c3deaf153a1b10ae176484713ff1640969f4cb96b653ebc"
-dependencies = [
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tokio-postgres",
 ]
 
 [[package]]
@@ -3053,7 +2965,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3063,6 +2975,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "rustls-pki-types",
  "rustls-webpki",
@@ -3076,10 +2989,10 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
- "openssl-probe 0.2.1",
+ "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.7.0",
+ "security-framework",
 ]
 
 [[package]]
@@ -3107,7 +3020,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework 3.7.0",
+ "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -3175,19 +3088,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "security-framework"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
 
 [[package]]
 name = "security-framework"
@@ -3674,7 +3574,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3817,16 +3717,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-postgres"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3850,6 +3740,20 @@ dependencies = [
  "tokio",
  "tokio-util",
  "whoami",
+]
+
+[[package]]
+name = "tokio-postgres-rustls"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2ad44aa0ae96db89c4742212ed41645b2f597311ff6e1945542a4d9fadc2fb"
+dependencies = [
+ "rustls",
+ "sha2 0.11.0",
+ "tokio",
+ "tokio-postgres",
+ "tokio-rustls",
+ "x509-cert",
 ]
 
 [[package]]
@@ -4305,7 +4209,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -16,9 +16,9 @@ tokio = { workspace = true, features = ["sync", "macros", "rt-multi-thread"] }
 
 rusqlite = { version = "0.39", features = ["bundled"] }
 tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "runtime"] }
+tokio-postgres-rustls = { version = "0.14", features = ["aws-lc-rs"] }
+rustls = "0.23"
 async-trait = "0.1"
-postgres-native-tls = "0.5"
-native-tls = "0.2"
 futures-util = "0.3.5"
 bytes = "1"
 csv = "1"

--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -18,14 +18,16 @@ use crate::{
 use anyhow::Context as _;
 use chrono::{DateTime, TimeZone, Utc};
 use hashbrown::{HashMap, HashSet};
-use native_tls::{Certificate, TlsConnector};
-use postgres_native_tls::MakeTlsConnector;
+use rustls::pki_types::pem::PemObject;
+use rustls::pki_types::CertificateDer;
+use rustls::{ClientConfig, RootCertStore};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Mutex;
 use tokio_postgres::Statement;
 use tokio_postgres::{GenericClient, Row};
+use tokio_postgres_rustls::MakeRustlsConnect;
 
 pub struct Postgres(String, std::sync::Once);
 
@@ -39,12 +41,11 @@ const CERT_URL: &str = "https://truststore.pki.rds.amazonaws.com/global/global-b
 
 pub async fn make_client(db_url: &str) -> anyhow::Result<tokio_postgres::Client> {
     if db_url.contains("rds.amazonaws.com") {
-        let mut builder = TlsConnector::builder();
-        for cert in make_certificates().await {
-            builder.add_root_certificate(cert);
-        }
-        let connector = builder.build().context("built TlsConnector")?;
-        let connector = MakeTlsConnector::new(connector);
+        let connector = MakeRustlsConnect::new(
+            ClientConfig::builder()
+                .with_root_certificates(make_certificates().await)
+                .with_no_client_auth(),
+        );
 
         let (db_client, connection) = match tokio_postgres::connect(db_url, connector).await {
             Ok(v) => v,
@@ -77,32 +78,33 @@ pub async fn make_client(db_url: &str) -> anyhow::Result<tokio_postgres::Client>
         Ok(db_client)
     }
 }
-async fn make_certificates() -> Vec<Certificate> {
-    use x509_cert::der::pem::LineEnding;
-    use x509_cert::der::EncodePem;
 
-    static CERTIFICATE_PEMS: Mutex<Option<Vec<u8>>> = Mutex::const_new(None);
+async fn make_certificates() -> Arc<RootCertStore> {
+    static ROOTS: Mutex<Option<Arc<RootCertStore>>> = Mutex::const_new(None);
 
-    let mut guard = CERTIFICATE_PEMS.lock().await;
-    if guard.is_none() {
-        let client = reqwest::Client::new();
-        let resp = client
-            .get(CERT_URL)
-            .send()
-            .await
-            .expect("failed to get RDS cert");
-        let certificate_pems = resp
-            .bytes()
-            .await
-            .expect("failed to get RDS cert body")
-            .to_vec();
-        *guard = Some(certificate_pems.clone());
+    let mut guard = ROOTS.lock().await;
+    if let Some(roots) = &*guard {
+        return roots.clone();
     }
-    let certs = x509_cert::Certificate::load_pem_chain(&guard.as_ref().unwrap()[..]).unwrap();
-    certs
-        .into_iter()
-        .map(|cert| Certificate::from_pem(cert.to_pem(LineEnding::LF).unwrap().as_bytes()).unwrap())
-        .collect()
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(CERT_URL)
+        .send()
+        .await
+        .expect("failed to get RDS cert");
+    let certificate_pems = resp.bytes().await.expect("failed to get RDS cert body");
+    let roots = CertificateDer::pem_slice_iter(&certificate_pems)
+        .collect::<Result<Vec<_>, _>>()
+        .expect("failed to parse RDS certs");
+
+    let mut store = RootCertStore::empty();
+    let (added, ignored) = store.add_parsable_certificates(roots);
+    assert!(added / 2 > ignored, "failed to add RDS certs");
+
+    let wrapped = Arc::new(store);
+    *guard = Some(wrapped.clone());
+    wrapped
 }
 
 static MIGRATIONS: &[&str] = &[


### PR DESCRIPTION
As suggested in

- https://github.com/rust-lang/rustc-perf/pull/2475#pullrequestreview-4640020616

-10/+1 dependencies seems nice enough, and no more OpenSSL, as you suggested.

This is untested, since I don't have credentials to RDS -- but seems likely to work?

(Might be nice to also migrate this repo from `master` -> `main`?)

r? @Kobzol 