### PR TITLE
Run DocJson benchmarks on production by default

### DIFF
--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -258,7 +258,13 @@ impl Profile {
 
     /// Set of default profiles that should be benchmarked for a master/try artifact.
     pub fn default_profiles() -> Vec<Self> {
-        vec![Profile::Check, Profile::Debug, Profile::Opt, Profile::Doc]
+        vec![
+            Profile::Check,
+            Profile::Debug,
+            Profile::Opt,
+            Profile::Doc,
+            Profile::DocJson,
+        ]
     }
 
     pub fn all_values() -> &'static [Self] {

--- a/site/src/job_queue/mod.rs
+++ b/site/src/job_queue/mod.rs
@@ -864,8 +864,8 @@ mod tests {
                 .unwrap()
                 .remove("foo")
                 .unwrap();
-            // runtime + rustc + 8 compile-time jobs (two x64 sets)
-            assert_eq!(jobs.len(), 10);
+            // runtime + rustc + 10 compile-time jobs (two x64 sets)
+            assert_eq!(jobs.len(), 12);
 
             Ok(ctx)
         })


### PR DESCRIPTION
As discussed on [Zulip](https://rust-lang.zulipchat.com/#narrow/channel/266220-t-rustdoc/topic/Is.20.60recursion_limit.60.20supposed.20to.20have.20cross-crate.20effects.3F), rustdoc would appreciate this, and it is quite relevant for the performance of cargo-semver-checks, but also other similar tools that started using the JSON rustdoc output recently.

Locally, it took ~200s to run all `DocJson` benchmarks with three iterations. If we divide that by ~2 (because we have two collector), it should add maybe 2-3 minutes (adding in overhead from the job queue) to each benchmark run.

I'm opening this as an experiment to see if it works fine on production, and what's the time hit. We can leave it running e.g. for a week and then evaluate if we want to keep it or not.