### PR TITLE
feat: support `@argfile` for rustc-fake

### DIFF
--- a/collector/src/arg_file_command.rs
+++ b/collector/src/arg_file_command.rs
@@ -1,0 +1,121 @@
+//! This module is explictly not `mod`ed as it's shared across multiple crates
+//! like bootstrap and compiletest via `#[path]` moduled declarations.
+//! It's important to keep this file isolated from the rest of build_helper so it can be compiled
+//! without build_helper.
+
+// Roughly match the `std::process::Command` API
+#![allow(dead_code, unreachable_pub)]
+
+use std::ffi::{OsStr, OsString};
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, CommandEnvs};
+
+use tempfile::NamedTempFile;
+
+/// A wrapper around [`Command`] that adds support for arg files.
+/// This is useful as we have some commands that can get very long and at times
+/// hit the OS limit (usually Windows)
+///
+/// This implementation is based off the `ProcessBuilder` implementation in Cargo
+/// but simplified.
+///
+/// NOTE: In most scenarios we want to avoid arg files as it makes debugging more complicated
+///       so we try to avoid it if the command is not close to the OS limit.
+#[derive(Debug)]
+pub struct ArgFileCommand {
+    command: Command,
+    args: Vec<OsString>,
+}
+
+impl ArgFileCommand {
+    pub fn new<S: AsRef<OsStr>>(program: S) -> Self {
+        let command = Command::new(program);
+        Self { command, args: Vec::new() }
+    }
+    pub fn arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut Self {
+        self.args.push(arg.as_ref().to_os_string());
+        self
+    }
+
+    pub fn args<I, S>(&mut self, args: I) -> &mut Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        self.args.extend(args.into_iter().map(|s| s.as_ref().to_os_string()));
+        self
+    }
+
+    pub fn env<K, V>(&mut self, key: K, val: V) -> &mut Self
+    where
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>,
+    {
+        self.command.env(key, val);
+        self
+    }
+
+    pub fn get_envs(&self) -> CommandEnvs<'_> {
+        self.command.get_envs()
+    }
+
+    pub fn env_remove<K: AsRef<OsStr>>(&mut self, key: K) -> &mut Self {
+        self.command.env_remove(key);
+        self
+    }
+
+    pub fn current_dir<P: AsRef<Path>>(&mut self, dir: P) -> &mut Self {
+        self.command.current_dir(dir);
+        self
+    }
+
+    pub fn stdin(&mut self, stdin: std::process::Stdio) -> &mut Self {
+        self.command.stdin(stdin);
+        self
+    }
+
+    pub fn build(mut self) -> std::io::Result<(Command, Option<NamedTempFile>)> {
+        // On Windows there is a hard limit of ~32KB, so we cut off at 30KB to
+        // give some buffer just incase.
+        #[cfg(windows)]
+        let threshold: usize = 30 * 1024;
+        // On unix the limit is defined by ARG_MAX. If its not explicitly set we set it to 1MB
+        // which is fairly large but lower than the ~2MB that it defaults to on most systems.
+        #[cfg(unix)]
+        let threshold: usize =
+            std::env::var("ARG_MAX").ok().and_then(|v| v.parse().ok()).unwrap_or(1024 * 1024);
+
+        let total_arg_len: usize = self.args.iter().map(|a| a.len() + 1).sum();
+        if total_arg_len <= threshold {
+            self.command.args(self.args);
+            return Ok((self.command, None));
+        }
+
+        let mut tmp = tempfile::Builder::new().prefix("bootstrap-argfile.").tempfile()?;
+
+        let mut arg = OsString::from("@");
+        arg.push(tmp.path());
+        self.command.arg(arg);
+
+        let mut buf = Vec::with_capacity(total_arg_len);
+        for arg in &self.args {
+            let arg = arg.to_str().ok_or_else(|| {
+                std::io::Error::other(format!(
+                    "argument for argfile contains invalid UTF-8 characters: `{}`",
+                    arg.to_string_lossy()
+                ))
+            })?;
+            if arg.contains('\n') {
+                return Err(std::io::Error::other(format!(
+                    "argument for argfile contains newlines: `{arg}`"
+                )));
+            }
+            writeln!(buf, "{arg}")?;
+        }
+        tmp.write_all(&buf)?;
+        tmp.flush()?;
+
+        Ok((self.command, Some(tmp)))
+    }
+}

--- a/collector/src/bin/rustc-fake.rs
+++ b/collector/src/bin/rustc-fake.rs
@@ -1,9 +1,21 @@
 use std::env;
 use std::ffi::OsString;
 use std::fs;
