### PR TITLE
Create a `parse_command` function to parse rust-timer commands

### DIFF
--- a/site/src/request_handlers/github.rs
+++ b/site/src/request_handlers/github.rs
@@ -61,6 +61,8 @@ async fn handle_push(ctxt: Arc<SiteCtxt>, push: github::Push) -> ServerResult<gi
     Ok(github::Response)
 }
 
+const RUST_TIMER_PREFIX: &str = "@rust-timer";
+
 async fn handle_issue(
     ctxt: Arc<SiteCtxt>,
     issue: github::Issue,
@@ -85,7 +87,7 @@ async fn handle_issue(
         }
     }
 
-    if comment.body.contains("@rust-timer") {
+    if comment.body.contains(RUST_TIMER_PREFIX) {
         return handle_rust_timer(ctxt, &gh_client, comment, issue).await;
     }
 
@@ -221,11 +223,28 @@ async fn handle_rust_timer(
         return Ok(github::Response);
     }
 
-    if let Some(queue) = parse_queue_command(&comment.body) {
-        let msg = match queue {
-            Ok(cmd) => {
-                let conn = ctxt.conn().await;
+    match parse_command(&comment.body) {
+        Ok(RustTimerCommand::Queue(cmd)) => {
+            let conn = ctxt.conn().await;
+            let comment = record_try_benchmark_request_without_artifacts(
+                &*conn,
+                issue.number,
+                cmd.params.backends.unwrap_or(""),
+                cmd.params.profiles.unwrap_or(""),
+                cmd.params.targets.unwrap_or(""),
+            )
+            .await;
+            main_client.post_comment(issue.number, comment).await;
+        }
+        Ok(RustTimerCommand::Build(cmd)) => {
+            // requested artifacts do not exist errors
+            if let Err(error) = validate_build_command(&cmd).await {
+                main_client.post_comment(issue.number, error).await;
+                return Ok(github::Response);
+            }
 
+            {
+                let conn = ctxt.conn().await;
                 record_try_benchmark_request_without_artifacts(
                     &*conn,
                     issue.number,
@@ -233,105 +252,88 @@ async fn handle_rust_timer(
                     cmd.params.profiles.unwrap_or(""),
                     cmd.params.targets.unwrap_or(""),
                 )
+                .await;
+            }
+
+            let enqueued = match enqueue_shas(&ctxt, main_client, issue.number, iter::once(cmd.sha))
                 .await
-            }
-            Err(error) => {
-                format!("Error occurred while parsing comment: {error}")
-            }
-        };
-        main_client.post_comment(issue.number, msg).await;
-        return Ok(github::Response);
-    }
-
-    let build_cmd = if let Some(cmd) = parse_build_command(&comment.body) {
-        match cmd {
-            Ok(cmd) => cmd,
-            Err(error) => {
-                main_client
-                    .post_comment(issue.number, format!("Cannot parse build command: {error}"))
-                    .await;
-                return Ok(github::Response);
-            }
-        }
-    } else {
-        main_client
-            .post_comment(issue.number, "Could not find valid rust-timer subcommand")
-            .await;
-        return Ok(github::Response);
-    };
-
-    // requested artifacts do not exist errors
-    if let Err(error) = validate_build_command(&build_cmd).await {
-        main_client.post_comment(issue.number, error).await;
-        return Ok(github::Response);
-    }
-
-    {
-        let conn = ctxt.conn().await;
-        record_try_benchmark_request_without_artifacts(
-            &*conn,
-            issue.number,
-            build_cmd.params.backends.unwrap_or(""),
-            build_cmd.params.profiles.unwrap_or(""),
-            build_cmd.params.targets.unwrap_or(""),
-        )
-        .await;
-    }
-
-    let enqueued =
-        match enqueue_shas(&ctxt, main_client, issue.number, iter::once(build_cmd.sha)).await {
-            Ok(enqueued) => enqueued,
-            Err(error) => {
-                log::error!("Failed to enqueue SHAs on {}: {error:?}", issue.number);
+            {
+                Ok(enqueued) => enqueued,
+                Err(error) => {
+                    log::error!("Failed to enqueue SHAs on {}: {error:?}", issue.number);
+                    main_client
+                        .post_comment(
+                            issue.number,
+                            "Failed to enqueue some commit SHAs. Maybe they were already benchmarked?"
+                                .to_string(),
+                        )
+                        .await;
+                    return Ok(github::Response);
+                }
+            };
+            if enqueued.is_empty() {
                 main_client
                     .post_comment(
                         issue.number,
-                        "Failed to enqueue some commit SHAs. Maybe they were already benchmarked?"
-                            .to_string(),
+                        format!(
+                            "The commit was not enqueued, as it was probably already benchmarked: {}\n",
+                            cmd.sha
+                        ),
                     )
                     .await;
-                return Ok(github::Response);
             }
-        };
-    if enqueued.is_empty() {
-        main_client
-            .post_comment(
-                issue.number,
-                format!(
-                    "The commit was not enqueued, as it was probably already benchmarked: {}\n",
-                    build_cmd.sha
-                ),
-            )
-            .await;
+        }
+        Err(e) => {
+            main_client.post_comment(issue.number, e).await;
+            return Ok(github::Response);
+        }
     }
 
     Ok(github::Response)
 }
 
-/// Parses the first occurrence of a `@rust-timer queue <shared-args>` command
-/// in the input string.
-fn parse_queue_command(body: &str) -> Option<Result<QueueCommand<'_>, String>> {
-    get_command_lines(body, "queue").next().map(|args| {
-        let args = parse_command_arguments(args)?;
-        let params = parse_benchmark_parameters(args)?;
-        Ok(QueueCommand { params })
+fn parse_command(body: &str) -> Result<RustTimerCommand<'_>, String> {
+    let mut cmds = body.lines().filter_map(move |line| {
+        line.find(RUST_TIMER_PREFIX)
+            .map(|index| line[index + RUST_TIMER_PREFIX.len()..].trim())
+    });
+    let Some(cmd) = cmds.next() else {
+        return Err(
+            "Cannot find @rust-timer command even though `@rust-timer` is tagged".to_string(),
+        );
+    };
+    if cmds.next().is_some() {
+        return Err("Rust-timer does not support multiple concurrent perf runs on the same PR. Please submit one perf run at a time, and wait until it is finished before submitting the next".to_string());
+    }
+    let (cmd, args) = cmd.split_once(" ").unwrap_or((cmd, ""));
+    let args = args.trim();
+
+    Ok(match cmd {
+        "queue" => RustTimerCommand::Queue(parse_queue_command_args(args)?),
+        "build" => RustTimerCommand::Build(parse_build_command_args(args)?),
+        _ => return Err(format!("Unknown rust-timer command: {cmd}")),
     })
 }
 
-/// Parses an occurrence of a `@rust-timer build <shared-args>` command in the input string.
-fn parse_build_command(body: &str) -> Option<Result<BuildCommand<'_>, String>> {
-    get_command_lines(body, "build").next().map(|args| {
-        let mut iter = args.splitn(2, ' ');
-        let Some(sha) = iter.next().filter(|s| !s.is_empty() && !s.contains('=')) else {
-            return Err("Missing SHA in build command".to_string());
-        };
+/// Parses the arguments of `<params>`
+fn parse_queue_command_args(args: &str) -> Result<QueueCommand<'_>, String> {
+    let args = parse_command_arguments(args)?;
+    let params = parse_benchmark_parameters(args)?;
+    Ok(QueueCommand { params })
+}
 
-        let sha = parse_sha(sha)?;
-        let args = iter.next().unwrap_or("");
-        let args = parse_command_arguments(args)?;
-        let params = parse_benchmark_parameters(args)?;
-        Ok(BuildCommand { sha, params })
-    })
+/// Parses the arguments of `<sha> <params>`
+fn parse_build_command_args(args: &str) -> Result<BuildCommand<'_>, String> {
+    let mut iter = args.splitn(2, ' ');
+    let Some(sha) = iter.next().filter(|s| !s.is_empty() && !s.contains('=')) else {
+        return Err("Missing SHA in build command".to_string());
+    };
+
+    let sha = parse_sha(sha)?;
+    let args = iter.next().unwrap_or("");
+    let args = parse_command_arguments(args)?;
+    let params = parse_benchmark_parameters(args)?;
+    Ok(BuildCommand { sha, params })
 }
 
 fn parse_sha(sha: &str) -> Result<&str, String> {
@@ -340,17 +342,6 @@ fn parse_sha(sha: &str) -> Result<&str, String> {
         return Err(format!("Sha `{sha}` is not alphanumeric"));
     }
     Ok(sha)
-}
-
-fn get_command_lines<'a>(body: &'a str, command: &'a str) -> impl Iterator<Item = &'a str> {
-    let prefix = "@rust-timer";
-    body.lines()
-        .filter_map(move |line| {
-            line.find(prefix)
-                .map(|index| line[index + prefix.len()..].trim())
-        })
-        .filter_map(move |line| line.strip_prefix(command))
-        .map(|l| l.trim_start())
 }
 
 fn parse_benchmark_parameters<'a>(
@@ -436,6 +427,12 @@ fn parse_command_arguments(args: &str) -> Result<HashMap<&str, &str>, String> {
 }
 
 #[derive(Debug)]
+enum RustTimerCommand<'a> {
+    Queue(QueueCommand<'a>),
+    Build(BuildCommand<'a>),
+}
+
+#[derive(Debug)]
 struct QueueCommand<'a> {
     params: BenchmarkParameters<'a>,
 }
@@ -474,171 +471,163 @@ mod tests {
     use super::*;
 
     #[test]
-    fn build_command_missing() {
-        assert!(parse_build_command("").is_none());
+    fn command_missing() {
+        insta::assert_compact_debug_snapshot!(parse_command(""),
+            @r#"Err("Cannot find @rust-timer command even though `@rust-timer` is tagged")"#);
     }
 
     #[test]
-    fn build_unknown_command() {
-        assert!(parse_build_command("@rust-timer foo").is_none());
+    fn unknown_command() {
+        insta::assert_compact_debug_snapshot!(parse_command("@rust-timer foo"),
+            @r#"Err("Unknown rust-timer command: foo")"#);
     }
 
     #[test]
     fn build_command_missing_sha() {
-        insta::assert_compact_debug_snapshot!(parse_build_command("@rust-timer build"),
-            @r#"Some(Err("Missing SHA in build command"))"#);
+        insta::assert_compact_debug_snapshot!(parse_command("@rust-timer build"),
+            @r#"Err("Missing SHA in build command")"#);
     }
 
     #[test]
     fn build_command() {
-        insta::assert_compact_debug_snapshot!(parse_build_command("@rust-timer build 5832462aa1d9373b24ace96ad2c50b7a18af9952"),
-            @r#"Some(Ok(BuildCommand { sha: "5832462aa1d9373b24ace96ad2c50b7a18af9952", params: BenchmarkParameters { backends: None, profiles: None, targets: None } }))"#);
+        insta::assert_compact_debug_snapshot!(parse_command("@rust-timer build 5832462aa1d9373b24ace96ad2c50b7a18af9952"),
+            @r#"Ok(Build(BuildCommand { sha: "5832462aa1d9373b24ace96ad2c50b7a18af9952", params: BenchmarkParameters { backends: None, profiles: None, targets: None } }))"#);
     }
 
     #[test]
     fn build_command_invalid_sha() {
-        insta::assert_compact_debug_snapshot!(parse_build_command("@rust-timer build 5832462aa1d9373b24ace96ad2c50b7a18af9952/5"),
-            @r#"Some(Err("Sha `5832462aa1d9373b24ace96ad2c50b7a18af9952/5` is not alphanumeric"))"#);
+        insta::assert_compact_debug_snapshot!(parse_command("@rust-timer build 5832462aa1d9373b24ace96ad2c50b7a18af9952/5"),
+            @r#"Err("Sha `5832462aa1d9373b24ace96ad2c50b7a18af9952/5` is not alphanumeric")"#);
     }
 
     #[test]
     fn build_command_multiple() {
-        insta::assert_compact_debug_snapshot!(parse_build_command(r#"
+        insta::assert_compact_debug_snapshot!(parse_command(r#"
 @rust-timer build 5832462aa1d9373b24ace96ad2c50b7a18af9952
 @rust-timer build 23936af287657fa4148aeab40cc2a780810fae52
 "#),
-            @r#"Some(Ok(BuildCommand { sha: "5832462aa1d9373b24ace96ad2c50b7a18af9952", params: BenchmarkParameters { backends: None, profiles: None, targets: None } }))"#);
+            @r#"Err("Rust-timer does not support multiple concurrent perf runs on the same PR. Please submit one perf run at a time, and wait until it is finished before submitting the next")"#);
     }
 
     #[test]
     fn build_command_unknown_arg() {
-        insta::assert_compact_debug_snapshot!(parse_build_command("@rust-timer build foo=bar"),
-            @r#"Some(Err("Missing SHA in build command"))"#);
+        insta::assert_compact_debug_snapshot!(parse_command("@rust-timer build foo=bar"),
+            @r#"Err("Missing SHA in build command")"#);
     }
 
     #[test]
     fn build_command_link() {
-        insta::assert_compact_debug_snapshot!(parse_build_command(r#"
+        insta::assert_compact_debug_snapshot!(parse_command(r#"
 @rust-timer build https://github.com/rust-lang/rust/commit/323f521bc6d8f2b966ba7838a3f3ee364e760b7e"#),
-            @r#"Some(Ok(BuildCommand { sha: "323f521bc6d8f2b966ba7838a3f3ee364e760b7e", params: BenchmarkParameters { backends: None, profiles: None, targets: None } }))"#);
-    }
-
-    #[test]
-    fn queue_command_missing() {
-        assert!(parse_queue_command("").is_none());
-    }
-
-    #[test]
-    fn queue_unknown_command() {
-        assert!(parse_queue_command("@rust-timer foo").is_none());
+            @r#"Ok(Build(BuildCommand { sha: "323f521bc6d8f2b966ba7838a3f3ee364e760b7e", params: BenchmarkParameters { backends: None, profiles: None, targets: None } }))"#);
     }
 
     #[test]
     fn queue_command() {
-        insta::assert_compact_debug_snapshot!(parse_queue_command("@rust-timer queue"),
-            @"Some(Ok(QueueCommand { params: BenchmarkParameters { backends: None, profiles: None, targets: None } }))");
+        insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue"),
+            @"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: None, profiles: None, targets: None } }))");
     }
 
     #[test]
     fn queue_command_unknown_arg() {
-        insta::assert_compact_debug_snapshot!(parse_queue_command("@rust-timer queue foo=bar"),
-            @r###"Some(Err("Unknown command argument(s) `foo`"))"###);
+        insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue foo=bar"),
+            @r###"Err("Unknown command argument(s) `foo`")"###);
     }
 
     #[test]
     fn queue_command_duplicate_arg() {
-        insta::assert_compact_debug_snapshot!(parse_queue_command("@rust-timer queue backends=a targets=c backends=b"),
-            @r#"Some(Err("Duplicate command argument `backends`"))"#);
+        insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue backends=a targets=c backends=b"),
+            @r#"Err("Duplicate command argument `backends`")"#);
     }
 
     #[test]
     fn queue_command_argument_spaces() {
-        insta::assert_compact_debug_snapshot!(parse_queue_command("@rust-timer queue backends  =  llvm"),
-            @r#"Some(Err("Invalid command argument `backends` (there may be no spaces around the `=` character)"))"#);
+        insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue backends  =  llvm"),
+            @r#"Err("Invalid command argument `backends` (there may be no spaces around the `=` character)")"#);
     }
 
     #[test]
     fn queue_command_spaces() {
-        insta::assert_compact_debug_snapshot!(parse_queue_command("@rust-timer     queue     backends=llvm   "),
-            @r#"Some(Ok(QueueCommand { params: BenchmarkParameters { backends: Some("llvm"), profiles: None, targets: None } }))"#);
+        insta::assert_compact_debug_snapshot!(parse_command("@rust-timer     queue     backends=llvm   "),
+            @r#"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: Some("llvm"), profiles: None, targets: None } }))"#);
     }
 
     #[test]
     fn queue_command_with_bors() {
-        insta::assert_compact_debug_snapshot!(parse_queue_command("@bors try @rust-timer queue backends=llvm"),
-            @r#"Some(Ok(QueueCommand { params: BenchmarkParameters { backends: Some("llvm"), profiles: None, targets: None } }))"#);
+        insta::assert_compact_debug_snapshot!(parse_command("@bors try @rust-timer queue backends=llvm"),
+            @r#"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: Some("llvm"), profiles: None, targets: None } }))"#);
     }
 
     #[test]
     fn queue_command_parameter_order() {
-        insta::assert_compact_debug_snapshot!(parse_queue_command("@rust-timer queue profiles=Doc backends=llvm"),
-            @r#"Some(Ok(QueueCommand { params: BenchmarkParameters { backends: Some("llvm"), profiles: Some("Doc"), targets: None } }))"#);
+        insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue profiles=Doc backends=llvm"),
+            @r#"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: Some("llvm"), profiles: Some("Doc"), targets: None } }))"#);
     }
 
     #[test]
     fn queue_command_multiline() {
-        insta::assert_compact_debug_snapshot!(parse_queue_command(r#"Ok, this looks good now.
+        insta::assert_compact_debug_snapshot!(parse_command(r#"Ok, this looks good now.
 Let's do a perf run quickly and then we can merge it.
 
 @bors try @rust-timer queue
 
 Otherwise LGTM."#),
-            @"Some(Ok(QueueCommand { params: BenchmarkParameters { backends: None, profiles: None, targets: None } }))");
+            @"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: None, profiles: None, targets: None } }))");
     }
 
     #[test]
     fn build_command_with_backends() {
-        insta::assert_compact_debug_snapshot!(parse_build_command(r#"@rust-timer build 5832462aa1d9373b24ace96ad2c50b7a18af995G"#),
-            @r#"Some(Ok(BuildCommand { sha: "5832462aa1d9373b24ace96ad2c50b7a18af995G", params: BenchmarkParameters { backends: None, profiles: None, targets: None } }))"#);
-        insta::assert_compact_debug_snapshot!(parse_build_command(r#"@rust-timer build 5832462aa1d9373b24ace96ad2c50b7a18af995A backends=Llvm"#),
-            @r#"Some(Ok(BuildCommand { sha: "5832462aa1d9373b24ace96ad2c50b7a18af995A", params: BenchmarkParameters { backends: Some("Llvm"), profiles: None, targets: None } }))"#);
-        insta::assert_compact_debug_snapshot!(parse_build_command(r#"@rust-timer build 23936af287657fa4148aeab40cc2a780810fae5B backends=Cranelift"#),
-            @r#"Some(Ok(BuildCommand { sha: "23936af287657fa4148aeab40cc2a780810fae5B", params: BenchmarkParameters { backends: Some("Cranelift"), profiles: None, targets: None } }))"#);
-        insta::assert_compact_debug_snapshot!(parse_build_command(r#"@rust-timer build 23936af287657fa4148aeab40cc2a780810fae5C backends=Cranelift,Llvm"#),
-            @r#"Some(Ok(BuildCommand { sha: "23936af287657fa4148aeab40cc2a780810fae5C", params: BenchmarkParameters { backends: Some("Cranelift,Llvm"), profiles: None, targets: None } }))"#);
+        insta::assert_compact_debug_snapshot!(parse_command(r#"@rust-timer build 5832462aa1d9373b24ace96ad2c50b7a18af995G"#),
+            @r#"Ok(Build(BuildCommand { sha: "5832462aa1d9373b24ace96ad2c50b7a18af995G", params: BenchmarkParameters { backends: None, profiles: None, targets: None } }))"#);
+        insta::assert_compact_debug_snapshot!(parse_command(r#"@rust-timer build 5832462aa1d9373b24ace96ad2c50b7a18af995A backends=Llvm"#),
+            @r#"Ok(Build(BuildCommand { sha: "5832462aa1d9373b24ace96ad2c50b7a18af995A", params: BenchmarkParameters { backends: Some("Llvm"), profiles: None, targets: None } }))"#);
+        insta::assert_compact_debug_snapshot!(parse_command(r#"@rust-timer build 23936af287657fa4148aeab40cc2a780810fae5B backends=Cranelift"#),
+            @r#"Ok(Build(BuildCommand { sha: "23936af287657fa4148aeab40cc2a780810fae5B", params: BenchmarkParameters { backends: Some("Cranelift"), profiles: None, targets: None } }))"#);
+        insta::assert_compact_debug_snapshot!(parse_command(r#"@rust-timer build 23936af287657fa4148aeab40cc2a780810fae5C backends=Cranelift,Llvm"#),
+            @r#"Ok(Build(BuildCommand { sha: "23936af287657fa4148aeab40cc2a780810fae5C", params: BenchmarkParameters { backends: Some("Cranelift,Llvm"), profiles: None, targets: None } }))"#);
     }
 
     #[test]
     fn queue_command_with_backends() {
-        insta::assert_compact_debug_snapshot!(parse_queue_command("@rust-timer queue backends=Llvm"),
-            @r#"Some(Ok(QueueCommand { params: BenchmarkParameters { backends: Some("Llvm"), profiles: None, targets: None } }))"#);
-        insta::assert_compact_debug_snapshot!(parse_queue_command("@rust-timer queue backends=Cranelift"),
-            @r#"Some(Ok(QueueCommand { params: BenchmarkParameters { backends: Some("Cranelift"), profiles: None, targets: None } }))"#);
-        insta::assert_compact_debug_snapshot!(parse_queue_command("@rust-timer queue backends=Cranelift,Llvm"),
-            @r#"Some(Ok(QueueCommand { params: BenchmarkParameters { backends: Some("Cranelift,Llvm"), profiles: None, targets: None } }))"#);
-        insta::assert_compact_debug_snapshot!(parse_queue_command("@rust-timer queue"),
-            @"Some(Ok(QueueCommand { params: BenchmarkParameters { backends: None, profiles: None, targets: None } }))");
+        insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue backends=Llvm"),
+            @r#"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: Some("Llvm"), profiles: None, targets: None } }))"#);
+        insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue backends=Cranelift"),
+            @r#"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: Some("Cranelift"), profiles: None, targets: None } }))"#);
+        insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue backends=Cranelift,Llvm"),
+            @r#"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: Some("Cranelift,Llvm"), profiles: None, targets: None } }))"#);
+        insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue"),
+            @"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: None, profiles: None, targets: None } }))");
     }
 
     #[test]
     fn queue_command_with_profiles() {
-        insta::assert_compact_debug_snapshot!(parse_queue_command("@rust-timer queue profiles=Doc"),
-            @r#"Some(Ok(QueueCommand { params: BenchmarkParameters { backends: None, profiles: Some("Doc"), targets: None } }))"#);
-        insta::assert_compact_debug_snapshot!(parse_queue_command("@rust-timer queue profiles=Check,Clippy"),
-            @r#"Some(Ok(QueueCommand { params: BenchmarkParameters { backends: None, profiles: Some("Check,Clippy"), targets: None } }))"#);
-        insta::assert_compact_debug_snapshot!(parse_queue_command("@rust-timer queue profiles=Doc,Clippy,Opt backends=Cranelift,Llvm"),
-            @r#"Some(Ok(QueueCommand { params: BenchmarkParameters { backends: Some("Cranelift,Llvm"), profiles: Some("Doc,Clippy,Opt"), targets: None } }))"#);
-        insta::assert_compact_debug_snapshot!(parse_queue_command("@rust-timer queue profiles=Foo"),
-            @r#"Some(Err("Cannot parse profiles: Invalid profile: Foo. Valid values are: check, debug, opt, doc, doc-json, clippy"))"#);
-        insta::assert_compact_debug_snapshot!(parse_queue_command("@rust-timer queue profiles=check"),
-            @r#"Some(Ok(QueueCommand { params: BenchmarkParameters { backends: None, profiles: Some("check"), targets: None } }))"#);
+        insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue profiles=Doc"),
+            @r#"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: None, profiles: Some("Doc"), targets: None } }))"#);
+        insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue profiles=Check,Clippy"),
+            @r#"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: None, profiles: Some("Check,Clippy"), targets: None } }))"#);
+        insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue profiles=Doc,Clippy,Opt backends=Cranelift,Llvm"),
+            @r#"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: Some("Cranelift,Llvm"), profiles: Some("Doc,Clippy,Opt"), targets: None } }))"#);
+        insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue profiles=Foo"),
+            @r#"Err("Cannot parse profiles: Invalid profile: Foo. Valid values are: check, debug, opt, doc, doc-json, clippy")"#);
+        insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue profiles=check"),
+            @r#"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: None, profiles: Some("check"), targets: None } }))"#);
     }
 
     #[test]
     fn queue_command_with_targets() {
-        insta::assert_compact_debug_snapshot!(parse_queue_command("@rust-timer queue targets=x86_64-unknown-linux-gnu"),
-            @r#"Some(Ok(QueueCommand { params: BenchmarkParameters { backends: None, profiles: None, targets: Some("x86_64-unknown-linux-gnu") } }))"#);
-        insta::assert_compact_debug_snapshot!(parse_queue_command("@rust-timer queue targets=x86_64-unknown-linux-gnu,67-unknown-none"),
-            @r#"Some(Err("Cannot parse targets: Only primary targets can be specified. Valid values are: x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu"))"#);
+        insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue targets=x86_64-unknown-linux-gnu"),
+            @r#"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: None, profiles: None, targets: Some("x86_64-unknown-linux-gnu") } }))"#);
+        insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue targets=x86_64-unknown-linux-gnu,67-unknown-none"),
+            @r#"Err("Cannot parse targets: Only primary targets can be specified. Valid values are: x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu")"#);
     }
 
     #[test]
     fn no_empty_arguments_thank_you() {
-        insta::assert_compact_debug_snapshot!(parse_queue_command("@rust-timer queue backends="),
-            @"Some(Ok(QueueCommand { params: BenchmarkParameters { backends: None, profiles: None, targets: None } }))");
-        insta::assert_compact_debug_snapshot!(parse_queue_command("@rust-timer queue targets="),
-            @"Some(Ok(QueueCommand { params: BenchmarkParameters { backends: None, profiles: None, targets: None } }))");
-        insta::assert_compact_debug_snapshot!(parse_queue_command("@rust-timer queue profiles="),
-            @"Some(Ok(QueueCommand { params: BenchmarkParameters { backends: None, profiles: None, targets: None } }))");
+        insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue backends="),
+            @"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: None, profiles: None, targets: None } }))");
+        insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue targets="),
+            @"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: None, profiles: None, targets: None } }))");
+        insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue profiles="),
+            @"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: None, profiles: None, targets: None } }))");
     }
 }


### PR DESCRIPTION
This separates the parsing code from the logic and makes the tests cover more of the parsing logic.
This is the last refactor to this file for now before I will add new things to it.

I would again recommend enabling "Hide whitespace" while reviewing

r? @Kobzol 