### PR TITLE
Add `doc-json` filter to the compare page

### DIFF
--- a/site/frontend/src/pages/compare/compile/common.ts
+++ b/site/frontend/src/pages/compare/compile/common.ts
@@ -9,6 +9,7 @@ export type CompileBenchmarkFilter = {
     debug: boolean;
     opt: boolean;
     doc: boolean;
+    docJson: boolean;
   };
   scenario: {
     full: boolean;
@@ -45,6 +46,7 @@ export const defaultCompileFilter: CompileBenchmarkFilter = {
     debug: true,
     opt: true,
     doc: true,
+    docJson: true,
   },
   scenario: {
     full: true,
@@ -126,6 +128,8 @@ export function computeCompileComparisonsWithNonRelevant(
       return filter.profile.opt;
     } else if (profile === "doc") {
       return filter.profile.doc;
+    } else if (profile === "doc-json") {
+      return filter.profile.docJson;
     } else {
       return true;
     }

--- a/site/frontend/src/pages/compare/compile/compile-page.vue
+++ b/site/frontend/src/pages/compare/compile/compile-page.vue
@@ -67,6 +67,11 @@ function loadFilterFromUrl(
       debug: getBoolOrDefault(urlParams, "debug", defaultFilter.profile.debug),
       opt: getBoolOrDefault(urlParams, "opt", defaultFilter.profile.opt),
       doc: getBoolOrDefault(urlParams, "doc", defaultFilter.profile.doc),
+      docJson: getBoolOrDefault(
+        urlParams,
+        "doc-json",
+        defaultFilter.profile.docJson
+      ),
     },
     scenario: {
       full: getBoolOrDefault(urlParams, "full", defaultFilter.scenario.full),
@@ -188,6 +193,12 @@ function storeFilterToUrl(
     "doc",
     filter.profile.doc,
     defaultFilter.profile.doc
+  );
+  storeOrResetBool(
+    urlParams,
+    "doc-json",
+    filter.profile.docJson,
+    defaultFilter.profile.docJson
   );
   storeOrResetBool(
     urlParams,

--- a/site/frontend/src/pages/compare/compile/filters.vue
+++ b/site/frontend/src/pages/compare/compile/filters.vue
@@ -119,6 +119,20 @@ const opened = createPersistedRef(PREF_FILTERS_OPENED);
                   produced by `rustdoc`.
                 </Tooltip>
               </li>
+              <li>
+                <label>
+                  <input
+                    type="checkbox"
+                    id="profile-doc-json"
+                    v-model="filter.profile.docJson"
+                  />
+                  <span class="label">doc-json</span>
+                </label>
+                <Tooltip
+                  >Documentation build that produces JSON data produced by
+                  `rustdoc`.
+                </Tooltip>
+              </li>
             </ul>
           </div>
           <div class="section section-list-wrapper">


### PR DESCRIPTION
Useful now that we run `doc-json` benchmarks by default.
