### PR TITLE
Temporarily fix the `serde` 4 threads benchmark

### DIFF
--- a/collector/src/compile/execute/mod.rs
+++ b/collector/src/compile/execute/mod.rs
@@ -417,12 +417,15 @@ impl<'a> CargoProcess<'a> {
 
             let mut cmd = self.base_command(self.cwd, cargo_subcommand);
             cmd.arg("-p").arg(self.get_pkgid(self.cwd)?);
-            // Whatever arguments were passed from the external environment, we only look
-            // at the config value
-            cmd.env(
-                "RUSTC_THREAD_COUNT",
-                self.frontend_threads.get().to_string(),
-            );
+
+            // FIXME: this is a hotfix for the -threads4 benchmark(s), until we finish support for
+            // parallel frontend benchmarks fully.
+            if !self.rustc_args.iter().any(|arg| arg.contains("-Zthreads")) {
+                cmd.env(
+                    "RUSTC_THREAD_COUNT",
+                    self.frontend_threads.get().to_string(),
+                );
+            }
             match self.profile {
                 Profile::Check => {
                     cmd.arg("--profile").arg("check");


### PR DESCRIPTION
This was broken in https://github.com/rust-lang/rustc-perf/pull/2491.

Found out in https://rust-lang.zulipchat.com/#narrow/channel/247081-t-compiler.2Fperformance/topic/Strange.20wall-time.20regression.20of.20serde-1.2E0.2E219-threads4/with/614825468.

Before we can setup the parallel frontend benchmarks as full first-class citizens, this should do as a hotfix.
