### PR TITLE
Add 30 day history link to artifact size tab on the compare page

### DIFF
--- a/site/frontend/src/pages/compare/artifact-size/artifact-size-table.vue
+++ b/site/frontend/src/pages/compare/artifact-size/artifact-size-table.vue
@@ -2,6 +2,7 @@
 import {ArtifactDescription} from "../types";
 import {diffClass, formatPercentChange, formatSize} from "../shared";
 import Tooltip from "../tooltip.vue";
+import {formatDate, getPastDate} from "../compile/table/utils";
 
 const props = defineProps<{
   a: ArtifactDescription;
@@ -104,10 +105,20 @@ function generateTitle(component: string): string {
     return ""; // Unknown component
   }
 }
+
+function historyLink(commit: ArtifactDescription): string {
+  // Move to `30 days ago` to display recent history
+  const start = formatDate(getPastDate(new Date(commit.date), 30));
+  const end = commit.commit;
+  return `/toolchain.html?start=${start}&end=${end}`;
+}
 </script>
 
 <template>
   <div class="category-title">Artifact component sizes</div>
+  <div style="text-align: center">
+    <a :href="historyLink(b)">View 30 day history</a>
+  </div>
   <div class="wrapper">
     <table>
       <thead>


### PR DESCRIPTION
Discussed [here](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/perf.2Er-l.2Eo.20artifact.20size.20graphs/with/611445474).

<img width="1465" height="610" alt="image" src="https://github.com/user-attachments/assets/b354c222-3b5d-41b2-8b80-687eab8b6b51" />