### PR TITLE
Fix compilation of regex-automata-0.4.8 with `doc-json`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,7 +251,7 @@ jobs:
 
   test-profiling:
     name: Test profiling
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Checkout the source code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -266,19 +266,8 @@ jobs:
         env:
           RUST_TOOLCHAIN_VERSION: beta
 
-      # We build a specific version of Valgrind because the one from the Ubuntu 22.04 repositories
-      # has problems with Rust debuginfo.
       - name: Install Valgrind
-        run: |
-          git clone https://sourceware.org/git/valgrind.git
-          cd valgrind
-          # Version from May 2022
-          git checkout 74e180e3c4d9e6bb4b2a9cd22eca7703412c5d42
-          ./autogen.sh
-          ./configure --prefix=${PWD}/build
-          make -j2
-          make install
-          echo "${PWD}/build/bin" >> $GITHUB_PATH
+        run: sudo apt install valgrind
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 

--- a/collector/compile-benchmarks/regex-automata-0.4.8/src/nfa/thompson/range_trie.rs
+++ b/collector/compile-benchmarks/regex-automata-0.4.8/src/nfa/thompson/range_trie.rs
@@ -725,18 +725,21 @@ impl NextInsert {
 /// below. It's plausible that the number of cases is not actually minimal,
 /// but it's important for this code to remain at least somewhat readable.
 ///
-/// Given [a,b] and [x,y], where a <= b, x <= y, b < 256 and y < 256, we define
+/// Given `[a,b]` and `[x,y]`, where a <= b, x <= y, b < 256 and y < 256, we define
 /// the follow distinct relationships where at least one must apply. The order
 /// of these matters, since multiple can match. The first to match applies.
 ///
+/// ```
 ///   1. b < x <=> [a,b] < [x,y]
 ///   2. y < a <=> [x,y] < [a,b]
+/// ```
 ///
 /// In the case of (1) and (2), these are the only cases where there is no
-/// overlap. Or otherwise, the intersection of [a,b] and [x,y] is empty. In
+/// overlap. Or otherwise, the intersection of `[a,b]` and `[x,y]` is empty. In
 /// order to compute the intersection, one can do [max(a,x), min(b,y)]. The
 /// intersection in all of the following cases is non-empty.
 ///
+/// ```
 ///    3. a = x && b = y <=> [a,b] == [x,y]
 ///    4. a = x && b < y <=> [x,y] right-extends [a,b]
 ///    5. b = y && a > x <=> [x,y] left-extends [a,b]
@@ -748,10 +751,12 @@ impl NextInsert {
 ///   11. y = a && x < b <=> [x,y] is left-adjacent to [a,b]
 ///   12. b > x && b < y <=> [a,b] left-overlaps [x,y]
 ///   13. y > a && y < b <=> [x,y] left-overlaps [a,b]
+/// ```
 ///
 /// In cases 3-13, we can form rules that partition the ranges into a
 /// non-overlapping ordered sequence of ranges:
 ///
+/// ```
 ///    3. [a,b]
 ///    4. [a,b], [b+1,y]
 ///    5. [x,a-1], [a,b]
@@ -763,10 +768,11 @@ impl NextInsert {
 ///   11. [x,y-1], [y,y], [y+1,b]
 ///   12. [a,x-1], [x,b], [b+1,y]
 ///   13. [x,a-1], [a,y], [y+1,b]
+/// ```
 ///
 /// In the code below, we go a step further and identify each of the above
 /// outputs as belonging either to the overlap of the two ranges or to one
-/// of [a,b] or [x,y] exclusively.
+/// of `[a,b]` or `[x,y]` exclusively.
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct Split {
     partitions: [SplitRange; 3],

--- a/collector/compile-benchmarks/regex-automata-0.4.8/src/util/determinize/state.rs
+++ b/collector/compile-benchmarks/regex-automata-0.4.8/src/util/determinize/state.rs
@@ -378,11 +378,11 @@ impl StateBuilderNFA {
 /// represent each pattern ID, in order, that this match state represents.
 ///
 /// After the pattern IDs (if any), NFA state IDs are delta encoded as
-/// varints.[1] The first NFA state ID is encoded as itself, and each
+/// varints.`[1]` The first NFA state ID is encoded as itself, and each
 /// subsequent NFA state ID is encoded as the difference between itself and the
 /// previous NFA state ID.
 ///
-/// [1] - https://developers.google.com/protocol-buffers/docs/encoding#varints
+/// `[1] - https://developers.google.com/protocol-buffers/docs/encoding#varints`
 struct Repr<'a>(&'a [u8]);
 
 impl<'a> Repr<'a> {

--- a/collector/compile-benchmarks/regex-automata-0.4.8/src/util/sparse_set.rs
+++ b/collector/compile-benchmarks/regex-automata-0.4.8/src/util/sparse_set.rs
@@ -96,7 +96,7 @@ pub(crate) struct SparseSet {
     /// Sparse maps ids to their location in dense.
     ///
     /// A state ID is in the set if and only if
-    /// sparse[id] < len && id == dense[sparse[id]].
+    /// `sparse[id] < len && id == dense[sparse[id]]`.
     ///
     /// Note that these are indices into 'dense'. It's a little weird to use
     /// StateID here, but we know our length can never exceed the bounds of

--- a/collector/compile-benchmarks/regex-automata-0.4.8/src/util/wire.rs
+++ b/collector/compile-benchmarks/regex-automata-0.4.8/src/util/wire.rs
@@ -315,7 +315,7 @@ pub(crate) fn u32s_to_pattern_ids(slice: &[u32]) -> &[PatternID] {
 /// Checks that the given slice has an alignment that matches `T`.
 ///
 /// This is useful for checking that a slice has an appropriate alignment
-/// before casting it to a &[T]. Note though that alignment is not itself
+/// before casting it to a `&[T]`. Note though that alignment is not itself
 /// sufficient to perform the cast for any `T`.
 pub(crate) fn check_alignment<T>(
     slice: &[u8],


### PR DESCRIPTION
This mode documents private and hidden items, and it was broken for this benchmark.