-use std::path::PathBuf;
+use std::io::BufRead;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+// Vendored from
+// <https://github.com/rust-lang/rust/blob/008fa22ce3f8d3c8dfaca2e6486043c2b21851eb/src/build_helper/src/arg_file_command.rs>.
+//
+// Let us keep it byte-for-byte identical,
+// which is easy to audit if any drift happens
+#[rustfmt::skip]
+#[path = "../arg_file_command.rs"]
+mod arg_file_command;
+
+use arg_file_command::ArgFileCommand;
 
 fn determinism_env(cmd: &mut Command) {
     // Since rust-lang/rust#89836, rustc stable crate IDs include a hash of the
@@ -49,10 +61,9 @@ fn create_self_profile_dir() -> PathBuf {
 }
 
 fn main() {
-    let mut args_os = env::args_os();
-    let name = args_os.next().unwrap().into_string().unwrap();
+    let name = env::args_os().next().unwrap().into_string().unwrap();
 
-    let mut args = args_os.collect::<Vec<_>>();
+    let mut args = collect_args();
 
     let rustc = env::var_os("RUSTC_REAL").unwrap();
     let actually_rustdoc = name.ends_with("rustdoc-fake");
@@ -93,6 +104,9 @@ fn main() {
 
         benchlib::process::raise_process_priority();
 
+        let expanded_args = args;
+        let (args, _argfile) = pack_args(expanded_args.clone());
+
         // These strings come from `PerfTool::name()`.
         match wrapper {
             "PerfStat" | "PerfStatSelfProfile" => {
@@ -128,7 +142,7 @@ fn main() {
                 print_memory();
                 print_time(dur);
                 if wrapper == "PerfStatSelfProfile" {
-                    process_self_profile_output(prof_out_dir, &args[..]);
+                    process_self_profile_output(prof_out_dir, &expanded_args[..]);
                 }
             }
 
@@ -209,7 +223,7 @@ fn main() {
                 println!("!counters-file:{}", counters_file.to_str().unwrap());
 
                 if wrapper == "XperfStatSelfProfile" {
-                    process_self_profile_output(prof_out_dir, &args[..]);
+                    process_self_profile_output(prof_out_dir, &expanded_args[..]);
                 }
             }
 
@@ -433,11 +447,56 @@ fn main() {
             }
         }
 
+        let (args, _argfile) = pack_args(args);
         let mut cmd = Command::new(&tool);
         determinism_env(&mut cmd);
         cmd.args(&args);
         exec(&mut cmd);
     }
+}
+
+/// Collect all the command line arguments, including the arguments from any `@argfile`
+///
+// Adapted from
+// <https://github.com/rust-lang/rust/blob/008fa22ce3f8d3c8dfaca2e6486043c2b21851eb/src/bootstrap/src/utils/shared_helpers.rs#L132-L144>.
+fn collect_args() -> Vec<OsString> {
+    let mut args = Vec::with_capacity(env::args_os().len());
+    for arg in env::args_os().skip(1) {
+        if let Some(path) = arg.to_str().and_then(|s| s.strip_prefix('@')) {
+            args.extend(args_from_argfile(Path::new(path)));
+        } else {
+            args.push(arg)
+        }
+    }
+    args
+}
+
+/// Reads all the arguments from argfile given by `path`.
+// Adapted from
+// <https://github.com/rust-lang/rust/blob/008fa22ce3f8d3c8dfaca2e6486043c2b21851eb/src/bootstrap/src/utils/shared_helpers.rs#L146-L156>.
+fn args_from_argfile(path: &Path) -> Vec<OsString> {
+    fn collect_lines(path: &Path) -> Result<Vec<OsString>, std::io::Error> {
+        let file = std::fs::File::open(path)?;
+        std::io::BufReader::new(file)
+            .lines()
+            .map(|r| r.map(OsString::from))
+            .collect()
+    }
+    collect_lines(path).expect("read args from argfile {path:?}")
+}
+
+/// Packs the arguments into an `@argfile` when they are too long.
+///
+/// The returned tempfile guard must stay alive until the tool has finished running.
+fn pack_args(args: Vec<OsString>) -> (Vec<OsString>, Option<tempfile::NamedTempFile>) {
+    // The program is never executed. Let's just give it a placeholder.
+    let mut cmd = ArgFileCommand::new("unused");
+    cmd.args(args);
+    let (cmd, argfile) = cmd.build().expect("failed to build argfile");
+    (
+        cmd.get_args().map(|arg| arg.to_os_string()).collect(),
+        argfile,
+    )
 }
 
 fn process_self_profile_output(prof_out_dir: PathBuf, args: &[OsString]) {


### PR DESCRIPTION
This PR includes

* A verbatim copy of `arg_file_command.rs` from rust-lang/rust
* adapted copies of some other helpers from bootstrap.

This found because we tried to enable new build-dir layout for nightly
in Cargo, but failed with

```
error: Unrecognized option: 'skip-this-rustc'
```

I _guess_ this was the root cause.

See

* https://triage.rust-lang.org/gha-logs/rust-lang/rust/89681531404
* https://github.com/rust-lang/rust/pull/159857#issuecomment-5078882351
