### PR TITLE
Add `*.map` files as static assets to the site.

### DIFF
--- a/site/src/resources.rs
+++ b/site/src/resources.rs
@@ -24,6 +24,8 @@ struct StaticAssets;
 #[include = "*.js"]
 #[include = "*.br"]
 #[include = "*.css"]
+// Source maps for debugging; only in debug mode since it increases binary size by ~6%
+#[cfg_attr(debug_assertions, include = "*.map")]
 struct StaticCompiledAssets;
 
 /// HTML template files that will be rendered by `tera`.


### PR DESCRIPTION
It could help debugging frontend issues (helping me a lot now).

While this could theoretically increase size or provide some excessive information (might possibly broaden attack surface? I don't really know), I think we could tell parcel not to create map files and therefore they wouldn't be bundeled. Therefore, it could be said there's no need to hide this behind an optional feature