### PR TITLE
Stop passing -Zincremental-verify-ich

### DIFF
--- a/collector/src/bin/rustc-fake.rs
+++ b/collector/src/bin/rustc-fake.rs
@@ -82,7 +82,16 @@ fn main() {
     // avoid. rustc-perf can accept the higher cost of always verifying hashes,
     // and we currently prefer to avoid exposing a means of hard-disabling
     // verification.
-    args.push(OsString::from("-Zincremental-verify-ich"));
+    //
+    // Only pass this for incremental compiles. For non-incremental compiles
+    // the flag only triggers a costly query key verification sweep.
+    let is_incremental = args.iter().any(|arg| {
+        arg.to_str()
+            .is_some_and(|a| a.starts_with("incremental=") || a.starts_with("-Cincremental="))
+    });
+    if is_incremental {
+        args.push(OsString::from("-Zincremental-verify-ich"));
+    }
 
     if let Some(pos) = args.iter().position(|arg| arg == "--wrap-rustc-with") {
         // Strip out the flag and its argument, and run rustc under the wrapper

--- a/collector/src/bin/rustc-fake.rs
+++ b/collector/src/bin/rustc-fake.rs
@@ -75,15 +75,6 @@ fn main() {
     args.push(OsString::from("-Adeprecated"));
     args.push(OsString::from("-Aunknown-lints"));
 
-    // This forces incremental query hash verification on. Currently, rustc
-    // hashes 1/32 of queries loaded from disk without this flag, but that 1/32
-    // is based on the (expected) hash of the data, which can vary from build to
-    // build, adding a source of noise to our measurements, which we prefer to
-    // avoid. rustc-perf can accept the higher cost of always verifying hashes,
-    // and we currently prefer to avoid exposing a means of hard-disabling
-    // verification.
-    args.push(OsString::from("-Zincremental-verify-ich"));
-
     if let Some(pos) = args.iter().position(|arg| arg == "--wrap-rustc-with") {
         // Strip out the flag and its argument, and run rustc under the wrapper
         // program named by the argument.


### PR DESCRIPTION
rustc-perf forces `-Zincremental-verify-ich` so that incremental cache verification, which normally covers a random 1/32 of loaded values, does not add noise: the subset was picked by value hash, so it differed between the two builds being compared.

Since [rust-lang/rust#160130](https://github.com/rust-lang/rust/pull/160130) the subset is picked by key fingerprint and session count. Both are the same for the two builds in a comparison, because rustc-perf [pins the rustc version](https://github.com/rust-lang/rustc-perf/blob/37f6778aae91f649efac6f02852621a17d864f31/collector/src/bin/rustc-fake.rs#L28) and runs the same scenarios, so the verification cost is identical on both sides and no longer noise.

We also want to build on this in a follow-up to [rust-lang/rust#160214](https://github.com/rust-lang/rust/pull/160214), where we want to avoid loading query results that are already green. Those values would then not be available for verification at all, so for that work it is desirable that rustc-perf measures exactly what users will run.