### PR TITLE
fix operator in renovate configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,7 +15,7 @@
     // Disable individual PRs for breaking changes
     {
       "matchCategories": ["rust", "js"],
-      "matchJsonata": ["isBreaking == true"],
+      "matchJsonata": ["isBreaking = true"],
       "enabled": false
     },
     {


### PR DESCRIPTION
there is an error in the renovate dashboard:
<img width="1934" height="452" alt="image" src="https://github.com/user-attachments/assets/4d8e97bd-2fbf-42af-9e14-cab17ada5b5e" />

You can see from the [docs](https://docs.renovatebot.com/configuration-options/#packagerulesmatchjsonata) that we should use `=` here for equality.