### PR TITLE
Add early check for missing rustdoc/clippy in a toolchain

### DIFF
--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -1701,6 +1701,27 @@ async fn create_benchmark_configs(
         .collect();
 
     let compile_config = if bench_rustc || !benchmarks.is_empty() {
+        if toolchain.components.rustdoc.is_none()
+            && matches!(
+                job.profile(),
+                database::Profile::Doc | database::Profile::DocJson
+            )
+        {
+            return Err(anyhow::anyhow!(
+                "Trying to run a {} profile, but the toolchain doesn't have rustdoc available",
+                job.profile()
+            ));
+        }
+
+        if toolchain.components.clippy.is_none()
+            && matches!(job.profile(), database::Profile::Clippy)
+        {
+            return Err(anyhow::anyhow!(
+                "Trying to run a {} profile, but the toolchain doesn't have clippy available",
+                job.profile()
+            ));
+        }
+
         Some(CompileBenchmarkConfig {
             benchmarks,
             profiles: vec![job.profile().into()],


### PR DESCRIPTION
I recently tried to run a Clippy benchmark on a toolchain without Clippy, and it failed quite late. This should be an immediate, and permanent, error instead.
