### PR TITLE
Add support for bare rustc invocation with `--print-sysroot`

### DIFF
--- a/collector/src/bin/rustc-fake.rs
+++ b/collector/src/bin/rustc-fake.rs
@@ -439,7 +439,7 @@ fn main() {
             // ... but not if we're just getting the rustc version.
             if !args
                 .iter()
-                .any(|arg| arg == "-vV" || arg == "--print=file-names")
+                .any(|arg| arg == "-vV" || arg == "--print=file-names" || arg == "--print=sysroot")
             {
                 eprintln!("{tool:?} {args:?}");
                 eprintln!("exiting -- non-wrapped rustc");


### PR DESCRIPTION
Cargo uses a separate `rustc --print=sysroot` invocation since https://github.com/rust-lang/cargo/pull/17276, which confused `rustc-perf`.
