### PR TITLE
[WIP] Parallel frontend display for the site

### DIFF
--- a/replacer/deno.json
+++ b/replacer/deno.json
@@ -1,0 +1,13 @@
+{
+  "tasks": {
+    "dev": "deno run --watch --allow-net main.ts"
+  },
+  "imports": {
+    "@ast-grep/napi": "npm:@ast-grep/napi@^0.44.1",
+    "@std/assert": "jsr:@std/assert",
+    "@std/fs": "jsr:@std/fs@^1.0.24",
+    "@std/path": "jsr:@std/path@^1.1.6",
+    "cmd-ts": "npm:cmd-ts@^0.15.0",
+    "ts-pattern": "npm:ts-pattern@^5.9.0"
+  }
+}

--- a/replacer/deno.lock
+++ b/replacer/deno.lock
@@ -1,0 +1,145 @@
+{
+  "version": "5",
+  "specifiers": {
+    "jsr:@std/assert@*": "1.0.19",
+    "jsr:@std/fs@^1.0.24": "1.0.24",
+    "jsr:@std/internal@^1.0.12": "1.0.14",
+    "jsr:@std/internal@^1.0.14": "1.0.14",
+    "jsr:@std/path@^1.1.5": "1.1.6",
+    "jsr:@std/path@^1.1.6": "1.1.6",
+    "npm:@ast-grep/napi@~0.44.1": "0.44.1",
+    "npm:cmd-ts@0.15": "0.15.0",
+    "npm:ts-pattern@^5.9.0": "5.9.0"
+  },
+  "jsr": {
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.12"
+      ]
+    },
+    "@std/fs@1.0.24": {
+      "integrity": "f3061b45b81673a2bece689da041df32d174be064c89eb6397fb5718d3fb7877",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.14",
+        "jsr:@std/path@^1.1.5"
+      ]
+    },
+    "@std/internal@1.0.14": {
+      "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
+    },
+    "@std/path@1.1.6": {
+      "integrity": "c68485c2a4dfbb5ae3cc74fae4e8c4e5d874cf8a8ed12927917235c758b46cbe",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.14"
+      ]
+    }
+  },
+  "npm": {
+    "@ast-grep/napi-darwin-arm64@0.44.1": {
+      "integrity": "sha512-JPcb1PvOkwKgccGbBgtoc4e6qfx/luvAtlc6SEtNPhvSwV8qagLb9MCSDcCiuqrqICx3qHj2CXouGbs66lCFvA==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "@ast-grep/napi-darwin-x64@0.44.1": {
+      "integrity": "sha512-TZj9CnCoe30mj2Nri/mMDORgkp1nkeCiw03CIRPOaUqNOvCNyMWLQhxwGJcG1KpY9MuTZsbLcQ3jju0fXZJjwQ==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "@ast-grep/napi-linux-arm64-gnu@0.44.1": {
+      "integrity": "sha512-tw/7ruKolNcy97tDf/24Arb8wo/Ho2FRHk98lrmYQZZr18fFaiYjRXTCJTizOsdo6wL/asht4Rpdo/eRPuDhVw==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@ast-grep/napi-linux-arm64-musl@0.44.1": {
+      "integrity": "sha512-IJlY4GnuDqABa40xMvJp62nEQWYmk6wXtZc2sbPiQoemxAPG6X2m+eWwYpE9heAQOe6iNkXsILNH8YZHRTYayA==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@ast-grep/napi-linux-x64-gnu@0.44.1": {
+      "integrity": "sha512-6YyLrXn0RcKCS/FpqAFVWWtbGNFYia5tNI6mX1PqVQPCMT5EojHDXpW2/eo6uV/BnGCsVpTocAWSpac6tACa6g==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@ast-grep/napi-linux-x64-musl@0.44.1": {
+      "integrity": "sha512-P8ze2Srap/4RsxbrzMy/NSvkRfLwNfvfoEbwBqS/q199t3wVkpS2gT13QkANrgU+RLUgAIawnFBpjbm5XinIuQ==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@ast-grep/napi-win32-arm64-msvc@0.44.1": {
+      "integrity": "sha512-ty5fItgu6aTDJg1fVkWwx0qboB5pFsyjRHSgi5uqXFzLbno1vOKog1pMzu3xcKcLqMiNI0axML+HdFOqSFQz0w==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
+    },
+    "@ast-grep/napi-win32-ia32-msvc@0.44.1": {
+      "integrity": "sha512-1wTv2MrQLygnaZhlgH8aYpOkHW051CwWWowTr2AFGkn+2PMfsTTG4SEWcZArOIKlAGdWAvvlut66tLyzKhAFyw==",
+      "os": ["win32"],
+      "cpu": ["ia32"]
+    },
+    "@ast-grep/napi-win32-x64-msvc@0.44.1": {
+      "integrity": "sha512-U8CK5JaH8YUezTJnyk97I3C5Twh9gKDB/Q3KztQdOZGeoYqthnQzM4Ntvlz8aWaVSssn7OyGMr3O8ZoK0W8aJg==",
+      "os": ["win32"],
+      "cpu": ["x64"]
+    },
+    "@ast-grep/napi@0.44.1": {
+      "integrity": "sha512-dJAJVYRKmUjXn+4mXUgfRvMrWujB9mLzPSq/2e8J7n6Hn3dY4jpZNpChj6hMi7PlZ2J2c7coAVoDBaax06uvXw==",
+      "optionalDependencies": [
+        "@ast-grep/napi-darwin-arm64",
+        "@ast-grep/napi-darwin-x64",
+        "@ast-grep/napi-linux-arm64-gnu",
+        "@ast-grep/napi-linux-arm64-musl",
+        "@ast-grep/napi-linux-x64-gnu",
+        "@ast-grep/napi-linux-x64-musl",
+        "@ast-grep/napi-win32-arm64-msvc",
+        "@ast-grep/napi-win32-ia32-msvc",
+        "@ast-grep/napi-win32-x64-msvc"
+      ]
+    },
+    "ansi-regex@6.2.2": {
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="
+    },
+    "chalk@5.6.2": {
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="
+    },
+    "cmd-ts@0.15.0": {
+      "integrity": "sha512-ASyAx+P6DNzNEZ6OYmvjjaLAQeI3L+4lm5rX2Jg8tondXdj06o9JTxi9mfC92KoVbrVFKhZ+j2TfBF8fcura6g==",
+      "dependencies": [
+        "chalk",
+        "debug",
+        "didyoumean",
+        "strip-ansi"
+      ]
+    },
+    "debug@4.4.3": {
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dependencies": [
+        "ms"
+      ]
+    },
+    "didyoumean@1.2.2": {
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="
+    },
+    "ms@2.1.3": {
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "strip-ansi@7.2.0": {
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dependencies": [
+        "ansi-regex"
+      ]
+    },
+    "ts-pattern@5.9.0": {
+      "integrity": "sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg=="
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@std/assert@*",
+      "jsr:@std/fs@^1.0.24",
+      "jsr:@std/path@^1.1.6",
+      "npm:@ast-grep/napi@~0.44.1",
+      "npm:cmd-ts@0.15",
+      "npm:ts-pattern@^5.9.0"
+    ]
+  }
+}

--- a/replacer/main.ts
+++ b/replacer/main.ts
@@ -1,0 +1,257 @@
+import {
+  registerDynamicLanguage,
+  parse,
+  SgNode,
+  NapiConfig,
+} from "@ast-grep/napi";
+import path from "node:path";
+import * as child_process from "node:child_process";
+import * as util from "node:util";
+import {match, P} from "ts-pattern";
+import * as cmd_ts from "cmd-ts";
+
+const exec = util.promisify(child_process.exec);
+
+// const rootDir = path.normalize("../");
+const rootDir = process.env["DIRENV_DIR"]?.slice(1) || path.normalize("../");
+
+const targetDir = path.join(rootDir, "site/frontend");
+
+function replaceMatchedNode(node: SgNode): string {
+  const srcText = node.text();
+
+  const matchPar = /^par_?(\d)?$/i.exec(srcText);
+  if (matchPar) {
+    const digit = matchPar[1];
+    if (digit != null) {
+      return `threads_${digit}`;
+    } else {
+      return `threads`;
+    }
+  }
+
+  const matchParallel = /^(P|p)arallel(s)?$/.exec(srcText);
+  if (matchParallel) {
+    const result = match([matchParallel[1], matchParallel[2]])
+      .with(["P", "s"], () => {
+        return "FrontendThreadsCounts";
+      })
+      .with(["p", "s"], () => {
+        return "frontendThreadsCounts";
+      })
+      .with(["P", P._], () => {
+        return "FrontendThreads";
+      })
+      .with([P._, P._], () => {
+        return "frontendThreads";
+      })
+      .exhaustive();
+    return result;
+  }
+
+  return srcText;
+}
+
+function performSubstitutionOfParallelOnTS(src: string): string {
+  const root = parse("typescript", src).root();
+
+  const generalMatch: NapiConfig = {
+    rule: {
+      any: [
+        {kind: "property_identifier"},
+        {kind: "identifier"},
+        {kind: "string_fragment"},
+      ],
+      regex: String.raw`(?i)^par(\d|allel)?s?$`,
+    },
+  };
+
+  const matches = root.findAll(generalMatch);
+  const edits = matches.map((n) => n.replace(replaceMatchedNode(n)));
+  const newSrc = root.commitEdits(edits);
+
+  return newSrc;
+}
+
+function performSingleSubstitutionOnVueByInjectionIdx(
+  vueText: string,
+  injectionIdx: number,
+): {
+  result: string;
+  changed: boolean;
+} {
+  const vueRoot = parse("vue", vueText).root();
+
+  const tsSearchRule: NapiConfig = {
+    rule: {
+      any: [
+        {
+          all: [
+            {
+              pattern: {
+                context: "<script $$$>$CONTENT</script>",
+                selector: "script_element",
+              },
+            },
+            {
+              has: {kind: "raw_text"},
+            },
+          ],
+        },
+        {
+          all: [
+            {
+              pattern: {
+                context: "{{$CONTENT}}",
+                selector: "interpolation",
+              },
+            },
+            {
+              has: {kind: "raw_text"},
+            },
+          ],
+        },
+      ],
+    },
+  };
+
+  const scriptNodes = vueRoot.findAll(tsSearchRule);
+
+  if (scriptNodes.length <= injectionIdx) {
+    return {result: vueText, changed: false};
+  }
+  const tsScriptNode = scriptNodes[injectionIdx].getMatch("CONTENT")!;
+  const {start, end} = tsScriptNode.range();
+
+  const newScriptText = performSubstitutionOfParallelOnTS(tsScriptNode.text());
+  const newVueText =
+    vueText.slice(0, start.index + 1) +
+    newScriptText +
+    vueText.slice(end.index);
+  return {result: newVueText, changed: true};
+}
+
+function performAllSubstitutionsOnVue(vueText: string): string {
+  let newVueText = vueText;
+  let changed = true;
+
+  for (let injectionIdx = 0; changed; injectionIdx++) {
+    const {result: newVueText_, changed: changed_} =
+      performSingleSubstitutionOnVueByInjectionIdx(newVueText, injectionIdx);
+    changed = changed_;
+    newVueText = newVueText_;
+  }
+  return newVueText;
+}
+
+async function performAllSubstitutionsOnAnyFile(
+  filename: string,
+): Promise<string> {
+  const fileContents = await Deno.readTextFile(filename);
+  const ext = path.extname(filename);
+  switch (ext) {
+    case ".vue":
+      return performAllSubstitutionsOnVue(fileContents);
+    case ".ts":
+      return performSubstitutionOfParallelOnTS(fileContents);
+    default:
+      throw new EvalError(`unknown extension: '${ext}'`);
+  }
+}
+
+async function getAllFilesWithExtensionInIndex(): Promise<string[]> {
+  const possibleFiles: string[] = await (async () => {
+    const {stdout, stderr} = await exec(`git ls-files ${targetDir}`);
+    if (stderr != "") {
+      console.error(stderr);
+    }
+    return stdout.split("\n").filter((x) => x.trim().length != 0);
+  })();
+  const filesMatching = possibleFiles.filter((x) => {
+    return [".ts", ".vue"].includes(path.extname(x));
+  });
+
+  return filesMatching;
+}
+
+function gitDiffContents(file: string, newContents: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = child_process.spawn("git", [
+      "--no-pager",
+      "diff",
+      "--no-index",
+      "--color=always",
+      "--",
+      file,
+      "-",
+    ]);
+
+    let out = "";
+    let err = "";
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+
+    child.stdout.on("data", (c) => (out += c));
+    child.stderr.on("data", (c) => (err += c));
+    child.on("error", reject);
+
+    child.on("close", (code) => {
+      if (code === 0 || code === 1) {
+        console.log(out);
+        resolve(out);
+      } else reject(new Error(err || `git exited with ${code}`));
+    });
+
+    child.stdin.end(newContents);
+  });
+}
+
+async function main(action: "diff" | "apply") {
+  // const argv = yargs(hideBin(process.argv)).parse();
+  registerDynamicLanguage({
+    vue: {
+      libraryPath: "/home/heinwol/temp/tree-sitter/vue.so",
+      extensions: ["vue"],
+      languageSymbol: "tree_sitter_vue",
+    },
+  });
+
+  const filesMatching = await getAllFilesWithExtensionInIndex();
+
+  for (const file of filesMatching) {
+    const newContents = await performAllSubstitutionsOnAnyFile(file);
+    switch (action) {
+      case "diff":
+        await gitDiffContents(file, newContents);
+        break;
+      case "apply":
+        await Deno.writeTextFile(file, newContents);
+        break;
+    }
+  }
+}
+
+async function doRun() {
+  const app = cmd_ts.command({
+    name: "substitute-with-ast-grep",
+    args: {
+      // someArg: cmd_ts.positional({
+      //   type: cmd_ts.string,
+      //   displayName: "some arg",
+      // }),
+      action: cmd_ts.positional({
+        type: cmd_ts.oneOf(["diff", "apply"]),
+        displayName: "action",
+      }),
+    },
+    handler: async ({action}) => {
+      // console.log({someArg});
+      await main(action);
+    },
+  });
+
+  await cmd_ts.run(app, process.argv.slice(2));
+}
+
+await doRun();

--- a/replacer/main_test.ts
+++ b/replacer/main_test.ts
@@ -1,0 +1,16 @@
+// import { assertEquals } from "@std/assert";
+// import { handler } from "./main.ts";
+
+// Deno.test("returns html on /", async () => {
+//   const res = handler(new Request("http://localhost/"));
+//   assertEquals(res.headers.get("content-type"), "text/html");
+//   const body = await res.text();
+//   assertEquals(body.includes("Welcome to Deno"), true);
+// });
+
+// Deno.test("returns json on /api", async () => {
+//   const res = handler(new Request("http://localhost/api"));
+//   const data = await res.json();
+//   assertEquals(data.message, "Hello, world!");
+//   assertEquals(typeof data.time, "string");
+// });

--- a/site/frontend/package.json
+++ b/site/frontend/package.json
@@ -30,6 +30,9 @@
     "uplot": "^1.6.24",
     "vue": "^3.2.47"
   },
+  "@parcel/resolver-default": {
+    "packageExports": true
+  },
   "targets": {
     "dashboard": {
       "source": "src/pages/dashboard.ts",

--- a/site/frontend/src/components/perfetto-link.vue
+++ b/site/frontend/src/components/perfetto-link.vue
@@ -15,6 +15,7 @@ const link = computed(() => {
     props.artifact.commit,
     `${props.testCase.benchmark}`,
     props.testCase.scenario,
+    props.testCase.parallel.toString(),
     props.testCase.profile.toLowerCase(),
     props.testCase.backend,
     props.testCase.target

--- a/site/frontend/src/components/perfetto-link.vue
+++ b/site/frontend/src/components/perfetto-link.vue
@@ -15,7 +15,7 @@ const link = computed(() => {
     props.artifact.commit,
     `${props.testCase.benchmark}`,
     props.testCase.scenario,
-    props.testCase.parallel.toString(),
+    props.testCase.frontendThreads.toString(),
     props.testCase.profile.toLowerCase(),
     props.testCase.backend,
     props.testCase.target

--- a/site/frontend/src/graph/api.ts
+++ b/site/frontend/src/graph/api.ts
@@ -12,9 +12,19 @@ export async function loadGraphs(
     stat: selector.stat,
     benchmark: selector.benchmark,
     scenario: selector.scenario,
+    parallel: selector.parallel,
     profile: selector.profile,
     backend: selector.backend,
     target: selector.target,
   };
-  return await getJson<CompileGraphData>(GRAPH_DATA_URL, params);
+  const dict: Dict<string> = Object.entries(params).reduce(
+    (acc, [key, value]) => {
+      if (value !== null && value !== undefined) {
+        acc[key] = value;
+      }
+      return acc;
+    },
+    {} as Dict<string>
+  );
+  return await getJson<CompileGraphData>(GRAPH_DATA_URL, dict);
 }

--- a/site/frontend/src/graph/api.ts
+++ b/site/frontend/src/graph/api.ts
@@ -1,12 +1,4 @@
-import {
-  Benchmarks,
-  CompileGraphData,
-  FrontendThreadsSeries,
-  GraphsSelector,
-  ProfileSeries,
-  ScenarioSeries,
-  Series,
-} from "./data";
+import {Benchmarks, CompileGraphData, GraphsSelector, Series} from "./data";
 import {getJson} from "../utils/requests";
 import {GRAPH_DATA_URL} from "../urls";
 
@@ -40,30 +32,9 @@ export async function loadGraphs(
     {} as Dict<string>
   );
   const raw = await getJson<CompileGraphDataRaw>(GRAPH_DATA_URL, dict);
-  console.debug(`raw (CompileGraphDataRaw):\n${JSON.stringify(raw, null, 2)}`);
+  // console.debug(`raw (CompileGraphDataRaw):\n${JSON.stringify(raw, null, 2)}`);
   return {
     commits: raw.commits,
-    benchmarks: new Benchmarks(
-      Object.fromEntries(
-        Object.entries(raw.benchmarks).map(([benchmark, profiles]) => [
-          benchmark,
-          new ProfileSeries(
-            Object.fromEntries(
-              Object.entries(profiles).map(([profile, scenarios]) => [
-                profile,
-                new ScenarioSeries(
-                  Object.fromEntries(
-                    Object.entries(scenarios).map(([scenario, threads]) => [
-                      scenario,
-                      new FrontendThreadsSeries(threads),
-                    ])
-                  )
-                ),
-              ])
-            )
-          ),
-        ])
-      )
-    ),
+    benchmarks: Benchmarks.fromJSON(raw.benchmarks),
   };
 }

--- a/site/frontend/src/graph/api.ts
+++ b/site/frontend/src/graph/api.ts
@@ -40,6 +40,7 @@ export async function loadGraphs(
     {} as Dict<string>
   );
   const raw = await getJson<CompileGraphDataRaw>(GRAPH_DATA_URL, dict);
+  console.debug(`raw (CompileGraphDataRaw):\n${JSON.stringify(raw, null, 2)}`);
   return {
     commits: raw.commits,
     benchmarks: new Benchmarks(

--- a/site/frontend/src/graph/api.ts
+++ b/site/frontend/src/graph/api.ts
@@ -12,7 +12,7 @@ export async function loadGraphs(
     stat: selector.stat,
     benchmark: selector.benchmark,
     scenario: selector.scenario,
-    parallel: selector.parallel,
+    frontendThreads: selector.frontendThreads,
     profile: selector.profile,
     backend: selector.backend,
     target: selector.target,

--- a/site/frontend/src/graph/api.ts
+++ b/site/frontend/src/graph/api.ts
@@ -1,4 +1,9 @@
-import {Benchmarks, CompileGraphData, GraphsSelector, Series} from "./data";
+import {
+  CompileBenchmarks,
+  CompileGraphData,
+  GraphsSelector,
+  Series,
+} from "./data";
 import {getJson} from "../utils/requests";
 import {GRAPH_DATA_URL} from "../urls";
 
@@ -34,6 +39,6 @@ export async function loadGraphs(
   const raw = await getJson<CompileGraphDataRaw>(GRAPH_DATA_URL, dict);
   return {
     commits: raw.commits,
-    benchmarks: Benchmarks.fromJSON(raw.benchmarks),
+    benchmarks: CompileBenchmarks.fromJSON(raw.benchmarks),
   };
 }

--- a/site/frontend/src/graph/api.ts
+++ b/site/frontend/src/graph/api.ts
@@ -32,7 +32,6 @@ export async function loadGraphs(
     {} as Dict<string>
   );
   const raw = await getJson<CompileGraphDataRaw>(GRAPH_DATA_URL, dict);
-  // console.debug(`raw (CompileGraphDataRaw):\n${JSON.stringify(raw, null, 2)}`);
   return {
     commits: raw.commits,
     benchmarks: Benchmarks.fromJSON(raw.benchmarks),

--- a/site/frontend/src/graph/api.ts
+++ b/site/frontend/src/graph/api.ts
@@ -1,6 +1,19 @@
-import {CompileGraphData, GraphsSelector} from "./data";
+import {
+  Benchmarks,
+  CompileGraphData,
+  FrontendThreadsSeries,
+  GraphsSelector,
+  ProfileSeries,
+  ScenarioSeries,
+  Series,
+} from "./data";
 import {getJson} from "../utils/requests";
 import {GRAPH_DATA_URL} from "../urls";
+
+interface CompileGraphDataRaw {
+  commits: Array<[number, string]>;
+  benchmarks: Dict<Dict<Dict<Dict<Series>>>>;
+}
 
 export async function loadGraphs(
   selector: GraphsSelector
@@ -26,5 +39,30 @@ export async function loadGraphs(
     },
     {} as Dict<string>
   );
-  return await getJson<CompileGraphData>(GRAPH_DATA_URL, dict);
+  const raw = await getJson<CompileGraphDataRaw>(GRAPH_DATA_URL, dict);
+  return {
+    commits: raw.commits,
+    benchmarks: new Benchmarks(
+      Object.fromEntries(
+        Object.entries(raw.benchmarks).map(([benchmark, profiles]) => [
+          benchmark,
+          new ProfileSeries(
+            Object.fromEntries(
+              Object.entries(profiles).map(([profile, scenarios]) => [
+                profile,
+                new ScenarioSeries(
+                  Object.fromEntries(
+                    Object.entries(scenarios).map(([scenario, threads]) => [
+                      scenario,
+                      new FrontendThreadsSeries(threads),
+                    ])
+                  )
+                ),
+              ])
+            )
+          ),
+        ])
+      )
+    ),
+  };
 }

--- a/site/frontend/src/graph/api.ts
+++ b/site/frontend/src/graph/api.ts
@@ -1,5 +1,5 @@
 import {
-  CompileBenchmarks,
+  CompileBenchmarkSeries,
   CompileGraphData,
   GraphsSelector,
   Series,
@@ -39,6 +39,6 @@ export async function loadGraphs(
   const raw = await getJson<CompileGraphDataRaw>(GRAPH_DATA_URL, dict);
   return {
     commits: raw.commits,
-    benchmarks: CompileBenchmarks.fromJSON(raw.benchmarks),
+    benchmarks: CompileBenchmarkSeries.fromJSON(raw.benchmarks),
   };
 }

--- a/site/frontend/src/graph/data.ts
+++ b/site/frontend/src/graph/data.ts
@@ -8,6 +8,7 @@ export interface GraphsSelector {
   stat: string;
   benchmark: string | null;
   scenario: string | null;
+  parallel: string | null;
   profile: string | null;
   backend: string | null;
   target: string | null;
@@ -21,8 +22,8 @@ export interface Series {
 // Graph data received from the server
 export interface CompileGraphData {
   commits: Array<[number, string]>;
-  // benchmark -> profile -> scenario -> series
-  benchmarks: Dict<Dict<Dict<Series>>>;
+  // benchmark -> profile -> parallel -> scenario -> series
+  benchmarks: Dict<Dict<Dict<Dict<Series>>>>;
 }
 
 export interface RuntimeGraphData {

--- a/site/frontend/src/graph/data.ts
+++ b/site/frontend/src/graph/data.ts
@@ -22,7 +22,7 @@ export interface Series {
 class DictWrapper<T> {
   constructor(public readonly data: Dict<T>) {}
 
-  get(key: string): T | undefined {
+  get(key: string): T {
     return this.data[key];
   }
 

--- a/site/frontend/src/graph/data.ts
+++ b/site/frontend/src/graph/data.ts
@@ -1,15 +1,17 @@
 import {capitalize} from "vue";
 import {mapFromJSON, MapWrapper} from "../utils/map-wrapper.ts";
 
-declare const brand: unique symbol;
-
 export type GraphKind = "raw" | "percentfromfirst" | "percentrelative";
+
+declare const brand: unique symbol;
+type Brand<T, Tag extends string> = T & {readonly [brand]: Tag};
 
 /**
  * specific key type for ProfileSeries as we have to deal with different
  * lowercased/capitalized representations depending on the use case
  */
-type ProfileKey = string & {readonly [brand]: "ProfileKey"};
+type ProfileName = Brand<string, "ProfileName">;
+
 const KNOWN_PROFILES_TO_BE_LOWERCASED = new Set([
   "Check",
   "Debug",
@@ -23,16 +25,21 @@ const KNOWN_PROFILES_TO_BE_LOWERCASED = new Set([
  * @param raw custom string
  * @returns representation is always capitalized
  */
-export function toProfileKey(raw: string): ProfileKey {
-  return capitalize(raw) as ProfileKey;
+export function toProfileKey(raw: string): ProfileName {
+  return capitalize(raw) as ProfileName;
 }
 
-export function profileKeyForGraphDisplay(profileKey: ProfileKey): string {
+export function profileKeyForGraphDisplay(profileKey: ProfileName): string {
   if (profileKey in KNOWN_PROFILES_TO_BE_LOWERCASED) {
     return profileKey.toLowerCase();
   }
   return profileKey;
 }
+
+// other keys just to be safe
+type ScenarioName = Brand<string, "ScenarioName">;
+type FrontendThreadsName = Brand<string, "FrontendThreadsName">;
+type CompileBenchmarkName = Brand<string, "CompileBenchmarkName">;
 
 // Parameters used to filter graph data
 export interface GraphsSelector {
@@ -40,10 +47,10 @@ export interface GraphsSelector {
   end: string;
   kind: GraphKind;
   stat: string;
-  benchmark: string | null;
-  scenario: string | null;
-  frontendThreads: string | null;
-  profile: string | null;
+  benchmark: CompileBenchmarkName | string | null;
+  scenario: ScenarioName | null;
+  frontendThreads: FrontendThreadsName | null;
+  profile: ProfileName | null;
   backend: string | null;
   target: string | null;
 }
@@ -53,29 +60,42 @@ export interface Series {
   interpolated_indices: Set<number>;
 }
 
-export class FrontendThreadsSeries extends MapWrapper<string, Series> {
+export class FrontendThreadsSeries extends MapWrapper<
+  FrontendThreadsName,
+  Series
+> {
   static fromJSON(json: Dict<Series>): FrontendThreadsSeries {
-    return new FrontendThreadsSeries(mapFromJSON(json, (s) => s));
-  }
-}
-
-export class ScenarioSeries extends MapWrapper<string, FrontendThreadsSeries> {
-  static fromJSON(json: Dict<Dict<Series>>): ScenarioSeries {
-    return new ScenarioSeries(
-      mapFromJSON(json, FrontendThreadsSeries.fromJSON)
+    return new FrontendThreadsSeries(
+      mapFromJSON(
+        json,
+        (k) => k as FrontendThreadsName,
+        (s) => s
+      )
     );
   }
 }
 
-export class ProfileSeries extends MapWrapper<ProfileKey, ScenarioSeries> {
+export class ScenarioSeries extends MapWrapper<
+  ScenarioName,
+  FrontendThreadsSeries
+> {
+  static fromJSON(json: Dict<Dict<Series>>): ScenarioSeries {
+    return new ScenarioSeries(
+      mapFromJSON(
+        json,
+        (k) => k as ScenarioName,
+        FrontendThreadsSeries.fromJSON
+      )
+    );
+  }
+}
+
+export class ProfileSeries extends MapWrapper<ProfileName, ScenarioSeries> {
   // here we have to convert to the proper ProfileKey representation
   static fromJSON(json: Dict<Dict<Dict<Series>>>): ProfileSeries {
-    let sourceMap = mapFromJSON(json, ScenarioSeries.fromJSON);
-    let resultMap: Map<ProfileKey, ScenarioSeries> = new Map();
-    for (const [k, v] of sourceMap.entries()) {
-      resultMap.set(toProfileKey(k), v);
-    }
-    return new ProfileSeries(resultMap);
+    return new ProfileSeries(
+      mapFromJSON(json, toProfileKey, ScenarioSeries.fromJSON)
+    );
   }
 }
 
@@ -83,9 +103,18 @@ export class ProfileSeries extends MapWrapper<ProfileKey, ScenarioSeries> {
  * benchmarks are of a fixed nested structure:
  *   - benchmark -> profile -> scenario -> frontend_threads -> series
  */
-export class CompileBenchmarks extends MapWrapper<string, ProfileSeries> {
+export class CompileBenchmarks extends MapWrapper<
+  CompileBenchmarkName,
+  ProfileSeries
+> {
   static fromJSON(json: Dict<Dict<Dict<Dict<Series>>>>): CompileBenchmarks {
-    return new CompileBenchmarks(mapFromJSON(json, ProfileSeries.fromJSON));
+    return new CompileBenchmarks(
+      mapFromJSON(
+        json,
+        (k) => k as CompileBenchmarkName,
+        ProfileSeries.fromJSON
+      )
+    );
   }
 }
 

--- a/site/frontend/src/graph/data.ts
+++ b/site/frontend/src/graph/data.ts
@@ -1,3 +1,5 @@
+import {mapFromJSON, MapWrapperE} from "../utils/map-wrapper.ts";
+
 export type GraphKind = "raw" | "percentfromfirst" | "percentrelative";
 
 // Parameters used to filter graph data
@@ -19,29 +21,34 @@ export interface Series {
   interpolated_indices: Set<number>;
 }
 
-class DictWrapper<T> {
-  constructor(public readonly data: Dict<T>) {}
-
-  get(key: string): T {
-    return this.data[key];
-  }
-
-  keys(): string[] {
-    return Object.keys(this.data);
-  }
-
-  toJSON(): Dict<T> {
-    return this.data;
+export class FrontendThreadsSeries extends MapWrapperE<Series> {
+  static fromJSON(json: Dict<Series>): FrontendThreadsSeries {
+    return new FrontendThreadsSeries(mapFromJSON(json, (s) => s));
   }
 }
 
-export class FrontendThreadsSeries extends DictWrapper<Series> {}
-export class ScenarioSeries extends DictWrapper<FrontendThreadsSeries> {}
-export class ProfileSeries extends DictWrapper<ScenarioSeries> {}
-export class Benchmarks extends DictWrapper<ProfileSeries> {}
+export class ScenarioSeries extends MapWrapperE<FrontendThreadsSeries> {
+  static fromJSON(json: Dict<Dict<Series>>): ScenarioSeries {
+    return new ScenarioSeries(
+      mapFromJSON(json, FrontendThreadsSeries.fromJSON)
+    );
+  }
+}
+
+export class ProfileSeries extends MapWrapperE<ScenarioSeries> {
+  static fromJSON(json: Dict<Dict<Dict<Series>>>): ProfileSeries {
+    return new ProfileSeries(mapFromJSON(json, ScenarioSeries.fromJSON));
+  }
+}
+
+export class Benchmarks extends MapWrapperE<ProfileSeries> {
+  static fromJSON(json: Dict<Dict<Dict<Dict<Series>>>>): Benchmarks {
+    return new Benchmarks(mapFromJSON(json, ProfileSeries.fromJSON));
+  }
+}
 
 // Graph data received from the server
-export class CompileGraphData {
+export interface CompileGraphData {
   commits: Array<[number, string]>;
   // benchmark -> profile -> parallel -> scenario -> series
   // WARNING: now uses new layout:

--- a/site/frontend/src/graph/data.ts
+++ b/site/frontend/src/graph/data.ts
@@ -1,6 +1,38 @@
+import {capitalize} from "vue";
 import {mapFromJSON, MapWrapper} from "../utils/map-wrapper.ts";
 
+declare const brand: unique symbol;
+
 export type GraphKind = "raw" | "percentfromfirst" | "percentrelative";
+
+/**
+ * specific key type for ProfileSeries as we have to deal with different
+ * lowercased/capitalized representations depending on the use case
+ */
+type ProfileKey = string & {readonly [brand]: "ProfileKey"};
+const KNOWN_PROFILES_TO_BE_LOWERCASED = new Set([
+  "Check",
+  "Debug",
+  "Opt",
+  "Doc",
+]);
+
+/**
+ * The server returns profiles capitalized, so we need to match that
+ * here, so that the graph code can find the expected profile.
+ * @param raw custom string
+ * @returns representation is always capitalized
+ */
+export function toProfileKey(raw: string): ProfileKey {
+  return capitalize(raw) as ProfileKey;
+}
+
+export function profileKeyForGraphDisplay(profileKey: ProfileKey): string {
+  if (profileKey in KNOWN_PROFILES_TO_BE_LOWERCASED) {
+    return profileKey.toLowerCase();
+  }
+  return profileKey;
+}
 
 // Parameters used to filter graph data
 export interface GraphsSelector {
@@ -21,13 +53,13 @@ export interface Series {
   interpolated_indices: Set<number>;
 }
 
-export class FrontendThreadsSeries extends MapWrapper<Series> {
+export class FrontendThreadsSeries extends MapWrapper<string, Series> {
   static fromJSON(json: Dict<Series>): FrontendThreadsSeries {
     return new FrontendThreadsSeries(mapFromJSON(json, (s) => s));
   }
 }
 
-export class ScenarioSeries extends MapWrapper<FrontendThreadsSeries> {
+export class ScenarioSeries extends MapWrapper<string, FrontendThreadsSeries> {
   static fromJSON(json: Dict<Dict<Series>>): ScenarioSeries {
     return new ScenarioSeries(
       mapFromJSON(json, FrontendThreadsSeries.fromJSON)
@@ -35,29 +67,36 @@ export class ScenarioSeries extends MapWrapper<FrontendThreadsSeries> {
   }
 }
 
-export class ProfileSeries extends MapWrapper<ScenarioSeries> {
+export class ProfileSeries extends MapWrapper<ProfileKey, ScenarioSeries> {
+  // here we have to convert to the proper ProfileKey representation
   static fromJSON(json: Dict<Dict<Dict<Series>>>): ProfileSeries {
-    return new ProfileSeries(mapFromJSON(json, ScenarioSeries.fromJSON));
+    let sourceMap = mapFromJSON(json, ScenarioSeries.fromJSON);
+    let resultMap: Map<ProfileKey, ScenarioSeries> = new Map();
+    for (const [k, v] of sourceMap.entries()) {
+      resultMap.set(toProfileKey(k), v);
+    }
+    return new ProfileSeries(resultMap);
   }
 }
 
-export class Benchmarks extends MapWrapper<ProfileSeries> {
+export class Benchmarks extends MapWrapper<string, ProfileSeries> {
   static fromJSON(json: Dict<Dict<Dict<Dict<Series>>>>): Benchmarks {
     return new Benchmarks(mapFromJSON(json, ProfileSeries.fromJSON));
   }
 }
 
-// Graph data received from the server
+/** Graph data received from the server */
 export interface CompileGraphData {
   commits: Array<[number, string]>;
-  // benchmark -> profile -> parallel -> scenario -> series
-  // WARNING: now uses new layout:
-  // benchmark -> profile -> scenario -> frontend_threads -> series
+  /**
+   * benchmarks are of a fixed nested structure:
+   *   - benchmark -> profile -> scenario -> frontend_threads -> series
+   */
   benchmarks: Benchmarks;
 }
 
 export interface RuntimeGraphData {
   commits: Array<[number, string]>;
-  // benchmark ->  series
+  /** benchmark ->  series */
   benchmarks: Dict<Series>;
 }

--- a/site/frontend/src/graph/data.ts
+++ b/site/frontend/src/graph/data.ts
@@ -79,20 +79,20 @@ export class ProfileSeries extends MapWrapper<ProfileKey, ScenarioSeries> {
   }
 }
 
-export class Benchmarks extends MapWrapper<string, ProfileSeries> {
-  static fromJSON(json: Dict<Dict<Dict<Dict<Series>>>>): Benchmarks {
-    return new Benchmarks(mapFromJSON(json, ProfileSeries.fromJSON));
+/**
+ * benchmarks are of a fixed nested structure:
+ *   - benchmark -> profile -> scenario -> frontend_threads -> series
+ */
+export class CompileBenchmarks extends MapWrapper<string, ProfileSeries> {
+  static fromJSON(json: Dict<Dict<Dict<Dict<Series>>>>): CompileBenchmarks {
+    return new CompileBenchmarks(mapFromJSON(json, ProfileSeries.fromJSON));
   }
 }
 
 /** Graph data received from the server */
 export interface CompileGraphData {
   commits: Array<[number, string]>;
-  /**
-   * benchmarks are of a fixed nested structure:
-   *   - benchmark -> profile -> scenario -> frontend_threads -> series
-   */
-  benchmarks: Benchmarks;
+  benchmarks: CompileBenchmarks;
 }
 
 export interface RuntimeGraphData {

--- a/site/frontend/src/graph/data.ts
+++ b/site/frontend/src/graph/data.ts
@@ -1,4 +1,4 @@
-import {mapFromJSON, MapWrapperE} from "../utils/map-wrapper.ts";
+import {mapFromJSON, MapWrapper} from "../utils/map-wrapper.ts";
 
 export type GraphKind = "raw" | "percentfromfirst" | "percentrelative";
 
@@ -21,13 +21,13 @@ export interface Series {
   interpolated_indices: Set<number>;
 }
 
-export class FrontendThreadsSeries extends MapWrapperE<Series> {
+export class FrontendThreadsSeries extends MapWrapper<Series> {
   static fromJSON(json: Dict<Series>): FrontendThreadsSeries {
     return new FrontendThreadsSeries(mapFromJSON(json, (s) => s));
   }
 }
 
-export class ScenarioSeries extends MapWrapperE<FrontendThreadsSeries> {
+export class ScenarioSeries extends MapWrapper<FrontendThreadsSeries> {
   static fromJSON(json: Dict<Dict<Series>>): ScenarioSeries {
     return new ScenarioSeries(
       mapFromJSON(json, FrontendThreadsSeries.fromJSON)
@@ -35,13 +35,13 @@ export class ScenarioSeries extends MapWrapperE<FrontendThreadsSeries> {
   }
 }
 
-export class ProfileSeries extends MapWrapperE<ScenarioSeries> {
+export class ProfileSeries extends MapWrapper<ScenarioSeries> {
   static fromJSON(json: Dict<Dict<Dict<Series>>>): ProfileSeries {
     return new ProfileSeries(mapFromJSON(json, ScenarioSeries.fromJSON));
   }
 }
 
-export class Benchmarks extends MapWrapperE<ProfileSeries> {
+export class Benchmarks extends MapWrapper<ProfileSeries> {
   static fromJSON(json: Dict<Dict<Dict<Dict<Series>>>>): Benchmarks {
     return new Benchmarks(mapFromJSON(json, ProfileSeries.fromJSON));
   }

--- a/site/frontend/src/graph/data.ts
+++ b/site/frontend/src/graph/data.ts
@@ -8,7 +8,7 @@ export interface GraphsSelector {
   stat: string;
   benchmark: string | null;
   scenario: string | null;
-  parallel: string | null;
+  frontendThreads: string | null;
   profile: string | null;
   backend: string | null;
   target: string | null;

--- a/site/frontend/src/graph/data.ts
+++ b/site/frontend/src/graph/data.ts
@@ -10,7 +10,7 @@ type Brand<T, Tag extends string> = T & {readonly [brand]: Tag};
  * specific key type for ProfileSeries as we have to deal with different
  * lowercased/capitalized representations depending on the use case
  */
-type ProfileName = Brand<string, "ProfileName">;
+export type Profile = Brand<string, "Profile">;
 
 const KNOWN_PROFILES_TO_BE_LOWERCASED = new Set([
   "Check",
@@ -25,21 +25,30 @@ const KNOWN_PROFILES_TO_BE_LOWERCASED = new Set([
  * @param raw custom string
  * @returns representation is always capitalized
  */
-export function toProfileKey(raw: string): ProfileName {
-  return capitalize(raw) as ProfileName;
+export function toProfile(raw: string): Profile {
+  return capitalize(raw) as Profile;
 }
 
-export function profileKeyForGraphDisplay(profileKey: ProfileName): string {
-  if (profileKey in KNOWN_PROFILES_TO_BE_LOWERCASED) {
-    return profileKey.toLowerCase();
+export function profileForGraphDisplay(profile: Profile): string {
+  if (profile in KNOWN_PROFILES_TO_BE_LOWERCASED) {
+    return profile.toLowerCase();
   }
-  return profileKey;
+  return profile;
 }
 
 // other keys just to be safe
-type ScenarioName = Brand<string, "ScenarioName">;
-type FrontendThreadsName = Brand<string, "FrontendThreadsName">;
-type CompileBenchmarkName = Brand<string, "CompileBenchmarkName">;
+export type Scenario = Brand<string, "Scenario">;
+export function toScenario(raw: string): Scenario {
+  return raw as Scenario;
+}
+export type FrontendThreads = Brand<string, "FrontendThreads">;
+export function toFrontendThreads(raw: string): FrontendThreads {
+  return raw as FrontendThreads;
+}
+export type CompileBenchmark = Brand<string, "CompileBenchmark">;
+export function toCompileBenchmark(raw: string): CompileBenchmark {
+  return raw as CompileBenchmark;
+}
 
 // Parameters used to filter graph data
 export interface GraphsSelector {
@@ -47,10 +56,10 @@ export interface GraphsSelector {
   end: string;
   kind: GraphKind;
   stat: string;
-  benchmark: CompileBenchmarkName | string | null;
-  scenario: ScenarioName | null;
-  frontendThreads: FrontendThreadsName | null;
-  profile: ProfileName | null;
+  benchmark: CompileBenchmark | string | null;
+  scenario: Scenario | null;
+  frontendThreads: FrontendThreads | null;
+  profile: Profile | null;
   backend: string | null;
   target: string | null;
 }
@@ -60,41 +69,30 @@ export interface Series {
   interpolated_indices: Set<number>;
 }
 
-export class FrontendThreadsSeries extends MapWrapper<
-  FrontendThreadsName,
-  Series
-> {
+export class FrontendThreadsSeries extends MapWrapper<FrontendThreads, Series> {
   static fromJSON(json: Dict<Series>): FrontendThreadsSeries {
     return new FrontendThreadsSeries(
-      mapFromJSON(
-        json,
-        (k) => k as FrontendThreadsName,
-        (s) => s
-      )
+      mapFromJSON(json, toFrontendThreads, (s) => s)
     );
   }
 }
 
 export class ScenarioSeries extends MapWrapper<
-  ScenarioName,
+  Scenario,
   FrontendThreadsSeries
 > {
   static fromJSON(json: Dict<Dict<Series>>): ScenarioSeries {
     return new ScenarioSeries(
-      mapFromJSON(
-        json,
-        (k) => k as ScenarioName,
-        FrontendThreadsSeries.fromJSON
-      )
+      mapFromJSON(json, toScenario, FrontendThreadsSeries.fromJSON)
     );
   }
 }
 
-export class ProfileSeries extends MapWrapper<ProfileName, ScenarioSeries> {
+export class ProfileSeries extends MapWrapper<Profile, ScenarioSeries> {
   // here we have to convert to the proper ProfileKey representation
   static fromJSON(json: Dict<Dict<Dict<Series>>>): ProfileSeries {
     return new ProfileSeries(
-      mapFromJSON(json, toProfileKey, ScenarioSeries.fromJSON)
+      mapFromJSON(json, toProfile, ScenarioSeries.fromJSON)
     );
   }
 }
@@ -103,17 +101,15 @@ export class ProfileSeries extends MapWrapper<ProfileName, ScenarioSeries> {
  * benchmarks are of a fixed nested structure:
  *   - benchmark -> profile -> scenario -> frontend_threads -> series
  */
-export class CompileBenchmarks extends MapWrapper<
-  CompileBenchmarkName,
+export class CompileBenchmarkSeries extends MapWrapper<
+  CompileBenchmark,
   ProfileSeries
 > {
-  static fromJSON(json: Dict<Dict<Dict<Dict<Series>>>>): CompileBenchmarks {
-    return new CompileBenchmarks(
-      mapFromJSON(
-        json,
-        (k) => k as CompileBenchmarkName,
-        ProfileSeries.fromJSON
-      )
+  static fromJSON(
+    json: Dict<Dict<Dict<Dict<Series>>>>
+  ): CompileBenchmarkSeries {
+    return new CompileBenchmarkSeries(
+      mapFromJSON(json, toCompileBenchmark, ProfileSeries.fromJSON)
     );
   }
 }
@@ -121,7 +117,7 @@ export class CompileBenchmarks extends MapWrapper<
 /** Graph data received from the server */
 export interface CompileGraphData {
   commits: Array<[number, string]>;
-  benchmarks: CompileBenchmarks;
+  benchmarks: CompileBenchmarkSeries;
 }
 
 export interface RuntimeGraphData {

--- a/site/frontend/src/graph/data.ts
+++ b/site/frontend/src/graph/data.ts
@@ -19,11 +19,34 @@ export interface Series {
   interpolated_indices: Set<number>;
 }
 
+class DictWrapper<T> {
+  constructor(public readonly data: Dict<T>) {}
+
+  get(key: string): T | undefined {
+    return this.data[key];
+  }
+
+  keys(): string[] {
+    return Object.keys(this.data);
+  }
+
+  toJSON(): Dict<T> {
+    return this.data;
+  }
+}
+
+export class FrontendThreadsSeries extends DictWrapper<Series> {}
+export class ScenarioSeries extends DictWrapper<FrontendThreadsSeries> {}
+export class ProfileSeries extends DictWrapper<ScenarioSeries> {}
+export class Benchmarks extends DictWrapper<ProfileSeries> {}
+
 // Graph data received from the server
-export interface CompileGraphData {
+export class CompileGraphData {
   commits: Array<[number, string]>;
   // benchmark -> profile -> parallel -> scenario -> series
-  benchmarks: Dict<Dict<Dict<Dict<Series>>>>;
+  // WARNING: now uses new layout:
+  // benchmark -> profile -> scenario -> frontend_threads -> series
+  benchmarks: Benchmarks;
 }
 
 export interface RuntimeGraphData {

--- a/site/frontend/src/graph/render.ts
+++ b/site/frontend/src/graph/render.ts
@@ -376,10 +376,14 @@ function genPlotOpts({
 
 function normalizeData(data: CompileGraphData) {
   function optInterpolated(profile) {
-    for (const scenario in profile) {
-      profile[scenario].interpolated_indices = new Set(
-        profile[scenario].interpolated_indices
-      );
+    for (const parallel in profile) {
+      let par = profile[parallel];
+      for (const scenario in par) {
+        par[scenario].interpolated_indices = new Set(
+          par[scenario].interpolated_indices
+        );
+      }
+      profile[parallel] = par;
     }
 
     return profile;
@@ -430,10 +434,7 @@ export function renderPlots(
     let i = 0;
 
     for (let profile in profiles) {
-      let scenarios = profiles[profile];
-      let scenarioNames = Object.keys(scenarios);
-      scenarioNames.sort();
-
+      let parallels = profiles[profile];
       let yAxis = selector.stat;
       let yAxisUnit = null;
 
@@ -486,23 +487,33 @@ export function renderPlots(
       let plotData = [xVals];
 
       let otherColorIdx = 0;
+      let indices = null;
 
-      for (let scenarioName of scenarioNames) {
-        let yVals = scenarios[scenarioName].points;
-        let color =
-          commonCacheStateColors[scenarioName] ||
-          otherCacheStateColors[otherColorIdx++];
+      for (let parallel in parallels) {
+        let scenarios = parallels[parallel];
+        let scenarioNames = Object.keys(scenarios);
+        scenarioNames.sort();
 
-        plotData.push(yVals);
+        for (let scenarioName of scenarioNames) {
+          let yVals = scenarios[scenarioName].points;
+          if (indices === null) {
+            indices = scenarios[scenarioName].interpolated_indices;
+          }
+          let color =
+            parallel == "1"
+              ? commonCacheStateColors[scenarioName] ||
+                otherCacheStateColors[otherColorIdx++]
+              : otherCacheStateColors[otherColorIdx++];
 
-        seriesOpts.push({
-          label: scenarioName,
-          width: devicePixelRatio,
-          stroke: color,
-        });
+          plotData.push(yVals);
+
+          seriesOpts.push({
+            label: scenarioName + "_par" + parallel,
+            width: devicePixelRatio,
+            stroke: color,
+          });
+        }
       }
-
-      let indices = scenarios[Object.keys(scenarios)[0]].interpolated_indices;
 
       let plotOpts = genPlotOpts({
         width,

--- a/site/frontend/src/graph/render.ts
+++ b/site/frontend/src/graph/render.ts
@@ -1,5 +1,10 @@
 import uPlot, {TypedArray} from "uplot";
-import {CompileGraphData, GraphsSelector, RuntimeGraphData} from "./data";
+import {
+  CompileGraphData,
+  GraphsSelector,
+  RuntimeGraphData,
+  ScenarioSeries,
+} from "./data";
 
 const commonCacheStateColors = {
   full: "#7cb5ec",
@@ -17,7 +22,7 @@ const otherCacheStateColors = [
   "#91e8e1",
 ];
 const interpolatedColor = "#fcb0f1";
-const profiles = ["Check", "Debug", "Opt", "Doc"];
+const KNOWN_PROFILES_CAMELCASE = ["Check", "Debug", "Opt", "Doc"];
 
 function tooltipPlugin({
   onclick,
@@ -390,12 +395,46 @@ function normalizeData(data: CompileGraphData) {
   }
 
   for (const name of Object.keys(data.benchmarks)) {
-    for (const profile of profiles) {
+    for (const profile of KNOWN_PROFILES_CAMELCASE) {
       if (data.benchmarks[name].hasOwnProperty(profile)) {
         data.benchmarks[name][profile.toLowerCase()] = optInterpolated(
           data.benchmarks[name][profile]
         );
         delete data.benchmarks[name][profile];
+      }
+    }
+  }
+}
+
+function normalizeData_(data: CompileGraphData) {
+  function optInterpolated(profile) {
+    for (const frontendThreads in profile) {
+      let threads = profile[frontendThreads];
+      for (const scenario in threads) {
+        threads[scenario].interpolated_indices = new Set(
+          threads[scenario].interpolated_indices
+        );
+      }
+      profile[frontendThreads] = threads;
+    }
+
+    return profile;
+  }
+
+  for (const name of data.benchmarks.keys()) {
+    for (const profileCamelCased of KNOWN_PROFILES_CAMELCASE) {
+      if (data.benchmarks.get(name).has(profileCamelCased)) {
+        let scenarios: ScenarioSeries = data.benchmarks
+          .get(name)
+          .get(profileCamelCased);
+        data.benchmarks
+          .get(name)
+          // .get(profile.toLowerCase())
+          .set(
+            profileCamelCased.toLowerCase(),
+            optInterpolated(data.benchmarks.get(name).get(profileCamelCased))
+          );
+        delete data.benchmarks[name][profileCamelCased];
       }
     }
   }
@@ -429,12 +468,12 @@ export function renderPlots(
   const benchNames = Object.keys(data.benchmarks).sort();
 
   for (const benchName of benchNames) {
-    let profiles = data.benchmarks[benchName];
+    let profiles = data.benchmarks.get(benchName);
 
     let i = 0;
 
-    for (let profile in profiles) {
-      let frontendThreadsCounts = profiles[profile];
+    for (let [profileName, scenario] of profiles.entries()) {
+      // let frontendThreadsCounts = profiles[profile];
       let yAxis = selector.stat;
       let yAxisUnit = null;
 
@@ -489,15 +528,14 @@ export function renderPlots(
       let otherColorIdx = 0;
       let indices = null;
 
-      for (let frontendThreads in frontendThreadsCounts) {
-        let scenarios = frontendThreadsCounts[frontendThreads];
-        let scenarioNames = Object.keys(scenarios);
-        scenarioNames.sort();
-
-        for (let scenarioName of scenarioNames) {
-          let yVals = scenarios[scenarioName].points;
+      let scenarioNames = Array.from(profiles.keys());
+      scenarioNames.sort();
+      for (let scenarioName of scenarioNames) {
+        let frontendThreadsCounts = scenario.get(scenarioName);
+        for (let [frontendThreads, series] of frontendThreadsCounts.entries()) {
+          let yVals = series.points;
           if (indices === null) {
-            indices = scenarios[scenarioName].interpolated_indices;
+            indices = series.interpolated_indices;
           }
           let color =
             frontendThreads == "1"
@@ -528,11 +566,12 @@ export function renderPlots(
         absoluteMode: selector.kind == "raw",
         hooks,
       });
+      const profileNameToRender = profileKeyToLowercase(profileName);
       if (renderTitle) {
-        plotOpts["title"] = `${benchName}-${profile}`;
+        plotOpts["title"] = `${benchName}-${profileNameToRender}`;
       }
 
-      new uPlot(plotOpts, plotData as any as TypedArray[], plotElement);
+      new uPlot(plotOpts, plotData as unknown as TypedArray[], plotElement);
 
       i++;
     }

--- a/site/frontend/src/graph/render.ts
+++ b/site/frontend/src/graph/render.ts
@@ -508,7 +508,7 @@ export function renderPlots(
           plotData.push(yVals);
 
           seriesOpts.push({
-            label: scenarioName + "_par" + frontendThreads,
+            label: scenarioName + "_threads_" + frontendThreads,
             width: devicePixelRatio,
             stroke: color,
           });

--- a/site/frontend/src/graph/render.ts
+++ b/site/frontend/src/graph/render.ts
@@ -401,11 +401,7 @@ export function renderPlots(
   const hooks = opts.hooks ?? {};
   const {width, height} = opts;
 
-  const benchNames = Object.keys(data.benchmarks).sort();
-
-  for (const benchName of benchNames) {
-    let profiles = data.benchmarks.get(benchName);
-
+  for (const [benchName, profiles] of data.benchmarks.entries()) {
     let i = 0;
 
     for (let [profileName, scenario] of profiles.entries()) {

--- a/site/frontend/src/graph/render.ts
+++ b/site/frontend/src/graph/render.ts
@@ -401,6 +401,11 @@ export function renderPlots(
   const hooks = opts.hooks ?? {};
   const {width, height} = opts;
 
+  console.debug(
+    `CompileBenchmarks passed to \`renderPlots\`:`,
+    data.benchmarks.toJSON()
+  );
+
   for (const [benchName, profiles] of data.benchmarks.entries()) {
     let i = 0;
 
@@ -459,7 +464,7 @@ export function renderPlots(
       let otherColorIdx = 0;
       let indices = null;
 
-      let scenarioNames = Array.from(profiles.keys());
+      let scenarioNames = Array.from(scenario.keys());
       scenarioNames.sort();
       for (let scenarioName of scenarioNames) {
         let frontendThreadsCounts = scenario.get(scenarioName);

--- a/site/frontend/src/graph/render.ts
+++ b/site/frontend/src/graph/render.ts
@@ -2,7 +2,7 @@ import uPlot, {TypedArray} from "uplot";
 import {
   CompileGraphData,
   GraphsSelector,
-  profileKeyForGraphDisplay,
+  profileForGraphDisplay,
   RuntimeGraphData,
 } from "./data";
 
@@ -502,7 +502,7 @@ export function renderPlots(
         absoluteMode: selector.kind == "raw",
         hooks,
       });
-      const profileNameToRender = profileKeyForGraphDisplay(profileName);
+      const profileNameToRender = profileForGraphDisplay(profileName);
       if (renderTitle) {
         plotOpts["title"] = `${benchName}-${profileNameToRender}`;
       }

--- a/site/frontend/src/graph/render.ts
+++ b/site/frontend/src/graph/render.ts
@@ -376,14 +376,14 @@ function genPlotOpts({
 
 function normalizeData(data: CompileGraphData) {
   function optInterpolated(profile) {
-    for (const parallel in profile) {
-      let par = profile[parallel];
-      for (const scenario in par) {
-        par[scenario].interpolated_indices = new Set(
-          par[scenario].interpolated_indices
+    for (const frontendThreads in profile) {
+      let threads = profile[frontendThreads];
+      for (const scenario in threads) {
+        threads[scenario].interpolated_indices = new Set(
+          threads[scenario].interpolated_indices
         );
       }
-      profile[parallel] = par;
+      profile[frontendThreads] = threads;
     }
 
     return profile;
@@ -434,7 +434,7 @@ export function renderPlots(
     let i = 0;
 
     for (let profile in profiles) {
-      let parallels = profiles[profile];
+      let frontendThreadsCounts = profiles[profile];
       let yAxis = selector.stat;
       let yAxisUnit = null;
 
@@ -489,8 +489,8 @@ export function renderPlots(
       let otherColorIdx = 0;
       let indices = null;
 
-      for (let parallel in parallels) {
-        let scenarios = parallels[parallel];
+      for (let frontendThreads in frontendThreadsCounts) {
+        let scenarios = frontendThreadsCounts[frontendThreads];
         let scenarioNames = Object.keys(scenarios);
         scenarioNames.sort();
 
@@ -500,7 +500,7 @@ export function renderPlots(
             indices = scenarios[scenarioName].interpolated_indices;
           }
           let color =
-            parallel == "1"
+            frontendThreads == "1"
               ? commonCacheStateColors[scenarioName] ||
                 otherCacheStateColors[otherColorIdx++]
               : otherCacheStateColors[otherColorIdx++];
@@ -508,7 +508,7 @@ export function renderPlots(
           plotData.push(yVals);
 
           seriesOpts.push({
-            label: scenarioName + "_par" + parallel,
+            label: scenarioName + "_par" + frontendThreads,
             width: devicePixelRatio,
             stroke: color,
           });

--- a/site/frontend/src/graph/render.ts
+++ b/site/frontend/src/graph/render.ts
@@ -2,8 +2,8 @@ import uPlot, {TypedArray} from "uplot";
 import {
   CompileGraphData,
   GraphsSelector,
+  profileKeyForGraphDisplay,
   RuntimeGraphData,
-  ScenarioSeries,
 } from "./data";
 
 const commonCacheStateColors = {
@@ -22,7 +22,6 @@ const otherCacheStateColors = [
   "#91e8e1",
 ];
 const interpolatedColor = "#fcb0f1";
-const KNOWN_PROFILES_CAMELCASE = ["Check", "Debug", "Opt", "Doc"];
 
 function tooltipPlugin({
   onclick,
@@ -379,67 +378,6 @@ function genPlotOpts({
   };
 }
 
-function normalizeData(data: CompileGraphData) {
-  function optInterpolated(profile) {
-    for (const frontendThreads in profile) {
-      let threads = profile[frontendThreads];
-      for (const scenario in threads) {
-        threads[scenario].interpolated_indices = new Set(
-          threads[scenario].interpolated_indices
-        );
-      }
-      profile[frontendThreads] = threads;
-    }
-
-    return profile;
-  }
-
-  for (const name of Object.keys(data.benchmarks)) {
-    for (const profile of KNOWN_PROFILES_CAMELCASE) {
-      if (data.benchmarks[name].hasOwnProperty(profile)) {
-        data.benchmarks[name][profile.toLowerCase()] = optInterpolated(
-          data.benchmarks[name][profile]
-        );
-        delete data.benchmarks[name][profile];
-      }
-    }
-  }
-}
-
-function normalizeData_(data: CompileGraphData) {
-  function optInterpolated(profile) {
-    for (const frontendThreads in profile) {
-      let threads = profile[frontendThreads];
-      for (const scenario in threads) {
-        threads[scenario].interpolated_indices = new Set(
-          threads[scenario].interpolated_indices
-        );
-      }
-      profile[frontendThreads] = threads;
-    }
-
-    return profile;
-  }
-
-  for (const name of data.benchmarks.keys()) {
-    for (const profileCamelCased of KNOWN_PROFILES_CAMELCASE) {
-      if (data.benchmarks.get(name).has(profileCamelCased)) {
-        let scenarios: ScenarioSeries = data.benchmarks
-          .get(name)
-          .get(profileCamelCased);
-        data.benchmarks
-          .get(name)
-          // .get(profile.toLowerCase())
-          .set(
-            profileCamelCased.toLowerCase(),
-            optInterpolated(data.benchmarks.get(name).get(profileCamelCased))
-          );
-        delete data.benchmarks[name][profileCamelCased];
-      }
-    }
-  }
-}
-
 export type GraphRenderOpts = {
   // Width of the graph
   width: number;
@@ -463,8 +401,6 @@ export function renderPlots(
   const hooks = opts.hooks ?? {};
   const {width, height} = opts;
 
-  normalizeData(data);
-
   const benchNames = Object.keys(data.benchmarks).sort();
 
   for (const benchName of benchNames) {
@@ -473,7 +409,6 @@ export function renderPlots(
     let i = 0;
 
     for (let [profileName, scenario] of profiles.entries()) {
-      // let frontendThreadsCounts = profiles[profile];
       let yAxis = selector.stat;
       let yAxisUnit = null;
 
@@ -566,7 +501,7 @@ export function renderPlots(
         absoluteMode: selector.kind == "raw",
         hooks,
       });
-      const profileNameToRender = profileKeyToLowercase(profileName);
+      const profileNameToRender = profileKeyForGraphDisplay(profileName);
       if (renderTitle) {
         plotOpts["title"] = `${benchName}-${profileNameToRender}`;
       }

--- a/site/frontend/src/pages/compare/compile/aggregations.vue
+++ b/site/frontend/src/pages/compare/compile/aggregations.vue
@@ -89,6 +89,18 @@ const totalAfter = computed(() =>
             </div>
           </div>
           <div class="aggregation-section">
+            <div class="header">Parallel</div>
+            <div class="groups">
+              <div class="group" v-for="parallel in ['1', '4']">
+                <div class="group-header">par{{ parallel }}</div>
+                <SummaryTable
+                  :summary="calculateSummary('parallel', parallel)"
+                  :withLegend="false"
+                ></SummaryTable>
+              </div>
+            </div>
+          </div>
+          <div class="aggregation-section">
             <div class="header">Category</div>
             <div class="groups">
               <div class="group" v-for="category in ['primary', 'secondary']">

--- a/site/frontend/src/pages/compare/compile/aggregations.vue
+++ b/site/frontend/src/pages/compare/compile/aggregations.vue
@@ -92,7 +92,7 @@ const totalAfter = computed(() =>
             <div class="header">Parallel</div>
             <div class="groups">
               <div class="group" v-for="parallel in ['1', '4']">
-                <div class="group-header">par{{ parallel }}</div>
+                <div class="group-header">par{{ frontendThreads }}</div>
                 <SummaryTable
                   :summary="calculateSummary('parallel', parallel)"
                   :withLegend="false"

--- a/site/frontend/src/pages/compare/compile/aggregations.vue
+++ b/site/frontend/src/pages/compare/compile/aggregations.vue
@@ -89,12 +89,14 @@ const totalAfter = computed(() =>
             </div>
           </div>
           <div class="aggregation-section">
-            <div class="header">Parallel</div>
+            <div class="header">FrontendThreads</div>
             <div class="groups">
-              <div class="group" v-for="parallel in ['1', '4']">
-                <div class="group-header">par{{ frontendThreads }}</div>
+              <div class="group" v-for="frontendThreads in ['1', '4']">
+                <div class="group-header">threads_{{ frontendThreads }}</div>
                 <SummaryTable
-                  :summary="calculateSummary('parallel', parallel)"
+                  :summary="
+                    calculateSummary('frontendThreads', frontendThreads)
+                  "
                   :withLegend="false"
                 ></SummaryTable>
               </div>

--- a/site/frontend/src/pages/compare/compile/benchmarks.vue
+++ b/site/frontend/src/pages/compare/compile/benchmarks.vue
@@ -1,5 +1,5 @@
 <script setup lang="tsx">
-import {computed, h} from "vue";
+import {computed} from "vue";
 import ComparisonsTable from "./table/comparisons-table.vue";
 import {TestCaseComparison} from "../data";
 import {CompareResponse} from "../types";

--- a/site/frontend/src/pages/compare/compile/common.ts
+++ b/site/frontend/src/pages/compare/compile/common.ts
@@ -2,6 +2,12 @@ import {BenchmarkFilter, CompareResponse, StatComparison} from "../types";
 import {calculateComparison, TestCaseComparison} from "../data";
 import {benchmarkNameMatchesFilter, targetMatchesFilter} from "../shared";
 import {DEFAULT_COMPILE_TARGET_TRIPLE} from "../../../api";
+import {
+  CompileBenchmark,
+  FrontendThreads,
+  Scenario,
+  Profile,
+} from "../../../graph/data.ts";
 
 export type CompileBenchmarkFilter = {
   profile: {
@@ -82,7 +88,7 @@ export const defaultCompileFilter: CompileBenchmarkFilter = {
   selfCompareBackend: false,
 };
 
-export type Profile = "check" | "debug" | "opt" | "doc";
+export type ProfileEnumeration = "check" | "debug" | "opt" | "doc";
 export type CodegenBackend = "llvm" | "cranelift";
 export type Category = "primary" | "secondary";
 export type Target = "x86_64-unknown-linux-gnu" | "aarch64-unknown-linux-gnu";
@@ -105,10 +111,10 @@ export interface CompileBenchmarkMetadata {
 }
 
 export interface CompileBenchmarkComparison {
-  benchmark: string;
+  benchmark: CompileBenchmark;
   profile: Profile;
-  scenario: string;
-  frontendThreads: number;
+  scenario: Scenario;
+  frontendThreads: FrontendThreads;
   backend: CodegenBackend;
   target: Target;
   comparison: StatComparison;
@@ -117,8 +123,8 @@ export interface CompileBenchmarkComparison {
 export interface CompileTestCase {
   benchmark: string;
   profile: Profile;
-  scenario: string;
-  frontendThreads: string;
+  scenario: Scenario;
+  frontendThreads: FrontendThreads;
   backend: CodegenBackend;
   target: Target;
   category: Category;
@@ -129,7 +135,7 @@ export function computeCompileComparisonsWithNonRelevant(
   comparisons: CompileBenchmarkComparison[],
   benchmarkMap: CompileBenchmarkMap
 ): TestCaseComparison<CompileTestCase>[] {
-  function profileFilter(profile: Profile): boolean {
+  function profileFilter(profile: ProfileEnumeration): boolean {
     if (profile === "check") {
       return filter.profile.check;
     } else if (profile === "debug") {
@@ -212,7 +218,9 @@ export function computeCompileComparisonsWithNonRelevant(
 
   function shouldShowTestCase(comparison: TestCaseComparison<CompileTestCase>) {
     return (
-      profileFilter(comparison.testCase.profile) &&
+      profileFilter(
+        comparison.testCase.profile.toLowerCase() as ProfileEnumeration
+      ) &&
       scenarioFilter(comparison.testCase.scenario) &&
       frontendThreadsFilter(comparison.testCase.frontendThreads) &&
       backendFilter(comparison.testCase.backend) &&
@@ -231,7 +239,7 @@ export function computeCompileComparisonsWithNonRelevant(
           benchmark: c.benchmark,
           profile: c.profile,
           scenario: c.scenario,
-          frontendThreads: c.frontendThreads.toString(),
+          frontendThreads: c.frontendThreads,
           backend: c.backend,
           target: c.target,
           category: (benchmarkMap[c.benchmark] || {}).category || "secondary",
@@ -276,11 +284,11 @@ export function transformDataForBackendComparison(
     {
       llvm: number | null;
       cranelift: number | null;
-      benchmark: string;
+      benchmark: CompileBenchmark;
       profile: Profile;
       target: Target;
-      scenario: string;
-      frontendThreads: number;
+      scenario: Scenario;
+      frontendThreads: FrontendThreads;
     }
   > = new Map();
   for (const comparison of comparisons) {

--- a/site/frontend/src/pages/compare/compile/common.ts
+++ b/site/frontend/src/pages/compare/compile/common.ts
@@ -160,7 +160,7 @@ export function computeCompileComparisonsWithNonRelevant(
     }
   }
 
-  function parallelFilter(frontendThreads: string): boolean {
+  function frontendThreadsFilter(frontendThreads: string): boolean {
     if (frontendThreads === "1") {
       return filter.frontendThreads.threads_1;
     } else if (frontendThreads === "4") {
@@ -214,7 +214,7 @@ export function computeCompileComparisonsWithNonRelevant(
     return (
       profileFilter(comparison.testCase.profile) &&
       scenarioFilter(comparison.testCase.scenario) &&
-      parallelFilter(comparison.testCase.frontendThreads) &&
+      frontendThreadsFilter(comparison.testCase.frontendThreads) &&
       backendFilter(comparison.testCase.backend) &&
       targetMatchesFilter(comparison.testCase.target, filter.target) &&
       categoryFilter(comparison.testCase.category) &&

--- a/site/frontend/src/pages/compare/compile/common.ts
+++ b/site/frontend/src/pages/compare/compile/common.ts
@@ -17,6 +17,10 @@ export type CompileBenchmarkFilter = {
     incrUnchanged: boolean;
     incrPatched: boolean;
   };
+  parallel: {
+    par1: boolean;
+    par4: boolean;
+  };
   backend: {
     llvm: boolean;
     cranelift: boolean;
@@ -53,6 +57,10 @@ export const defaultCompileFilter: CompileBenchmarkFilter = {
     incrFull: true,
     incrUnchanged: true,
     incrPatched: true,
+  },
+  parallel: {
+    par1: true,
+    par4: true,
   },
   backend: {
     llvm: true,
@@ -100,6 +108,7 @@ export interface CompileBenchmarkComparison {
   benchmark: string;
   profile: Profile;
   scenario: string;
+  parallel: number;
   backend: CodegenBackend;
   target: Target;
   comparison: StatComparison;
@@ -109,6 +118,7 @@ export interface CompileTestCase {
   benchmark: string;
   profile: Profile;
   scenario: string;
+  parallel: string;
   backend: CodegenBackend;
   target: Target;
   category: Category;
@@ -150,6 +160,17 @@ export function computeCompileComparisonsWithNonRelevant(
     }
   }
 
+  function parallelFilter(parallel: string): boolean {
+    if (parallel === "1") {
+      return filter.parallel.par1;
+    } else if (parallel === "4") {
+      return filter.parallel.par4;
+    } else {
+      // Unknown, but by default we should show things
+      return true;
+    }
+  }
+
   function backendFilter(backend: string): boolean {
     if (backend === "llvm") {
       return filter.backend.llvm;
@@ -162,7 +183,8 @@ export function computeCompileComparisonsWithNonRelevant(
   }
 
   function artifactFilter(metadata: CompileBenchmarkMetadata | null): boolean {
-    if (metadata?.binary === null) return true;
+    // Loose equality to prevent metadata.binary null access later
+    if (metadata?.binary == null) return true;
 
     const isBinary = metadata.binary;
     const isLibrary = !isBinary;
@@ -192,6 +214,7 @@ export function computeCompileComparisonsWithNonRelevant(
     return (
       profileFilter(comparison.testCase.profile) &&
       scenarioFilter(comparison.testCase.scenario) &&
+      parallelFilter(comparison.testCase.parallel) &&
       backendFilter(comparison.testCase.backend) &&
       targetMatchesFilter(comparison.testCase.target, filter.target) &&
       categoryFilter(comparison.testCase.category) &&
@@ -208,6 +231,7 @@ export function computeCompileComparisonsWithNonRelevant(
           benchmark: c.benchmark,
           profile: c.profile,
           scenario: c.scenario,
+          parallel: c.parallel.toString(),
           backend: c.backend,
           target: c.target,
           category: (benchmarkMap[c.benchmark] || {}).category || "secondary",
@@ -231,7 +255,7 @@ export function computeCompileComparisonsWithNonRelevant(
 export function createCompileBenchmarkMap(
   data: CompareResponse
 ): CompileBenchmarkMap {
-  const benchmarks = {};
+  const benchmarks: CompileBenchmarkMap = {};
   for (const benchmark of data.compile_benchmark_metadata) {
     benchmarks[benchmark.name] = {...benchmark};
   }
@@ -239,7 +263,7 @@ export function createCompileBenchmarkMap(
 }
 
 export function testCaseKey(testCase: CompileTestCase): string {
-  return `${testCase.benchmark};${testCase.profile};${testCase.scenario};${testCase.backend};${testCase.category}`;
+  return `${testCase.benchmark};${testCase.profile};${testCase.scenario};${testCase.parallel};${testCase.backend};${testCase.category}`;
 }
 
 // Transform compile comparisons to compare LLVM vs Cranelift, instead of
@@ -256,10 +280,11 @@ export function transformDataForBackendComparison(
       profile: Profile;
       target: Target;
       scenario: string;
+      parallel: number;
     }
   > = new Map();
   for (const comparison of comparisons) {
-    const key = `${comparison.benchmark};${comparison.profile};${comparison.scenario};${comparison.target}`;
+    const key = `${comparison.benchmark};${comparison.profile};${comparison.scenario};${comparison.parallel};${comparison.target}`;
     if (!benchmarkMap.has(key)) {
       benchmarkMap.set(key, {
         llvm: null,
@@ -267,10 +292,11 @@ export function transformDataForBackendComparison(
         benchmark: comparison.benchmark,
         profile: comparison.profile,
         scenario: comparison.scenario,
+        parallel: comparison.parallel,
         target: comparison.target,
       });
     }
-    const record = benchmarkMap.get(key);
+    const record = benchmarkMap.get(key)!;
     if (comparison.backend === "llvm") {
       record.llvm = comparison.comparison.statistics[0];
     } else if (comparison.backend === "cranelift") {
@@ -283,11 +309,12 @@ export function transformDataForBackendComparison(
       benchmark: entry.benchmark,
       profile: entry.profile,
       scenario: entry.scenario,
+      parallel: entry.parallel,
       // Treat LLVM as the baseline
       backend: "llvm",
       target: entry.target,
       comparison: {
-        statistics: [entry.llvm, entry.cranelift],
+        statistics: [entry.llvm ?? 0, entry.cranelift ?? 0],
         is_relevant: true,
         significance_factor: 1.0,
         significance_threshold: 1.0,

--- a/site/frontend/src/pages/compare/compile/common.ts
+++ b/site/frontend/src/pages/compare/compile/common.ts
@@ -17,9 +17,9 @@ export type CompileBenchmarkFilter = {
     incrUnchanged: boolean;
     incrPatched: boolean;
   };
-  parallel: {
-    par1: boolean;
-    par4: boolean;
+  frontendThreads: {
+    threads_1: boolean;
+    threads_4: boolean;
   };
   backend: {
     llvm: boolean;
@@ -58,9 +58,9 @@ export const defaultCompileFilter: CompileBenchmarkFilter = {
     incrUnchanged: true,
     incrPatched: true,
   },
-  parallel: {
-    par1: true,
-    par4: true,
+  frontendThreads: {
+    threads_1: true,
+    threads_4: true,
   },
   backend: {
     llvm: true,
@@ -108,7 +108,7 @@ export interface CompileBenchmarkComparison {
   benchmark: string;
   profile: Profile;
   scenario: string;
-  parallel: number;
+  frontendThreads: number;
   backend: CodegenBackend;
   target: Target;
   comparison: StatComparison;
@@ -118,7 +118,7 @@ export interface CompileTestCase {
   benchmark: string;
   profile: Profile;
   scenario: string;
-  parallel: string;
+  frontendThreads: string;
   backend: CodegenBackend;
   target: Target;
   category: Category;
@@ -160,11 +160,11 @@ export function computeCompileComparisonsWithNonRelevant(
     }
   }
 
-  function parallelFilter(parallel: string): boolean {
-    if (parallel === "1") {
-      return filter.parallel.par1;
-    } else if (parallel === "4") {
-      return filter.parallel.par4;
+  function parallelFilter(frontendThreads: string): boolean {
+    if (frontendThreads === "1") {
+      return filter.frontendThreads.threads_1;
+    } else if (frontendThreads === "4") {
+      return filter.frontendThreads.threads_4;
     } else {
       // Unknown, but by default we should show things
       return true;
@@ -214,7 +214,7 @@ export function computeCompileComparisonsWithNonRelevant(
     return (
       profileFilter(comparison.testCase.profile) &&
       scenarioFilter(comparison.testCase.scenario) &&
-      parallelFilter(comparison.testCase.parallel) &&
+      parallelFilter(comparison.testCase.frontendThreads) &&
       backendFilter(comparison.testCase.backend) &&
       targetMatchesFilter(comparison.testCase.target, filter.target) &&
       categoryFilter(comparison.testCase.category) &&
@@ -231,7 +231,7 @@ export function computeCompileComparisonsWithNonRelevant(
           benchmark: c.benchmark,
           profile: c.profile,
           scenario: c.scenario,
-          parallel: c.parallel.toString(),
+          frontendThreads: c.frontendThreads.toString(),
           backend: c.backend,
           target: c.target,
           category: (benchmarkMap[c.benchmark] || {}).category || "secondary",
@@ -263,7 +263,7 @@ export function createCompileBenchmarkMap(
 }
 
 export function testCaseKey(testCase: CompileTestCase): string {
-  return `${testCase.benchmark};${testCase.profile};${testCase.scenario};${testCase.parallel};${testCase.backend};${testCase.category}`;
+  return `${testCase.benchmark};${testCase.profile};${testCase.scenario};${testCase.frontendThreads};${testCase.backend};${testCase.category}`;
 }
 
 // Transform compile comparisons to compare LLVM vs Cranelift, instead of
@@ -280,11 +280,11 @@ export function transformDataForBackendComparison(
       profile: Profile;
       target: Target;
       scenario: string;
-      parallel: number;
+      frontendThreads: number;
     }
   > = new Map();
   for (const comparison of comparisons) {
-    const key = `${comparison.benchmark};${comparison.profile};${comparison.scenario};${comparison.parallel};${comparison.target}`;
+    const key = `${comparison.benchmark};${comparison.profile};${comparison.scenario};${comparison.frontendThreads};${comparison.target}`;
     if (!benchmarkMap.has(key)) {
       benchmarkMap.set(key, {
         llvm: null,
@@ -292,7 +292,7 @@ export function transformDataForBackendComparison(
         benchmark: comparison.benchmark,
         profile: comparison.profile,
         scenario: comparison.scenario,
-        parallel: comparison.parallel,
+        frontendThreads: comparison.frontendThreads,
         target: comparison.target,
       });
     }
@@ -309,7 +309,7 @@ export function transformDataForBackendComparison(
       benchmark: entry.benchmark,
       profile: entry.profile,
       scenario: entry.scenario,
-      parallel: entry.parallel,
+      frontendThreads: entry.frontendThreads,
       // Treat LLVM as the baseline
       backend: "llvm",
       target: entry.target,

--- a/site/frontend/src/pages/compare/compile/compile-page.vue
+++ b/site/frontend/src/pages/compare/compile/compile-page.vue
@@ -91,6 +91,10 @@ function loadFilterFromUrl(
         defaultFilter.scenario.incrPatched
       ),
     },
+    parallel: {
+      par1: getBoolOrDefault(urlParams, "par1", defaultFilter.parallel.par1),
+      par4: getBoolOrDefault(urlParams, "par4", defaultFilter.parallel.par4),
+    },
     backend: {
       llvm: getBoolOrDefault(
         urlParams,
@@ -223,6 +227,18 @@ function storeFilterToUrl(
     "incrPatched",
     filter.scenario.incrPatched,
     defaultFilter.scenario.incrPatched
+  );
+  storeOrResetBool(
+    urlParams,
+    "par1",
+    filter.parallel.par1,
+    defaultFilter.parallel.par1
+  );
+  storeOrResetBool(
+    urlParams,
+    "par4",
+    filter.parallel.par4,
+    defaultFilter.parallel.par4
   );
   storeOrResetBool(
     urlParams,

--- a/site/frontend/src/pages/compare/compile/compile-page.vue
+++ b/site/frontend/src/pages/compare/compile/compile-page.vue
@@ -91,9 +91,17 @@ function loadFilterFromUrl(
         defaultFilter.scenario.incrPatched
       ),
     },
-    parallel: {
-      par1: getBoolOrDefault(urlParams, "par1", defaultFilter.parallel.par1),
-      par4: getBoolOrDefault(urlParams, "par4", defaultFilter.parallel.par4),
+    frontendThreads: {
+      threads_1: getBoolOrDefault(
+        urlParams,
+        "threads_1",
+        defaultFilter.frontendThreads.threads_1
+      ),
+      threads_4: getBoolOrDefault(
+        urlParams,
+        "threads_4",
+        defaultFilter.frontendThreads.threads_4
+      ),
     },
     backend: {
       llvm: getBoolOrDefault(
@@ -230,15 +238,15 @@ function storeFilterToUrl(
   );
   storeOrResetBool(
     urlParams,
-    "par1",
-    filter.parallel.par1,
-    defaultFilter.parallel.par1
+    "threads_1",
+    filter.frontendThreads.threads_1,
+    defaultFilter.frontendThreads.threads_1
   );
   storeOrResetBool(
     urlParams,
-    "par4",
-    filter.parallel.par4,
-    defaultFilter.parallel.par4
+    "threads_4",
+    filter.frontendThreads.threads_4,
+    defaultFilter.frontendThreads.threads_4
   );
   storeOrResetBool(
     urlParams,

--- a/site/frontend/src/pages/compare/compile/export.ts
+++ b/site/frontend/src/pages/compare/compile/export.ts
@@ -10,6 +10,7 @@ export function exportToMarkdown(
       "Benchmark",
       "Profile",
       "Scenario",
+      "Parallel",
       "% Change",
       "Significance Factor",
     ];
@@ -32,6 +33,7 @@ export function exportToMarkdown(
         comparison.testCase.benchmark,
         comparison.testCase.profile,
         comparison.testCase.scenario,
+        comparison.testCase.parallel.toString(),
         `${comparison.percent.toFixed(2)}%`,
         `${comparison.significanceFactor.toFixed(2)}x`,
       ];

--- a/site/frontend/src/pages/compare/compile/export.ts
+++ b/site/frontend/src/pages/compare/compile/export.ts
@@ -33,7 +33,7 @@ export function exportToMarkdown(
         comparison.testCase.benchmark,
         comparison.testCase.profile,
         comparison.testCase.scenario,
-        comparison.testCase.frontendThreads.toString(),
+        comparison.testCase.frontendThreads,
         `${comparison.percent.toFixed(2)}%`,
         `${comparison.significanceFactor.toFixed(2)}x`,
       ];

--- a/site/frontend/src/pages/compare/compile/export.ts
+++ b/site/frontend/src/pages/compare/compile/export.ts
@@ -10,7 +10,7 @@ export function exportToMarkdown(
       "Benchmark",
       "Profile",
       "Scenario",
-      "Parallel",
+      "FrontendThreads",
       "% Change",
       "Significance Factor",
     ];
@@ -33,7 +33,7 @@ export function exportToMarkdown(
         comparison.testCase.benchmark,
         comparison.testCase.profile,
         comparison.testCase.scenario,
-        comparison.testCase.parallel.toString(),
+        comparison.testCase.frontendThreads.toString(),
         `${comparison.percent.toFixed(2)}%`,
         `${comparison.significanceFactor.toFixed(2)}x`,
       ];

--- a/site/frontend/src/pages/compare/compile/filters.vue
+++ b/site/frontend/src/pages/compare/compile/filters.vue
@@ -208,6 +208,40 @@ const opened = createPersistedRef(PREF_FILTERS_OPENED);
           <div class="section section-list-wrapper">
             <div class="section-heading">
               <div style="width: 160px">
+                <span>Parallels</span>
+                <Tooltip
+                  >The different parallel frontend options (-Zthreads=N).
+                </Tooltip>
+              </div>
+            </div>
+            <ul class="states-list">
+              <li>
+                <label>
+                  <input
+                    type="checkbox"
+                    id="build-par1"
+                    v-model="filter.parallel.par1"
+                  />
+                  <span class="label">par1</span>
+                </label>
+                <Tooltip>Single-threaded rustc frontend. </Tooltip>
+              </li>
+              <li>
+                <label>
+                  <input
+                    type="checkbox"
+                    id="build-par4"
+                    v-model="filter.parallel.par4"
+                  />
+                  <span class="label">par4</span>
+                </label>
+                <Tooltip>Parallel rustc frontend with 4 threads. </Tooltip>
+              </li>
+            </ul>
+          </div>
+          <div class="section section-list-wrapper">
+            <div class="section-heading">
+              <div style="width: 160px">
                 <span>Backends</span>
                 <Tooltip
                   >The different codegen backends used to generate executable

--- a/site/frontend/src/pages/compare/compile/filters.vue
+++ b/site/frontend/src/pages/compare/compile/filters.vue
@@ -208,7 +208,7 @@ const opened = createPersistedRef(PREF_FILTERS_OPENED);
           <div class="section section-list-wrapper">
             <div class="section-heading">
               <div style="width: 160px">
-                <span>Parallels</span>
+                <span>Frontend Threads</span>
                 <Tooltip
                   >The different parallel frontend options (-Zthreads=N).
                 </Tooltip>
@@ -219,10 +219,10 @@ const opened = createPersistedRef(PREF_FILTERS_OPENED);
                 <label>
                   <input
                     type="checkbox"
-                    id="build-par1"
-                    v-model="filter.parallel.par1"
+                    id="build-threads_1"
+                    v-model="filter.frontendThreads.threads_1"
                   />
-                  <span class="label">par1</span>
+                  <span class="label">1</span>
                 </label>
                 <Tooltip>Single-threaded rustc frontend. </Tooltip>
               </li>
@@ -230,10 +230,10 @@ const opened = createPersistedRef(PREF_FILTERS_OPENED);
                 <label>
                   <input
                     type="checkbox"
-                    id="build-par4"
-                    v-model="filter.parallel.par4"
+                    id="build-threads_4"
+                    v-model="filter.frontendThreads.threads_4"
                   />
-                  <span class="label">par4</span>
+                  <span class="label">4</span>
                 </label>
                 <Tooltip>Parallel rustc frontend with 4 threads. </Tooltip>
               </li>

--- a/site/frontend/src/pages/compare/compile/table/benchmark-detail-graph.vue
+++ b/site/frontend/src/pages/compare/compile/table/benchmark-detail-graph.vue
@@ -38,6 +38,7 @@ function createGraphsSelector(): CompileDetailGraphsSelector {
     benchmark: props.testCase.benchmark,
     profile: props.testCase.profile,
     scenario: props.testCase.scenario,
+    parallel: props.testCase.parallel.toString(),
     backend: props.testCase.backend,
     stat: props.metric,
     start,
@@ -66,7 +67,9 @@ async function renderGraphs(detail: CompileDetailGraphs) {
           // The server returns profiles capitalized, so we need to match that
           // here, so that the graph code can find the expected profile.
           [capitalize(selector.profile)]: {
-            [selector.scenario]: detail.graphs[index],
+            [selector.parallel]: {
+              [selector.scenario]: detail.graphs[index],
+            },
           },
         },
       },
@@ -75,6 +78,7 @@ async function renderGraphs(detail: CompileDetailGraphs) {
       benchmark: selector.benchmark,
       profile: selector.profile,
       scenario: selector.scenario,
+      parallel: selector.parallel,
       stat: selector.stat,
       start: selector.start,
       end: selector.end,
@@ -122,6 +126,9 @@ async function renderGraph(
   date: Date | null,
   chartRef: Ref<HTMLElement | null>
 ) {
+  if (chartRef.value === null) {
+    return;
+  }
   const opts: GraphRenderOpts = {
     width: Math.min(window.innerWidth - 40, 465),
     height: 300,
@@ -192,15 +199,15 @@ function getGraphRange(
   // If this is a try commit, we don't know its future, so always we just display
   // the last `DAY_RANGE` days.
   if (artifact.type === "try") {
-    const date = new Date(artifact.date);
+    let date = artifact.date ? new Date(artifact.date) : new Date();
     return {
       start: formatDate(getPastDate(date, DAY_RANGE)),
       end: artifact.commit,
       date: null,
     };
   } else {
-    let [start_date, end_date] = [baseArtifact, artifact].map(
-      (c) => new Date(c.date)
+    let [start_date, end_date] = [baseArtifact, artifact].map((c) =>
+      c.date ? new Date(c.date) : new Date()
     );
     // If this is a master commit, we attempt to display more than the full history for commit
     // ranges. If the commit range is not larger than the `dayRange`, the display will likely be

--- a/site/frontend/src/pages/compare/compile/table/benchmark-detail-graph.vue
+++ b/site/frontend/src/pages/compare/compile/table/benchmark-detail-graph.vue
@@ -38,7 +38,7 @@ function createGraphsSelector(): CompileDetailGraphsSelector {
     benchmark: props.testCase.benchmark,
     profile: props.testCase.profile,
     scenario: props.testCase.scenario,
-    parallel: props.testCase.parallel.toString(),
+    frontendThreads: props.testCase.frontendThreads.toString(),
     backend: props.testCase.backend,
     stat: props.metric,
     start,
@@ -67,7 +67,7 @@ async function renderGraphs(detail: CompileDetailGraphs) {
           // The server returns profiles capitalized, so we need to match that
           // here, so that the graph code can find the expected profile.
           [capitalize(selector.profile)]: {
-            [selector.parallel]: {
+            [selector.frontendThreads]: {
               [selector.scenario]: detail.graphs[index],
             },
           },
@@ -78,7 +78,7 @@ async function renderGraphs(detail: CompileDetailGraphs) {
       benchmark: selector.benchmark,
       profile: selector.profile,
       scenario: selector.scenario,
-      parallel: selector.parallel,
+      frontendThreads: selector.frontendThreads,
       stat: selector.stat,
       start: selector.start,
       end: selector.end,

--- a/site/frontend/src/pages/compare/compile/table/benchmark-detail-graph.vue
+++ b/site/frontend/src/pages/compare/compile/table/benchmark-detail-graph.vue
@@ -6,14 +6,17 @@ import {
   CompileDetailGraphsSelector,
 } from "./detail-resolver";
 import {
-  CompileBenchmarks,
+  CompileBenchmarkSeries,
   CompileGraphData,
   FrontendThreadsSeries,
   GraphKind,
   GraphsSelector,
   ProfileSeries,
   ScenarioSeries,
-  toProfileKey,
+  toCompileBenchmark,
+  toFrontendThreads,
+  toProfile,
+  toScenario,
 } from "../../../../graph/data";
 import {CompileTestCase} from "../common";
 import {GraphRenderOpts, renderPlots} from "../../../../graph/render";
@@ -43,7 +46,7 @@ function createGraphsSelector(): CompileDetailGraphsSelector {
     benchmark: props.testCase.benchmark,
     profile: props.testCase.profile,
     scenario: props.testCase.scenario,
-    frontendThreads: props.testCase.frontendThreads.toString(),
+    frontendThreads: props.testCase.frontendThreads,
     backend: props.testCase.backend,
     stat: props.metric,
     start,
@@ -67,24 +70,23 @@ async function renderGraphs(detail: CompileDetailGraphs) {
   ): [CompileGraphData, GraphsSelector] {
     const data: CompileGraphData = {
       commits: detail.commits,
-      benchmarks: new CompileBenchmarks({
-        [selector.benchmark]: new ProfileSeries({
-          [toProfileKey(selector.profile)]: new ScenarioSeries({
-            [selector.frontendThreads]: new FrontendThreadsSeries({
-              [selector.scenario]: detail.graphs[index],
-            }),
+      benchmarks: new CompileBenchmarkSeries({
+        [toCompileBenchmark(selector.benchmark)]: new ProfileSeries({
+          [toProfile(selector.profile)]: new ScenarioSeries({
+            [toFrontendThreads(selector.frontendThreads)]:
+              new FrontendThreadsSeries({
+                [toScenario(selector.scenario)]: detail.graphs[index],
+              }),
           }),
         }),
       }),
     };
+
     console.debug(
-      `built CompileGraphData inside of \`buildGraph\`:\n${JSON.stringify(
-        data,
-        null,
-        2
-      )}`
+      "built CompileGraphData.benchmarks inside of \`buildGraph\`:",
+      data.benchmarks.toJSON()
     );
-    const graphSelector = {
+    const graphSelector: GraphsSelector = {
       benchmark: selector.benchmark,
       profile: selector.profile,
       scenario: selector.scenario,

--- a/site/frontend/src/pages/compare/compile/table/benchmark-detail-graph.vue
+++ b/site/frontend/src/pages/compare/compile/table/benchmark-detail-graph.vue
@@ -6,7 +6,7 @@ import {
   CompileDetailGraphsSelector,
 } from "./detail-resolver";
 import {
-  Benchmarks,
+  CompileBenchmarks,
   CompileGraphData,
   FrontendThreadsSeries,
   GraphKind,
@@ -67,7 +67,7 @@ async function renderGraphs(detail: CompileDetailGraphs) {
   ): [CompileGraphData, GraphsSelector] {
     const data: CompileGraphData = {
       commits: detail.commits,
-      benchmarks: new Benchmarks({
+      benchmarks: new CompileBenchmarks({
         [selector.benchmark]: new ProfileSeries({
           [toProfileKey(selector.profile)]: new ScenarioSeries({
             [selector.frontendThreads]: new FrontendThreadsSeries({

--- a/site/frontend/src/pages/compare/compile/table/benchmark-detail-graph.vue
+++ b/site/frontend/src/pages/compare/compile/table/benchmark-detail-graph.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import {computed, onMounted, capitalize, Ref, ref} from "vue";
+import {computed, onMounted, Ref, ref} from "vue";
 import {
   COMPILE_DETAIL_GRAPHS_RESOLVER,
   CompileDetailGraphs,
@@ -13,6 +13,7 @@ import {
   GraphsSelector,
   ProfileSeries,
   ScenarioSeries,
+  toProfileKey,
 } from "../../../../graph/data";
 import {CompileTestCase} from "../common";
 import {GraphRenderOpts, renderPlots} from "../../../../graph/render";
@@ -68,9 +69,7 @@ async function renderGraphs(detail: CompileDetailGraphs) {
       commits: detail.commits,
       benchmarks: new Benchmarks({
         [selector.benchmark]: new ProfileSeries({
-          // The server returns profiles capitalized, so we need to match that
-          // here, so that the graph code can find the expected profile.
-          [capitalize(selector.profile)]: new ScenarioSeries({
+          [toProfileKey(selector.profile)]: new ScenarioSeries({
             [selector.frontendThreads]: new FrontendThreadsSeries({
               [selector.scenario]: detail.graphs[index],
             }),

--- a/site/frontend/src/pages/compare/compile/table/benchmark-detail-graph.vue
+++ b/site/frontend/src/pages/compare/compile/table/benchmark-detail-graph.vue
@@ -6,9 +6,13 @@ import {
   CompileDetailGraphsSelector,
 } from "./detail-resolver";
 import {
+  Benchmarks,
   CompileGraphData,
+  FrontendThreadsSeries,
   GraphKind,
   GraphsSelector,
+  ProfileSeries,
+  ScenarioSeries,
 } from "../../../../graph/data";
 import {CompileTestCase} from "../common";
 import {GraphRenderOpts, renderPlots} from "../../../../graph/render";
@@ -62,17 +66,17 @@ async function renderGraphs(detail: CompileDetailGraphs) {
   ): [CompileGraphData, GraphsSelector] {
     const data: CompileGraphData = {
       commits: detail.commits,
-      benchmarks: {
-        [selector.benchmark]: {
+      benchmarks: new Benchmarks({
+        [selector.benchmark]: new ProfileSeries({
           // The server returns profiles capitalized, so we need to match that
           // here, so that the graph code can find the expected profile.
-          [capitalize(selector.profile)]: {
-            [selector.frontendThreads]: {
+          [capitalize(selector.profile)]: new ScenarioSeries({
+            [selector.frontendThreads]: new FrontendThreadsSeries({
               [selector.scenario]: detail.graphs[index],
-            },
-          },
-        },
-      },
+            }),
+          }),
+        }),
+      }),
     };
     const graphSelector = {
       benchmark: selector.benchmark,

--- a/site/frontend/src/pages/compare/compile/table/benchmark-detail-graph.vue
+++ b/site/frontend/src/pages/compare/compile/table/benchmark-detail-graph.vue
@@ -77,6 +77,13 @@ async function renderGraphs(detail: CompileDetailGraphs) {
         }),
       }),
     };
+    console.debug(
+      `built CompileGraphData inside of \`buildGraph\`:\n${JSON.stringify(
+        data,
+        null,
+        2
+      )}`
+    );
     const graphSelector = {
       benchmark: selector.benchmark,
       profile: selector.profile,

--- a/site/frontend/src/pages/compare/compile/table/benchmark-detail.vue
+++ b/site/frontend/src/pages/compare/compile/table/benchmark-detail.vue
@@ -35,6 +35,7 @@ function createSectionsSelector(): CompileDetailSectionsSelector {
     benchmark: props.testCase.benchmark,
     profile: props.testCase.profile,
     scenario: props.testCase.scenario,
+    parallel: props.testCase.parallel.toString(),
     backend: props.testCase.backend,
     target: props.testCase.target,
     start: props.baseArtifact.commit,
@@ -54,8 +55,9 @@ function detailedQueryLink(
   commit: ArtifactDescription,
   baseCommit?: ArtifactDescription
 ): string {
-  const {benchmark, profile, scenario, backend, target} = props.testCase;
-  let link = `/detailed-query.html?commit=${commit.commit}&benchmark=${benchmark}-${profile}&scenario=${scenario}&backend=${backend}&target=${target}`;
+  const {benchmark, profile, scenario, parallel, backend, target} =
+    props.testCase;
+  let link = `/detailed-query.html?commit=${commit.commit}&benchmark=${benchmark}-${profile}&scenario=${scenario}&parallel=${parallel}&backend=${backend}&target=${target}`;
   if (baseCommit !== undefined) {
     link += `&base_commit=${baseCommit.commit}`;
   }
@@ -68,17 +70,19 @@ function graphLink(
   testCase: CompileTestCase
 ): string {
   // Move to `30 days ago` to display history of the test case
-  const start = formatDate(getPastDate(new Date(commit.date), 30));
+  const start = formatDate(
+    getPastDate(commit.date ? new Date(commit.date) : new Date(), 30)
+  );
   const end = commit.commit;
-  const {benchmark, profile, scenario, target, backend} = testCase;
-  return `/index.html?start=${start}&end=${end}&benchmark=${benchmark}&profile=${profile}&scenario=${scenario}&target=${target}&backend=${backend}&stat=${metric}`;
+  const {benchmark, profile, scenario, parallel, target, backend} = testCase;
+  return `/index.html?start=${start}&end=${end}&benchmark=${benchmark}&profile=${profile}&scenario=${scenario}&parallel=${parallel}&target=${target}&backend=${backend}&stat=${metric}`;
 }
 
 const metadata = computed(
   (): CompileBenchmarkMetadata =>
     props.benchmarkMap[props.testCase.benchmark] ?? null
 );
-const cargoProfile = computed((): CargoProfileMetadata => {
+const cargoProfile = computed((): CargoProfileMetadata | undefined => {
   if (
     props.testCase.profile === "opt" &&
     metadata?.value.release_profile !== null
@@ -120,6 +124,10 @@ onMounted(() => {
               <td>{{ testCase.scenario }}</td>
             </tr>
             <tr>
+              <td>Parallel</td>
+              <td>{{ testCase.parallel }}</td>
+            </tr>
+            <tr>
               <td>Category</td>
               <td>{{ testCase.category }}</td>
             </tr>
@@ -136,15 +144,15 @@ onMounted(() => {
             </tr>
             <tr v-if="(cargoProfile?.lto ?? null) !== null">
               <td>LTO</td>
-              <td>{{ cargoProfile.lto }}</td>
+              <td>{{ cargoProfile?.lto }}</td>
             </tr>
             <tr v-if="(cargoProfile?.debug ?? null) !== null">
               <td>Debuginfo</td>
-              <td>{{ cargoProfile.debug }}</td>
+              <td>{{ cargoProfile?.debug }}</td>
             </tr>
             <tr v-if="(cargoProfile?.codegen_units ?? null) !== null">
               <td>Codegen units</td>
-              <td>{{ cargoProfile.codegen_units }}</td>
+              <td>{{ cargoProfile?.codegen_units }}</td>
             </tr>
           </tbody>
         </table>
@@ -224,8 +232,8 @@ onMounted(() => {
               (sectionsDetail?.before ?? null) !== null &&
               (sectionsDetail?.after ?? null) !== null
             "
-            :before="sectionsDetail.before"
-            :after="sectionsDetail.after"
+            :before="sectionsDetail?.before"
+            :after="sectionsDetail?.after"
           />
           <span v-else-if="sectionsDetail === null">Loading…</span>
           <span v-else>Not available</span>

--- a/site/frontend/src/pages/compare/compile/table/benchmark-detail.vue
+++ b/site/frontend/src/pages/compare/compile/table/benchmark-detail.vue
@@ -35,7 +35,7 @@ function createSectionsSelector(): CompileDetailSectionsSelector {
     benchmark: props.testCase.benchmark,
     profile: props.testCase.profile,
     scenario: props.testCase.scenario,
-    parallel: props.testCase.parallel.toString(),
+    frontendThreads: props.testCase.frontendThreads.toString(),
     backend: props.testCase.backend,
     target: props.testCase.target,
     start: props.baseArtifact.commit,
@@ -57,7 +57,7 @@ function detailedQueryLink(
 ): string {
   const {benchmark, profile, scenario, parallel, backend, target} =
     props.testCase;
-  let link = `/detailed-query.html?commit=${commit.commit}&benchmark=${benchmark}-${profile}&scenario=${scenario}&parallel=${parallel}&backend=${backend}&target=${target}`;
+  let link = `/detailed-query.html?commit=${commit.commit}&benchmark=${benchmark}-${profile}&scenario=${scenario}&parallel=${frontendThreads}&backend=${backend}&target=${target}`;
   if (baseCommit !== undefined) {
     link += `&base_commit=${baseCommit.commit}`;
   }
@@ -75,7 +75,7 @@ function graphLink(
   );
   const end = commit.commit;
   const {benchmark, profile, scenario, parallel, target, backend} = testCase;
-  return `/index.html?start=${start}&end=${end}&benchmark=${benchmark}&profile=${profile}&scenario=${scenario}&parallel=${parallel}&target=${target}&backend=${backend}&stat=${metric}`;
+  return `/index.html?start=${start}&end=${end}&benchmark=${benchmark}&profile=${profile}&scenario=${scenario}&parallel=${frontendThreads}&target=${target}&backend=${backend}&stat=${metric}`;
 }
 
 const metadata = computed(
@@ -125,7 +125,7 @@ onMounted(() => {
             </tr>
             <tr>
               <td>Parallel</td>
-              <td>{{ testCase.parallel }}</td>
+              <td>{{ testCase.frontendThreads }}</td>
             </tr>
             <tr>
               <td>Category</td>

--- a/site/frontend/src/pages/compare/compile/table/benchmark-detail.vue
+++ b/site/frontend/src/pages/compare/compile/table/benchmark-detail.vue
@@ -55,9 +55,9 @@ function detailedQueryLink(
   commit: ArtifactDescription,
   baseCommit?: ArtifactDescription
 ): string {
-  const {benchmark, profile, scenario, parallel, backend, target} =
+  const {benchmark, profile, scenario, frontendThreads, backend, target} =
     props.testCase;
-  let link = `/detailed-query.html?commit=${commit.commit}&benchmark=${benchmark}-${profile}&scenario=${scenario}&parallel=${frontendThreads}&backend=${backend}&target=${target}`;
+  let link = `/detailed-query.html?commit=${commit.commit}&benchmark=${benchmark}-${profile}&scenario=${scenario}&frontendThreads=${frontendThreads}&backend=${backend}&target=${target}`;
   if (baseCommit !== undefined) {
     link += `&base_commit=${baseCommit.commit}`;
   }
@@ -74,8 +74,9 @@ function graphLink(
     getPastDate(commit.date ? new Date(commit.date) : new Date(), 30)
   );
   const end = commit.commit;
-  const {benchmark, profile, scenario, parallel, target, backend} = testCase;
-  return `/index.html?start=${start}&end=${end}&benchmark=${benchmark}&profile=${profile}&scenario=${scenario}&parallel=${frontendThreads}&target=${target}&backend=${backend}&stat=${metric}`;
+  const {benchmark, profile, scenario, frontendThreads, target, backend} =
+    testCase;
+  return `/index.html?start=${start}&end=${end}&benchmark=${benchmark}&profile=${profile}&scenario=${scenario}&frontendThreads=${frontendThreads}&target=${target}&backend=${backend}&stat=${metric}`;
 }
 
 const metadata = computed(
@@ -124,7 +125,7 @@ onMounted(() => {
               <td>{{ testCase.scenario }}</td>
             </tr>
             <tr>
-              <td>Parallel</td>
+              <td>FrontendThreads</td>
               <td>{{ testCase.frontendThreads }}</td>
             </tr>
             <tr>

--- a/site/frontend/src/pages/compare/compile/table/comparisons-table.vue
+++ b/site/frontend/src/pages/compare/compile/table/comparisons-table.vue
@@ -27,7 +27,7 @@ function prettifyRawNumber(number: number): string {
 
 // Modify this when changing the number of columns in the table!
 const columnCount = computed(() => {
-  const base = 8;
+  const base = 9;
   if (props.showRawData) {
     return base + 2;
   }
@@ -61,6 +61,7 @@ const unit = computed(() => {
           <th>Benchmark</th>
           <th>Profile</th>
           <th>Scenario</th>
+          <th>Parallel</th>
           <th v-if="showBackend">Backend</th>
           <th>Target</th>
           <th>% Change</th>
@@ -101,6 +102,7 @@ const unit = computed(() => {
                 {{ comparison.testCase.profile }}
               </td>
               <td>{{ comparison.testCase.scenario }}</td>
+              <td>{{ comparison.testCase.parallel }}</td>
               <td v-if="showBackend">{{ comparison.testCase.backend }}</td>
               <td :title="comparison.testCase.target">
                 {{ formatTarget(comparison.testCase.target) }}

--- a/site/frontend/src/pages/compare/compile/table/comparisons-table.vue
+++ b/site/frontend/src/pages/compare/compile/table/comparisons-table.vue
@@ -49,7 +49,7 @@ const unit = computed(() => {
     <slot name="header"></slot>
     <div v-if="comparisons.length === 0" style="text-align: center">
       {{
-        hasNonRelevant
+hasNonRelevant
           ? "No relevant results (enable Filters -> Show non-relevant results to see all)"
           : "No results"
       }}
@@ -102,7 +102,7 @@ const unit = computed(() => {
                 {{ comparison.testCase.profile }}
               </td>
               <td>{{ comparison.testCase.scenario }}</td>
-              <td>{{ comparison.testCase.parallel }}</td>
+              <td>{{ comparison.testCase.frontendThreads }}</td>
               <td v-if="showBackend">{{ comparison.testCase.backend }}</td>
               <td :title="comparison.testCase.target">
                 {{ formatTarget(comparison.testCase.target) }}
@@ -118,7 +118,7 @@ const unit = computed(() => {
                 <div class="numeric-aligned">
                   <div>
                     {{
-                      comparison.significanceThreshold
+comparison.significanceThreshold
                         ? comparison.significanceThreshold.toFixed(2) + "%"
                         : "-"
                     }}
@@ -129,7 +129,7 @@ const unit = computed(() => {
                 <div class="numeric-aligned">
                   <div>
                     {{
-                      comparison.significanceFactor
+comparison.significanceFactor
                         ? comparison.significanceFactor.toFixed(2) + "x"
                         : "-"
                     }}

--- a/site/frontend/src/pages/compare/compile/table/comparisons-table.vue
+++ b/site/frontend/src/pages/compare/compile/table/comparisons-table.vue
@@ -49,7 +49,7 @@ const unit = computed(() => {
     <slot name="header"></slot>
     <div v-if="comparisons.length === 0" style="text-align: center">
       {{
-hasNonRelevant
+        hasNonRelevant
           ? "No relevant results (enable Filters -> Show non-relevant results to see all)"
           : "No results"
       }}
@@ -118,7 +118,7 @@ hasNonRelevant
                 <div class="numeric-aligned">
                   <div>
                     {{
-comparison.significanceThreshold
+                      comparison.significanceThreshold
                         ? comparison.significanceThreshold.toFixed(2) + "%"
                         : "-"
                     }}
@@ -129,7 +129,7 @@ comparison.significanceThreshold
                 <div class="numeric-aligned">
                   <div>
                     {{
-comparison.significanceFactor
+                      comparison.significanceFactor
                         ? comparison.significanceFactor.toFixed(2) + "x"
                         : "-"
                     }}

--- a/site/frontend/src/pages/compare/compile/table/comparisons-table.vue
+++ b/site/frontend/src/pages/compare/compile/table/comparisons-table.vue
@@ -61,7 +61,7 @@ const unit = computed(() => {
           <th>Benchmark</th>
           <th>Profile</th>
           <th>Scenario</th>
-          <th>Parallel</th>
+          <th>FrontendThreads</th>
           <th v-if="showBackend">Backend</th>
           <th>Target</th>
           <th>% Change</th>

--- a/site/frontend/src/pages/compare/compile/table/detail-resolver.ts
+++ b/site/frontend/src/pages/compare/compile/table/detail-resolver.ts
@@ -12,6 +12,7 @@ export interface CompileDetailGraphsSelector {
   stat: string;
   benchmark: string;
   scenario: string;
+  parallel: string;
   profile: string;
   backend: string;
   target: string;
@@ -32,6 +33,7 @@ export interface CompileDetailSectionsSelector {
   end: string;
   benchmark: string;
   scenario: string;
+  parallel: string;
   profile: string;
   backend: string;
   target: string;
@@ -66,7 +68,7 @@ export const COMPILE_DETAIL_GRAPHS_RESOLVER: CachedDataLoader<
   CompileDetailGraphs
 > = new CachedDataLoader(
   (key: CompileDetailGraphsSelector) =>
-    `${key.benchmark};${key.profile};${key.scenario};${key.backend};${key.start};${key.end};${key.stat};${key.kinds};${key.target}`,
+    `${key.benchmark};${key.profile};${key.scenario};${key.parallel};${key.backend};${key.start};${key.end};${key.stat};${key.kinds};${key.target}`,
   loadGraphsDetail
 );
 
@@ -79,6 +81,7 @@ async function loadGraphsDetail(
     stat: selector.stat,
     benchmark: selector.benchmark,
     scenario: selector.scenario,
+    parallel: selector.parallel,
     profile: selector.profile,
     backend: selector.backend,
     target: selector.target,
@@ -96,7 +99,7 @@ export const COMPILE_DETAIL_SECTIONS_RESOLVER: CachedDataLoader<
   CompileDetailSections
 > = new CachedDataLoader(
   (key: CompileDetailSectionsSelector) =>
-    `${key.benchmark};${key.profile};${key.scenario};${key.backend};${key.target};${key.start};${key.end}`,
+    `${key.benchmark};${key.profile};${key.scenario};${key.parallel};${key.backend};${key.target};${key.start};${key.end}`,
   loadSectionsDetail
 );
 
@@ -108,6 +111,7 @@ async function loadSectionsDetail(
     end: selector.end,
     benchmark: selector.benchmark,
     scenario: selector.scenario,
+    parallel: selector.parallel,
     profile: selector.profile,
     backend: selector.backend,
     target: selector.target,

--- a/site/frontend/src/pages/compare/compile/table/detail-resolver.ts
+++ b/site/frontend/src/pages/compare/compile/table/detail-resolver.ts
@@ -1,4 +1,10 @@
-import {GraphKind, Series} from "../../../../graph/data";
+import {
+  FrontendThreads,
+  GraphKind,
+  Scenario,
+  Series,
+  Profile,
+} from "../../../../graph/data";
 import {getJson} from "../../../../utils/requests";
 import {
   COMPARE_COMPILE_DETAIL_GRAPHS_DATA_URL,
@@ -11,9 +17,9 @@ export interface CompileDetailGraphsSelector {
   end: string;
   stat: string;
   benchmark: string;
-  scenario: string;
-  frontendThreads: string;
-  profile: string;
+  scenario: Scenario;
+  frontendThreads: FrontendThreads;
+  profile: Profile;
   backend: string;
   target: string;
   kinds: GraphKind[];

--- a/site/frontend/src/pages/compare/compile/table/detail-resolver.ts
+++ b/site/frontend/src/pages/compare/compile/table/detail-resolver.ts
@@ -12,7 +12,7 @@ export interface CompileDetailGraphsSelector {
   stat: string;
   benchmark: string;
   scenario: string;
-  parallel: string;
+  frontendThreads: string;
   profile: string;
   backend: string;
   target: string;
@@ -33,7 +33,7 @@ export interface CompileDetailSectionsSelector {
   end: string;
   benchmark: string;
   scenario: string;
-  parallel: string;
+  frontendThreads: string;
   profile: string;
   backend: string;
   target: string;
@@ -68,7 +68,7 @@ export const COMPILE_DETAIL_GRAPHS_RESOLVER: CachedDataLoader<
   CompileDetailGraphs
 > = new CachedDataLoader(
   (key: CompileDetailGraphsSelector) =>
-    `${key.benchmark};${key.profile};${key.scenario};${key.parallel};${key.backend};${key.start};${key.end};${key.stat};${key.kinds};${key.target}`,
+    `${key.benchmark};${key.profile};${key.scenario};${key.frontendThreads};${key.backend};${key.start};${key.end};${key.stat};${key.kinds};${key.target}`,
   loadGraphsDetail
 );
 
@@ -81,7 +81,7 @@ async function loadGraphsDetail(
     stat: selector.stat,
     benchmark: selector.benchmark,
     scenario: selector.scenario,
-    parallel: selector.parallel,
+    frontendThreads: selector.frontendThreads,
     profile: selector.profile,
     backend: selector.backend,
     target: selector.target,
@@ -99,7 +99,7 @@ export const COMPILE_DETAIL_SECTIONS_RESOLVER: CachedDataLoader<
   CompileDetailSections
 > = new CachedDataLoader(
   (key: CompileDetailSectionsSelector) =>
-    `${key.benchmark};${key.profile};${key.scenario};${key.parallel};${key.backend};${key.target};${key.start};${key.end}`,
+    `${key.benchmark};${key.profile};${key.scenario};${key.frontendThreads};${key.backend};${key.target};${key.start};${key.end}`,
   loadSectionsDetail
 );
 
@@ -111,7 +111,7 @@ async function loadSectionsDetail(
     end: selector.end,
     benchmark: selector.benchmark,
     scenario: selector.scenario,
-    parallel: selector.parallel,
+    frontendThreads: selector.frontendThreads,
     profile: selector.profile,
     backend: selector.backend,
     target: selector.target,

--- a/site/frontend/src/pages/compare/compile/table/sections-chart.vue
+++ b/site/frontend/src/pages/compare/compile/table/sections-chart.vue
@@ -154,14 +154,14 @@ function deactivate() {
                   </div>
                   <div>
                     {{
-                      getSectionByName(
+getSectionByName(
                         props.before,
                         section.name
                       )?.value?.toLocaleString() ?? "??"
                     }}
                     ->
                     {{
-                      getSectionByName(
+getSectionByName(
                         props.after,
                         section.name
                       )?.value.toLocaleString() ?? "??"

--- a/site/frontend/src/pages/compare/compile/table/sections-chart.vue
+++ b/site/frontend/src/pages/compare/compile/table/sections-chart.vue
@@ -154,14 +154,14 @@ function deactivate() {
                   </div>
                   <div>
                     {{
-getSectionByName(
+                      getSectionByName(
                         props.before,
                         section.name
                       )?.value?.toLocaleString() ?? "??"
                     }}
                     ->
                     {{
-getSectionByName(
+                      getSectionByName(
                         props.after,
                         section.name
                       )?.value.toLocaleString() ?? "??"

--- a/site/frontend/src/pages/compare/compile/table/shortcuts/cachegrind-cmd.vue
+++ b/site/frontend/src/pages/compare/compile/table/shortcuts/cachegrind-cmd.vue
@@ -4,7 +4,7 @@
  **/
 
 import {CompileTestCase} from "../../common";
-import {computed} from "vue";
+import {computed, ref} from "vue";
 import {normalizeProfile} from "./utils";
 import {cargo_collector_command} from "../../../../../utils/cargo";
 
@@ -34,16 +34,39 @@ function normalizeScenario(scenario: string): string {
   }
   return "<invalid scenario>";
 }
+
+const codeBlock = ref<HTMLElement | null>(null);
+const buttonText = ref("Copy");
+
+const copyCode = async () => {
+  if (codeBlock.value) {
+    const textToCopy = codeBlock.value.innerText;
+    try {
+      await navigator.clipboard.writeText(textToCopy);
+      buttonText.value = "Copied!";
+      setTimeout(() => {
+        buttonText.value = "Copy";
+      }, 2000);
+    } catch (err) {
+      console.error("Copy error:", err);
+      buttonText.value = "Error";
+    }
+  }
+};
 </script>
 
 <template>
-  <pre><code>{{ cargo_collector_command() }} \
+  <button style="margin-left: 10px" @click="copyCode">
+    {{ buttonText }}
+  </button>
+  <pre><code ref="codeBlock">{{ cargo_collector_command() }} \
     profile_local cachegrind \
     +{{ firstCommit }} \<template v-if="props.baselineCommit !== undefined">
     --rustc2 +{{ props.commit }} \</template>
     --exact-match {{ testCase.benchmark }} \
     --profiles {{ normalizeProfile(testCase.profile) }} \
-    --scenarios {{ normalizeScenario(testCase.scenario) }}</code></pre>
+    --scenarios {{ normalizeScenario(testCase.scenario) }} \
+    --parallels {{ testCase.parallel }}</code></pre>
 </template>
 
 <style scoped lang="scss">

--- a/site/frontend/src/pages/compare/compile/table/shortcuts/cachegrind-cmd.vue
+++ b/site/frontend/src/pages/compare/compile/table/shortcuts/cachegrind-cmd.vue
@@ -66,7 +66,7 @@ const copyCode = async () => {
     --exact-match {{ testCase.benchmark }} \
     --profiles {{ normalizeProfile(testCase.profile) }} \
     --scenarios {{ normalizeScenario(testCase.scenario) }} \
-    --parallels {{ testCase.parallel }}</code></pre>
+    --parallels {{ testCase.frontendThreads }}</code></pre>
 </template>
 
 <style scoped lang="scss">

--- a/site/frontend/src/pages/compare/compile/table/shortcuts/cachegrind-cmd.vue
+++ b/site/frontend/src/pages/compare/compile/table/shortcuts/cachegrind-cmd.vue
@@ -66,7 +66,7 @@ const copyCode = async () => {
     --exact-match {{ testCase.benchmark }} \
     --profiles {{ normalizeProfile(testCase.profile) }} \
     --scenarios {{ normalizeScenario(testCase.scenario) }} \
-    --parallels {{ testCase.frontendThreads }}</code></pre>
+    --frontend-threads {{ testCase.frontendThreads }}</code></pre>
 </template>
 
 <style scoped lang="scss">

--- a/site/frontend/src/pages/compare/compile/table/shortcuts/utils.ts
+++ b/site/frontend/src/pages/compare/compile/table/shortcuts/utils.ts
@@ -1,7 +1,7 @@
-import {Profile} from "../../common";
+import {ProfileEnumeration} from "../../common";
 
 // Normalize profile from a test case to a CLI value for collector.
-export function normalizeProfile(profile: Profile): string {
+export function normalizeProfile(profile: ProfileEnumeration): string {
   if (profile === "opt") {
     return "Opt";
   } else if (profile === "debug") {

--- a/site/frontend/src/pages/compare/metric-selector.vue
+++ b/site/frontend/src/pages/compare/metric-selector.vue
@@ -32,7 +32,7 @@ function changeMetric(e: Event) {
       :title="metric.description"
     >
       <a :href="createUrlForMetric(metric.metric).toString()">{{
-metric.label
+        metric.label
       }}</a>
     </div>
     <select class="stats" @change="changeMetric" v-if="metrics.length > 0">

--- a/site/frontend/src/pages/compare/metric-selector.vue
+++ b/site/frontend/src/pages/compare/metric-selector.vue
@@ -32,7 +32,7 @@ function changeMetric(e: Event) {
       :title="metric.description"
     >
       <a :href="createUrlForMetric(metric.metric).toString()">{{
-        metric.label
+metric.label
       }}</a>
     </div>
     <select class="stats" @change="changeMetric" v-if="metrics.length > 0">

--- a/site/frontend/src/pages/compare/page.vue
+++ b/site/frontend/src/pages/compare/page.vue
@@ -66,7 +66,13 @@ async function loadCompareData(
       end: selector.end,
       stat: selector.stat,
     };
-    return await postMsgpack<CompareResponse>(COMPARE_DATA_URL, params);
+    const result = await postMsgpack<CompareResponse>(COMPARE_DATA_URL, params);
+    if (result.compile_comparisons[0].frontendThreads == null) {
+      throw new EvalError(
+        `bad response:\n${JSON.stringify(result.compile_comparisons)}`
+      );
+    }
+    return result;
   });
   data.value = response;
 

--- a/site/frontend/src/pages/compare/page.vue
+++ b/site/frontend/src/pages/compare/page.vue
@@ -67,10 +67,8 @@ async function loadCompareData(
       stat: selector.stat,
     };
     const result = await postMsgpack<CompareResponse>(COMPARE_DATA_URL, params);
-    if (result.compile_comparisons[0].frontendThreads == null) {
-      throw new EvalError(
-        `bad response:\n${JSON.stringify(result.compile_comparisons)}`
-      );
+    if (result.compile_comparisons[0]?.frontendThreads == null) {
+      throw new EvalError(`bad response:\n${JSON.stringify(result)}`);
     }
     return result;
   });

--- a/site/frontend/src/pages/compare/runtime/benchmark-detail-graph.vue
+++ b/site/frontend/src/pages/compare/runtime/benchmark-detail-graph.vue
@@ -66,6 +66,7 @@ async function renderGraphs(detail: RuntimeDetailGraphs) {
       end: selector.end,
       profile: null,
       scenario: null,
+      parallel: null,
       target: selector.target,
       backend: null,
       kind,
@@ -110,6 +111,9 @@ async function renderGraph(
   date: Date | null,
   chartRef: Ref<HTMLElement | null>
 ) {
+  if (chartRef.value === null) {
+    return;
+  }
   const opts: GraphRenderOpts = {
     width: Math.min(window.innerWidth - 40, 465),
     height: 300,
@@ -181,15 +185,15 @@ function getGraphRange(
   // If this is a try commit, we don't know its future, so always we just display
   // the last `DAY_RANGE` days.
   if (artifact.type === "try") {
-    const date = new Date(artifact.date);
+    const date = artifact.date ? new Date(artifact.date) : new Date();
     return {
       start: formatDate(getPastDate(date, DAY_RANGE)),
       end: artifact.commit,
       date: null,
     };
   } else {
-    let [start_date, end_date] = [baseArtifact, artifact].map(
-      (c) => new Date(c.date)
+    let [start_date, end_date] = [baseArtifact, artifact].map((c) =>
+      c.date ? new Date(c.date) : new Date()
     );
     // If this is a master commit, we attempt to display more than the full history for commit
     // ranges. If the commit range is not larger than the `dayRange`, the display will likely be

--- a/site/frontend/src/pages/compare/runtime/benchmark-detail-graph.vue
+++ b/site/frontend/src/pages/compare/runtime/benchmark-detail-graph.vue
@@ -66,7 +66,7 @@ async function renderGraphs(detail: RuntimeDetailGraphs) {
       end: selector.end,
       profile: null,
       scenario: null,
-      parallel: null,
+      frontendThreads: null,
       target: selector.target,
       backend: null,
       kind,

--- a/site/frontend/src/pages/compare/runtime/comparisons-table.vue
+++ b/site/frontend/src/pages/compare/runtime/comparisons-table.vue
@@ -103,7 +103,7 @@ const unit = computed(() => {
                 <div class="numeric-aligned">
                   <div>
                     {{
-comparison.significanceThreshold
+                      comparison.significanceThreshold
                         ? comparison.significanceThreshold.toFixed(2) + "%"
                         : "-"
                     }}
@@ -114,7 +114,7 @@ comparison.significanceThreshold
                 <div class="numeric-aligned">
                   <div>
                     {{
-comparison.significanceFactor
+                      comparison.significanceFactor
                         ? comparison.significanceFactor.toFixed(2) + "x"
                         : "-"
                     }}

--- a/site/frontend/src/pages/compare/runtime/comparisons-table.vue
+++ b/site/frontend/src/pages/compare/runtime/comparisons-table.vue
@@ -103,7 +103,7 @@ const unit = computed(() => {
                 <div class="numeric-aligned">
                   <div>
                     {{
-                      comparison.significanceThreshold
+comparison.significanceThreshold
                         ? comparison.significanceThreshold.toFixed(2) + "%"
                         : "-"
                     }}
@@ -114,7 +114,7 @@ const unit = computed(() => {
                 <div class="numeric-aligned">
                   <div>
                     {{
-                      comparison.significanceFactor
+comparison.significanceFactor
                         ? comparison.significanceFactor.toFixed(2) + "x"
                         : "-"
                     }}

--- a/site/frontend/src/pages/compare/shared.ts
+++ b/site/frontend/src/pages/compare/shared.ts
@@ -2,7 +2,7 @@ import {Target} from "./compile/common";
 
 export function formatDate(dateString: string): string {
   const date = new Date(dateString);
-  function padStr(i) {
+  function padStr(i: number) {
     return i < 10 ? "0" + i : "" + i;
   }
   return `${date.getUTCFullYear()}-${padStr(date.getUTCMonth() + 1)}-${padStr(
@@ -62,7 +62,7 @@ export function formatPercentChange(
   if (!isValidValue(before) || !isValidValue(after)) {
     return invalidPlaceholder;
   }
-  return `${(((after - before) / before) * 100).toFixed(3)}%`;
+  return `${(((after! - before!) / before!) * 100).toFixed(3)}%`;
 }
 
 // Checks if the value is not undefined and not zero
@@ -116,13 +116,13 @@ export function targetMatchesFilter(
 
 // Store the bool value into URL parameters, or reset it if it has the default
 // value.
-export function storeOrResetBool<T extends boolean | string>(
+export function storeOrResetBool<T extends boolean | string | null>(
   urlParams: Dict<string>,
   name: string,
   value: T,
   defaultValue: T
 ) {
-  if (value === defaultValue) {
+  if (value === defaultValue || value === null) {
     if (urlParams.hasOwnProperty(name)) {
       delete urlParams[name];
     }

--- a/site/frontend/src/pages/compare/tabs.vue
+++ b/site/frontend/src/pages/compare/tabs.vue
@@ -1,5 +1,5 @@
 <script setup lang="tsx">
-import {h, ref, Ref} from "vue";
+import {ref, Ref} from "vue";
 import {CompareResponse, Tab} from "./types";
 import {
   diffClass,

--- a/site/frontend/src/pages/compare/tabs.vue
+++ b/site/frontend/src/pages/compare/tabs.vue
@@ -134,7 +134,7 @@ const activeTab: Ref<Tab> = ref(props.initialTab);
           :class="{[diffClass(bootstrapB - bootstrapA)]: bootstrapValid}"
         >
           {{ ((bootstrapB - bootstrapA) / 10e8).toFixed(1) }}s ({{
-(((bootstrapB - bootstrapA) / bootstrapA) * 100).toFixed(3)
+            (((bootstrapB - bootstrapA) / bootstrapA) * 100).toFixed(3)
           }}%)
         </div>
       </template>
@@ -157,7 +157,7 @@ const activeTab: Ref<Tab> = ref(props.initialTab);
         >
           {{ totalSizeB < totalSizeA ? "-" : ""
           }}{{ formatSize(Math.abs(totalSizeB - totalSizeA)) }} ({{
-formatPercentChange(totalSizeA, totalSizeB)
+            formatPercentChange(totalSizeA, totalSizeB)
           }})
         </div>
       </template>

--- a/site/frontend/src/pages/compare/tabs.vue
+++ b/site/frontend/src/pages/compare/tabs.vue
@@ -134,7 +134,7 @@ const activeTab: Ref<Tab> = ref(props.initialTab);
           :class="{[diffClass(bootstrapB - bootstrapA)]: bootstrapValid}"
         >
           {{ ((bootstrapB - bootstrapA) / 10e8).toFixed(1) }}s ({{
-            (((bootstrapB - bootstrapA) / bootstrapA) * 100).toFixed(3)
+(((bootstrapB - bootstrapA) / bootstrapA) * 100).toFixed(3)
           }}%)
         </div>
       </template>
@@ -157,7 +157,7 @@ const activeTab: Ref<Tab> = ref(props.initialTab);
         >
           {{ totalSizeB < totalSizeA ? "-" : ""
           }}{{ formatSize(Math.abs(totalSizeB - totalSizeA)) }} ({{
-            formatPercentChange(totalSizeA, totalSizeB)
+formatPercentChange(totalSizeA, totalSizeB)
           }})
         </div>
       </template>

--- a/site/frontend/src/pages/detailed-query/page.vue
+++ b/site/frontend/src/pages/detailed-query/page.vue
@@ -1,5 +1,5 @@
 <script setup lang="tsx">
-import {h, ref, Ref, computed} from "vue";
+import {ref, Ref, computed} from "vue";
 import {getUrlParams, changeUrl} from "../../utils/navigation";
 import {postMsgpack} from "../../utils/requests";
 import {SELF_PROFILE_DATA_URL} from "../../urls";
@@ -15,7 +15,14 @@ import {
   TableRowData,
 } from "./utils";
 
-const loading = ref(true);
+enum Status {
+  Loading = "LOADING",
+  Ready = "READY",
+  Failed = "FAILED",
+}
+
+const status = ref<Status>(Status.Loading);
+const errorMsg = ref("");
 const data: Ref<SelfProfileResponse | null> = ref(null);
 const selector: Ref<Selector | null> = ref(null);
 const showIncr = ref(true);
@@ -189,7 +196,8 @@ function storeSortToUrl() {
 
 async function loadData() {
   const params = getUrlParams();
-  const {commit, base_commit, benchmark, scenario, backend, target} = params;
+  const {commit, base_commit, benchmark, scenario, parallel, backend, target} =
+    params;
 
   // Load sort state from URL
   loadSortFromUrl(params);
@@ -206,19 +214,29 @@ async function loadData() {
     base_commit: base_commit ?? null,
     benchmark: benchmarkSeparate,
     scenario,
+    parallel,
     profile,
     backend,
     target,
   };
   selector.value = currentSelector;
-
-  const response = await postMsgpack<SelfProfileResponse>(
-    SELF_PROFILE_DATA_URL,
-    currentSelector
-  );
-  data.value = response;
-  populateUIData(response, currentSelector);
-  loading.value = false;
+  try {
+    const response = await postMsgpack<SelfProfileResponse>(
+      SELF_PROFILE_DATA_URL,
+      currentSelector,
+      false
+    );
+    data.value = response;
+    populateUIData(response, currentSelector);
+    status.value = Status.Ready;
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      errorMsg.value = error.message;
+    } else {
+      errorMsg.value = String(error);
+    }
+    status.value = Status.Failed;
+  }
 }
 
 function populateUIData(responseData: SelfProfileResponse, state: Selector) {
@@ -298,12 +316,16 @@ function DeltaComponent({delta}: {delta: DeltaData | null}) {
 }
 
 loadData();
+const LoadingStatus = Status;
 </script>
 
 <template>
   <div>
-    <div v-if="loading">
+    <div v-if="status === LoadingStatus.Loading">
       <p>Loading...</p>
+    </div>
+    <div v-else-if="status === LoadingStatus.Failed">
+      <p>{{ errorMsg }}</p>
     </div>
     <div v-else id="content">
       <h3 id="title">

--- a/site/frontend/src/pages/detailed-query/page.vue
+++ b/site/frontend/src/pages/detailed-query/page.vue
@@ -196,8 +196,15 @@ function storeSortToUrl() {
 
 async function loadData() {
   const params = getUrlParams();
-  const {commit, base_commit, benchmark, scenario, parallel, backend, target} =
-    params;
+  const {
+    commit,
+    base_commit,
+    benchmark,
+    scenario,
+    frontendThreads,
+    backend,
+    target,
+  } = params;
 
   // Load sort state from URL
   loadSortFromUrl(params);
@@ -214,7 +221,7 @@ async function loadData() {
     base_commit: base_commit ?? null,
     benchmark: benchmarkSeparate,
     scenario,
-    parallel,
+    frontendThreads,
     profile,
     backend,
     target,

--- a/site/frontend/src/pages/detailed-query/utils.ts
+++ b/site/frontend/src/pages/detailed-query/utils.ts
@@ -10,6 +10,7 @@ export interface Selector {
   benchmark: string;
   profile: string;
   scenario: string;
+  parallel: string;
   backend: string;
   target: string;
 }
@@ -81,6 +82,7 @@ export function perfettoProfilerData(
   commit: string,
   benchmark: string,
   scenario: string,
+  parallel: string,
   profile: string,
   backend: string,
   target: string
@@ -89,11 +91,12 @@ export function perfettoProfilerData(
     commit,
     benchmark,
     scenario,
+    parallel,
     profile,
     backend,
     target
   );
-  const traceTitle = `${benchmark}-${scenario} (${commit})`;
+  const traceTitle = `${benchmark}-${scenario}-par${parallel} (${commit})`;
   return {link, traceTitle};
 }
 
@@ -113,7 +116,7 @@ export function createTitleData(selector: Selector | null): {
   let selfHref = "";
 
   if (state.base_commit) {
-    const args = `&scenario=${state.scenario}&benchmark=${state.benchmark}-${state.profile}&backend=${state.backend}&target=${state.target}`;
+    const args = `&scenario=${state.scenario}&parallel=${state.parallel}&benchmark=${state.benchmark}-${state.profile}&backend=${state.backend}&target=${state.target}`;
     selfHref = `/detailed-query.html?commit=${state.commit}${args}`;
     baseHref = `/detailed-query.html?commit=${state.base_commit}${args}`;
   }
@@ -178,11 +181,12 @@ export function createDownloadLinksData(selector: Selector | null): {
       : "???";
 
   const createLinks = (commit: string) => ({
-    raw: `/perf/download-raw-self-profile?commit=${commit}&benchmark=${state.benchmark}&profile=${state.profile}&scenario=${state.scenario}&backend=${state.backend}&target=${state.target}`,
+    raw: `/perf/download-raw-self-profile?commit=${commit}&benchmark=${state.benchmark}&profile=${state.profile}&scenario=${state.scenario}&parallel=${state.parallel}&backend=${state.backend}&target=${state.target}`,
     flamegraph: processedSelfProfileRelativeUrl(
       commit,
       state.benchmark,
       state.scenario,
+      state.parallel.toString(),
       state.profile,
       state.backend,
       state.target,
@@ -192,6 +196,7 @@ export function createDownloadLinksData(selector: Selector | null): {
       commit,
       state.benchmark,
       state.scenario,
+      state.parallel.toString(),
       state.profile,
       state.backend,
       state.target,
@@ -201,6 +206,7 @@ export function createDownloadLinksData(selector: Selector | null): {
       commit,
       state.benchmark,
       state.scenario,
+      state.parallel.toString(),
       state.profile,
       state.backend,
       state.target,
@@ -210,6 +216,7 @@ export function createDownloadLinksData(selector: Selector | null): {
       commit,
       state.benchmark,
       state.scenario,
+      state.parallel.toString(),
       state.profile,
       state.backend,
       state.target
@@ -219,6 +226,7 @@ export function createDownloadLinksData(selector: Selector | null): {
         commit,
         state.benchmark,
         state.scenario,
+        state.parallel.toString(),
         state.profile,
         state.backend,
         state.target
@@ -230,7 +238,7 @@ export function createDownloadLinksData(selector: Selector | null): {
   const newLinks = createLinks(state.commit);
 
   const diffLink = state.base_commit
-    ? `/perf/processed-self-profile?commit=${state.commit}&base_commit=${state.base_commit}&benchmark=${state.benchmark}&profile=${state.profile}&scenario=${state.scenario}&backend=${state.backend}&target=${state.target}&type=codegen-schedule`
+    ? `/perf/processed-self-profile?commit=${state.commit}&base_commit=${state.base_commit}&benchmark=${state.benchmark}&profile=${state.profile}&scenario=${state.scenario}&parallel=${state.parallel}&backend=${state.backend}&target=${state.target}&type=codegen-schedule`
     : "";
 
   function cachegrindCommand(
@@ -246,6 +254,7 @@ export function createDownloadLinksData(selector: Selector | null): {
     cmd += ` --exact-match ${state.benchmark}`;
     cmd += ` --profiles ${profile(state.profile)}`;
     cmd += ` --scenarios ${scenarioFilter(state.scenario)}`;
+    cmd += ` --parallels ${state.parallel}`;
     return cmd;
   }
 

--- a/site/frontend/src/pages/detailed-query/utils.ts
+++ b/site/frontend/src/pages/detailed-query/utils.ts
@@ -254,7 +254,7 @@ export function createDownloadLinksData(selector: Selector | null): {
     cmd += ` --exact-match ${state.benchmark}`;
     cmd += ` --profiles ${profile(state.profile)}`;
     cmd += ` --scenarios ${scenarioFilter(state.scenario)}`;
-    cmd += ` --parallels ${state.frontendThreads}`;
+    cmd += ` --frontend-threads ${state.frontendThreads}`;
     return cmd;
   }
 

--- a/site/frontend/src/pages/detailed-query/utils.ts
+++ b/site/frontend/src/pages/detailed-query/utils.ts
@@ -96,7 +96,7 @@ export function perfettoProfilerData(
     backend,
     target
   );
-  const traceTitle = `${benchmark}-${scenario}-par${frontendThreads} (${commit})`;
+  const traceTitle = `${benchmark}-${scenario}-threads_${frontendThreads} (${commit})`;
   return {link, traceTitle};
 }
 
@@ -116,7 +116,7 @@ export function createTitleData(selector: Selector | null): {
   let selfHref = "";
 
   if (state.base_commit) {
-    const args = `&scenario=${state.scenario}&parallel=${state.frontendThreads}&benchmark=${state.benchmark}-${state.profile}&backend=${state.backend}&target=${state.target}`;
+    const args = `&scenario=${state.scenario}&frontendThreads=${state.frontendThreads}&benchmark=${state.benchmark}-${state.profile}&backend=${state.backend}&target=${state.target}`;
     selfHref = `/detailed-query.html?commit=${state.commit}${args}`;
     baseHref = `/detailed-query.html?commit=${state.base_commit}${args}`;
   }
@@ -181,7 +181,7 @@ export function createDownloadLinksData(selector: Selector | null): {
       : "???";
 
   const createLinks = (commit: string) => ({
-    raw: `/perf/download-raw-self-profile?commit=${commit}&benchmark=${state.benchmark}&profile=${state.profile}&scenario=${state.scenario}&parallel=${state.frontendThreads}&backend=${state.backend}&target=${state.target}`,
+    raw: `/perf/download-raw-self-profile?commit=${commit}&benchmark=${state.benchmark}&profile=${state.profile}&scenario=${state.scenario}&frontendThreads=${state.frontendThreads}&backend=${state.backend}&target=${state.target}`,
     flamegraph: processedSelfProfileRelativeUrl(
       commit,
       state.benchmark,
@@ -238,7 +238,7 @@ export function createDownloadLinksData(selector: Selector | null): {
   const newLinks = createLinks(state.commit);
 
   const diffLink = state.base_commit
-    ? `/perf/processed-self-profile?commit=${state.commit}&base_commit=${state.base_commit}&benchmark=${state.benchmark}&profile=${state.profile}&scenario=${state.scenario}&parallel=${state.frontendThreads}&backend=${state.backend}&target=${state.target}&type=codegen-schedule`
+    ? `/perf/processed-self-profile?commit=${state.commit}&base_commit=${state.base_commit}&benchmark=${state.benchmark}&profile=${state.profile}&scenario=${state.scenario}&frontendThreads=${state.frontendThreads}&backend=${state.backend}&target=${state.target}&type=codegen-schedule`
     : "";
 
   function cachegrindCommand(

--- a/site/frontend/src/pages/detailed-query/utils.ts
+++ b/site/frontend/src/pages/detailed-query/utils.ts
@@ -10,7 +10,7 @@ export interface Selector {
   benchmark: string;
   profile: string;
   scenario: string;
-  parallel: string;
+  frontendThreads: string;
   backend: string;
   target: string;
 }
@@ -82,7 +82,7 @@ export function perfettoProfilerData(
   commit: string,
   benchmark: string,
   scenario: string,
-  parallel: string,
+  frontendThreads: string,
   profile: string,
   backend: string,
   target: string
@@ -91,12 +91,12 @@ export function perfettoProfilerData(
     commit,
     benchmark,
     scenario,
-    parallel,
+    frontendThreads,
     profile,
     backend,
     target
   );
-  const traceTitle = `${benchmark}-${scenario}-par${parallel} (${commit})`;
+  const traceTitle = `${benchmark}-${scenario}-par${frontendThreads} (${commit})`;
   return {link, traceTitle};
 }
 
@@ -116,7 +116,7 @@ export function createTitleData(selector: Selector | null): {
   let selfHref = "";
 
   if (state.base_commit) {
-    const args = `&scenario=${state.scenario}&parallel=${state.parallel}&benchmark=${state.benchmark}-${state.profile}&backend=${state.backend}&target=${state.target}`;
+    const args = `&scenario=${state.scenario}&parallel=${state.frontendThreads}&benchmark=${state.benchmark}-${state.profile}&backend=${state.backend}&target=${state.target}`;
     selfHref = `/detailed-query.html?commit=${state.commit}${args}`;
     baseHref = `/detailed-query.html?commit=${state.base_commit}${args}`;
   }
@@ -181,12 +181,12 @@ export function createDownloadLinksData(selector: Selector | null): {
       : "???";
 
   const createLinks = (commit: string) => ({
-    raw: `/perf/download-raw-self-profile?commit=${commit}&benchmark=${state.benchmark}&profile=${state.profile}&scenario=${state.scenario}&parallel=${state.parallel}&backend=${state.backend}&target=${state.target}`,
+    raw: `/perf/download-raw-self-profile?commit=${commit}&benchmark=${state.benchmark}&profile=${state.profile}&scenario=${state.scenario}&parallel=${state.frontendThreads}&backend=${state.backend}&target=${state.target}`,
     flamegraph: processedSelfProfileRelativeUrl(
       commit,
       state.benchmark,
       state.scenario,
-      state.parallel.toString(),
+      state.frontendThreads.toString(),
       state.profile,
       state.backend,
       state.target,
@@ -196,7 +196,7 @@ export function createDownloadLinksData(selector: Selector | null): {
       commit,
       state.benchmark,
       state.scenario,
-      state.parallel.toString(),
+      state.frontendThreads.toString(),
       state.profile,
       state.backend,
       state.target,
@@ -206,7 +206,7 @@ export function createDownloadLinksData(selector: Selector | null): {
       commit,
       state.benchmark,
       state.scenario,
-      state.parallel.toString(),
+      state.frontendThreads.toString(),
       state.profile,
       state.backend,
       state.target,
@@ -216,7 +216,7 @@ export function createDownloadLinksData(selector: Selector | null): {
       commit,
       state.benchmark,
       state.scenario,
-      state.parallel.toString(),
+      state.frontendThreads.toString(),
       state.profile,
       state.backend,
       state.target
@@ -226,7 +226,7 @@ export function createDownloadLinksData(selector: Selector | null): {
         commit,
         state.benchmark,
         state.scenario,
-        state.parallel.toString(),
+        state.frontendThreads.toString(),
         state.profile,
         state.backend,
         state.target
@@ -238,7 +238,7 @@ export function createDownloadLinksData(selector: Selector | null): {
   const newLinks = createLinks(state.commit);
 
   const diffLink = state.base_commit
-    ? `/perf/processed-self-profile?commit=${state.commit}&base_commit=${state.base_commit}&benchmark=${state.benchmark}&profile=${state.profile}&scenario=${state.scenario}&parallel=${state.parallel}&backend=${state.backend}&target=${state.target}&type=codegen-schedule`
+    ? `/perf/processed-self-profile?commit=${state.commit}&base_commit=${state.base_commit}&benchmark=${state.benchmark}&profile=${state.profile}&scenario=${state.scenario}&parallel=${state.frontendThreads}&backend=${state.backend}&target=${state.target}&type=codegen-schedule`
     : "";
 
   function cachegrindCommand(
@@ -254,7 +254,7 @@ export function createDownloadLinksData(selector: Selector | null): {
     cmd += ` --exact-match ${state.benchmark}`;
     cmd += ` --profiles ${profile(state.profile)}`;
     cmd += ` --scenarios ${scenarioFilter(state.scenario)}`;
-    cmd += ` --parallels ${state.parallel}`;
+    cmd += ` --parallels ${state.frontendThreads}`;
     return cmd;
   }
 

--- a/site/frontend/src/pages/graphs/page.vue
+++ b/site/frontend/src/pages/graphs/page.vue
@@ -19,6 +19,7 @@ function loadSelectorFromUrl(urlParams: Dict<string>): GraphsSelector {
   const stat = urlParams["stat"] ?? "instructions:u";
   const benchmark = urlParams["benchmark"] ?? null;
   const scenario = urlParams["scenario"] ?? null;
+  const parallel = urlParams["parallel"] ?? null;
   const profile = urlParams["profile"] ?? null;
   const target = urlParams["target"] ?? null;
   const backend = urlParams["backend"] ?? null;
@@ -29,6 +30,7 @@ function loadSelectorFromUrl(urlParams: Dict<string>): GraphsSelector {
     stat,
     benchmark,
     scenario,
+    parallel,
     profile,
     backend,
     target,
@@ -50,14 +52,15 @@ function filterBenchmarks(
 
 /*
  * Returns true if a specific subset of charts is selected by benchmark
- * name, profile or scenario. In that case, the regular aligned grid of charts
+ * name, profile, scenario or parallel. In that case, the regular aligned grid of charts
  * will not be shown.
  */
 function hasSpecificSelection(selector: GraphsSelector): boolean {
   return (
     selector.benchmark !== null ||
     selector.profile !== null ||
-    selector.scenario !== null
+    selector.scenario !== null ||
+    selector.parallel !== null
   );
 }
 
@@ -75,6 +78,9 @@ async function loadGraphData(selector: GraphsSelector, loading: Ref<boolean>) {
     .map((benchmark) => Object.keys(graphData.benchmarks[benchmark]).length)
     .reduce((sum, item) => sum + item, 0);
 
+  if (wrapperRef.value == null) {
+    return;
+  }
   const parentWidth = wrapperRef.value.clientWidth;
   let columns = countGraphs === 1 ? 1 : 4;
 
@@ -98,7 +104,10 @@ async function loadGraphData(selector: GraphsSelector, loading: Ref<boolean>) {
 
   // If we select a smaller subset of benchmarks, then just show them.
   if (hasSpecificSelection(selector)) {
-    renderPlots(graphData, selector, document.getElementById("charts"), opts);
+    let plotElem = document.getElementById("charts");
+    if (plotElem) {
+      renderPlots(graphData, selector, plotElem, opts);
+    }
   } else {
     // If we select all of them, we expect that there will be a regular grid.
 
@@ -109,7 +118,10 @@ async function loadGraphData(selector: GraphsSelector, loading: Ref<boolean>) {
       graphData,
       (benchName) => !benchName.endsWith("-tiny")
     );
-    renderPlots(withoutTiny, selector, document.getElementById("charts"), opts);
+    let plotElem = document.getElementById("charts");
+    if (plotElem) {
+      renderPlots(withoutTiny, selector, plotElem, opts);
+    }
 
     // Then, render only the size-related ones in their own dedicated section as they are less
     // important than having the better grouping. So, we only include the benchmarks ending in
@@ -117,12 +129,10 @@ async function loadGraphData(selector: GraphsSelector, loading: Ref<boolean>) {
     const onlyTiny = filterBenchmarks(graphData, (benchName) =>
       benchName.endsWith("-tiny")
     );
-    renderPlots(
-      onlyTiny,
-      selector,
-      document.getElementById("size-charts"),
-      opts
-    );
+    let sizeCharts = document.getElementById("size-charts");
+    if (sizeCharts) {
+      renderPlots(onlyTiny, selector, sizeCharts, opts);
+    }
   }
 }
 
@@ -141,7 +151,7 @@ function updateSelection(params: SelectionParams) {
 const info: BenchmarkInfo = await loadBenchmarkInfo();
 
 const loading = ref(true);
-const wrapperRef = ref(null);
+const wrapperRef = ref<HTMLDivElement | null>(null);
 
 const selector: GraphsSelector = loadSelectorFromUrl(getUrlParams());
 
@@ -155,7 +165,7 @@ loadGraphData(selector, loading);
     :kind="selector.kind"
     :stat="selector.stat"
     :info="info"
-    :target="selector.target"
+    :target="selector.target ?? ''"
     @change="updateSelection"
   ></DataSelector>
   <div>

--- a/site/frontend/src/pages/graphs/page.vue
+++ b/site/frontend/src/pages/graphs/page.vue
@@ -1,12 +1,7 @@
 <script setup lang="ts">
 import {nextTick, Ref, ref} from "vue";
 import {withLoading} from "../../utils/loading";
-import {
-  Benchmarks,
-  CompileGraphData,
-  GraphKind,
-  GraphsSelector,
-} from "../../graph/data";
+import {CompileGraphData, GraphKind, GraphsSelector} from "../../graph/data";
 import DataSelector, {SelectionParams} from "./data-selector.vue";
 import {
   createUrlWithAppendedParams,
@@ -46,11 +41,7 @@ function filterBenchmarks(
   data: CompileGraphData,
   filter: (key: string) => boolean
 ): CompileGraphData {
-  const benchmarks = new Benchmarks(
-    Object.fromEntries(
-      Object.entries(data.benchmarks.data).filter(([key, _]) => filter(key))
-    )
-  );
+  const benchmarks = data.benchmarks.filter(([key, _]) => filter(key));
   return {
     ...data,
     benchmarks,
@@ -81,9 +72,6 @@ async function loadGraphData(selector: GraphsSelector, loading: Ref<boolean>) {
   // Then draw the plots.
   await nextTick();
 
-  // const countGraphs = Object.keys(graphData.benchmarks)
-  //   .map((benchmark) => Object.keys(graphData.benchmarks.get(benchmark)).length)
-  // .reduce((sum, item) => sum + item, 0);
   const countGraphs = graphData.benchmarks
     .map_entries((_key, value) => value.size)
     .reduce_entries((sum, _key, value) => sum + value, 0);

--- a/site/frontend/src/pages/graphs/page.vue
+++ b/site/frontend/src/pages/graphs/page.vue
@@ -81,9 +81,12 @@ async function loadGraphData(selector: GraphsSelector, loading: Ref<boolean>) {
   // Then draw the plots.
   await nextTick();
 
-  const countGraphs = Object.keys(graphData.benchmarks)
-    .map((benchmark) => Object.keys(graphData.benchmarks.get(benchmark)).length)
-    .reduce((sum, item) => sum + item, 0);
+  // const countGraphs = Object.keys(graphData.benchmarks)
+  //   .map((benchmark) => Object.keys(graphData.benchmarks.get(benchmark)).length)
+  // .reduce((sum, item) => sum + item, 0);
+  const countGraphs = graphData.benchmarks
+    .map_entries((_key, value) => value.size)
+    .reduce_entries((sum, _key, value) => sum + value, 0);
 
   if (wrapperRef.value == null) {
     return;

--- a/site/frontend/src/pages/graphs/page.vue
+++ b/site/frontend/src/pages/graphs/page.vue
@@ -1,7 +1,12 @@
 <script setup lang="ts">
 import {nextTick, Ref, ref} from "vue";
 import {withLoading} from "../../utils/loading";
-import {CompileGraphData, GraphKind, GraphsSelector} from "../../graph/data";
+import {
+  Benchmarks,
+  CompileGraphData,
+  GraphKind,
+  GraphsSelector,
+} from "../../graph/data";
 import DataSelector, {SelectionParams} from "./data-selector.vue";
 import {
   createUrlWithAppendedParams,
@@ -30,7 +35,7 @@ function loadSelectorFromUrl(urlParams: Dict<string>): GraphsSelector {
     stat,
     benchmark,
     scenario,
-    parallel,
+    frontendThreads,
     profile,
     backend,
     target,
@@ -41,8 +46,10 @@ function filterBenchmarks(
   data: CompileGraphData,
   filter: (key: string) => boolean
 ): CompileGraphData {
-  const benchmarks = Object.fromEntries(
-    Object.entries(data.benchmarks).filter(([key, _]) => filter(key))
+  const benchmarks = new Benchmarks(
+    Object.fromEntries(
+      Object.entries(data.benchmarks.data).filter(([key, _]) => filter(key))
+    )
   );
   return {
     ...data,
@@ -75,7 +82,7 @@ async function loadGraphData(selector: GraphsSelector, loading: Ref<boolean>) {
   await nextTick();
 
   const countGraphs = Object.keys(graphData.benchmarks)
-    .map((benchmark) => Object.keys(graphData.benchmarks[benchmark]).length)
+    .map((benchmark) => Object.keys(graphData.benchmarks.get(benchmark)).length)
     .reduce((sum, item) => sum + item, 0);
 
   if (wrapperRef.value == null) {

--- a/site/frontend/src/pages/graphs/page.vue
+++ b/site/frontend/src/pages/graphs/page.vue
@@ -1,7 +1,14 @@
 <script setup lang="ts">
 import {nextTick, Ref, ref} from "vue";
 import {withLoading} from "../../utils/loading";
-import {CompileGraphData, GraphKind, GraphsSelector} from "../../graph/data";
+import {
+  CompileGraphData,
+  GraphKind,
+  GraphsSelector,
+  toFrontendThreads,
+  toProfile,
+  toScenario,
+} from "../../graph/data";
 import DataSelector, {SelectionParams} from "./data-selector.vue";
 import {
   createUrlWithAppendedParams,
@@ -29,9 +36,9 @@ function loadSelectorFromUrl(urlParams: Dict<string>): GraphsSelector {
     kind,
     stat,
     benchmark,
-    scenario,
-    frontendThreads,
-    profile,
+    scenario: toScenario(scenario),
+    frontendThreads: toFrontendThreads(frontendThreads),
+    profile: toProfile(profile),
     backend,
     target,
   };

--- a/site/frontend/src/pages/graphs/page.vue
+++ b/site/frontend/src/pages/graphs/page.vue
@@ -19,7 +19,7 @@ function loadSelectorFromUrl(urlParams: Dict<string>): GraphsSelector {
   const stat = urlParams["stat"] ?? "instructions:u";
   const benchmark = urlParams["benchmark"] ?? null;
   const scenario = urlParams["scenario"] ?? null;
-  const parallel = urlParams["parallel"] ?? null;
+  const frontendThreads = urlParams["frontendThreads"] ?? null;
   const profile = urlParams["profile"] ?? null;
   const target = urlParams["target"] ?? null;
   const backend = urlParams["backend"] ?? null;
@@ -60,7 +60,7 @@ function hasSpecificSelection(selector: GraphsSelector): boolean {
     selector.benchmark !== null ||
     selector.profile !== null ||
     selector.scenario !== null ||
-    selector.parallel !== null
+    selector.frontendThreads !== null
   );
 }
 

--- a/site/frontend/src/pages/status/collector.vue
+++ b/site/frontend/src/pages/status/collector.vue
@@ -1,5 +1,5 @@
 <script setup lang="tsx">
-import {h, ref, Ref} from "vue";
+import {ref, Ref} from "vue";
 import {
   parseISO,
   differenceInHours,
@@ -40,7 +40,8 @@ const ACTIVE_FILTERS: Ref<Record<BenchmarkJobStatus, boolean>> = ref({
 const showJobs: Ref<boolean> = ref(true);
 
 function filterJobByStatus(status: string) {
-  ACTIVE_FILTERS.value[status] = !ACTIVE_FILTERS.value[status];
+  let stat = status as BenchmarkJobStatus;
+  ACTIVE_FILTERS.value[stat] = !ACTIVE_FILTERS.value[stat];
 }
 
 function formatJobStatus(status: BenchmarkJobStatus): string {
@@ -117,8 +118,8 @@ function formatProfile(job: BenchmarkJob): string {
     return "";
   }
 }
-function timeSince(timestamp: string): string {
-  const date = parseDateIsoStringOrNull(timestamp);
+function timeSince(timestamp: string | null): string {
+  const date = parseDateIsoStringOrNull(timestamp ?? undefined);
   if (date === null) {
     return "";
   }
@@ -130,7 +131,7 @@ function timeSince(timestamp: string): string {
 // Takes a date like `2025-09-10T08:22:47.161348Z` and shows just the time
 // portion (`08:22:47`).
 function formatTime(dateString: string | null): string {
-  const date = parseDateIsoStringOrNull(dateString);
+  const date = parseDateIsoStringOrNull(dateString ?? undefined);
   if (date === null) {
     return "";
   }
@@ -141,9 +142,9 @@ function jobDuration(job: BenchmarkJob): string {
   if (!isJobComplete(job)) {
     return "";
   }
-  const start = parseDateIsoStringOrNull(job.startedAt);
-  const end = parseDateIsoStringOrNull(job.completedAt);
-  const diff = differenceInSeconds(end, start);
+  const start = parseDateIsoStringOrNull(job.startedAt ?? undefined);
+  const end = parseDateIsoStringOrNull(job.completedAt ?? undefined);
+  const diff = start && end ? differenceInSeconds(end, start) : 0;
   return `Job took ${formatSecondsAsDuration(diff)}`;
 }
 

--- a/site/frontend/src/pages/status/collector.vue
+++ b/site/frontend/src/pages/status/collector.vue
@@ -167,7 +167,7 @@ function averageCollectorDuration(collector: CollectorConfig): string {
       <div class="collector-name">
         <span>
           <strong class="collector-sm-padding-right">{{
-props.collector.name
+            props.collector.name
           }}</strong>
           <span
             class="collector-sm-padding-left-right collector-left-divider"

--- a/site/frontend/src/pages/status/collector.vue
+++ b/site/frontend/src/pages/status/collector.vue
@@ -167,7 +167,7 @@ function averageCollectorDuration(collector: CollectorConfig): string {
       <div class="collector-name">
         <span>
           <strong class="collector-sm-padding-right">{{
-            props.collector.name
+props.collector.name
           }}</strong>
           <span
             class="collector-sm-padding-left-right collector-left-divider"

--- a/site/frontend/src/pages/status/page.vue
+++ b/site/frontend/src/pages/status/page.vue
@@ -1,5 +1,5 @@
 <script setup lang="tsx">
-import {h, ref, Ref} from "vue";
+import {ref, Ref} from "vue";
 import {differenceInSeconds} from "date-fns";
 
 import {getJson} from "../../utils/requests";
@@ -192,13 +192,11 @@ function RequestProgress({
   } else if (request.status === "Queued") {
     return "";
   } else {
-    return (
-      <progress
-        title={`${completed} out of ${jobs.length} job(s) completed`}
+    return `<progress
+        title={'${completed} out of ${jobs.length} job(s) completed'}
         max={jobs.length}
         value={completed}
-      ></progress>
-    );
+      ></progress>`;
   }
 }
 

--- a/site/frontend/src/pages/status/page.vue
+++ b/site/frontend/src/pages/status/page.vue
@@ -261,7 +261,7 @@ loadStatusData(loading);
                 <td>
                   {{ formatStatus(req)
                   }}{{
-                    req.status === "Completed" && req.hasPendingJobs ? "*" : ""
+req.status === "Completed" && req.hasPendingJobs ? "*" : ""
                   }}
                 </td>
                 <td>

--- a/site/frontend/src/pages/status/page.vue
+++ b/site/frontend/src/pages/status/page.vue
@@ -261,7 +261,7 @@ loadStatusData(loading);
                 <td>
                   {{ formatStatus(req)
                   }}{{
-req.status === "Completed" && req.hasPendingJobs ? "*" : ""
+                    req.status === "Completed" && req.hasPendingJobs ? "*" : ""
                   }}
                 </td>
                 <td>

--- a/site/frontend/src/self-profile.ts
+++ b/site/frontend/src/self-profile.ts
@@ -4,18 +4,20 @@ export function chromeProfileUrl(
   commit: string,
   benchmark: string,
   scenario: string,
+  parallel: string,
   profile: string,
   backend: string,
-  target: string
+  target: string,
 ): string {
   const relativeUrl = processedSelfProfileRelativeUrl(
     commit,
     benchmark,
     scenario,
+    parallel,
     profile,
     backend,
     target,
-    "crox"
+    "crox",
   );
   return window.location.origin + relativeUrl;
 }
@@ -24,10 +26,11 @@ export function processedSelfProfileRelativeUrl(
   commit: string,
   benchmark: string,
   scenario: string,
+  parallel: string,
   profile: string,
   backend: string,
   target: string,
-  type: string
+  type: string,
 ): string {
-  return `/perf/processed-self-profile?commit=${commit}&benchmark=${benchmark}&profile=${profile}&scenario=${scenario}&backend=${backend}&target=${target}&type=${type}`;
+  return `/perf/processed-self-profile?commit=${commit}&benchmark=${benchmark}&profile=${profile}&scenario=${scenario}&parallel=${parallel}&backend=${backend}&target=${target}&type=${type}`;
 }

--- a/site/frontend/src/self-profile.ts
+++ b/site/frontend/src/self-profile.ts
@@ -7,7 +7,7 @@ export function chromeProfileUrl(
   frontendThreads: string,
   profile: string,
   backend: string,
-  target: string,
+  target: string
 ): string {
   const relativeUrl = processedSelfProfileRelativeUrl(
     commit,
@@ -17,7 +17,7 @@ export function chromeProfileUrl(
     profile,
     backend,
     target,
-    "crox",
+    "crox"
   );
   return window.location.origin + relativeUrl;
 }
@@ -30,7 +30,7 @@ export function processedSelfProfileRelativeUrl(
   profile: string,
   backend: string,
   target: string,
-  type: string,
+  type: string
 ): string {
-  return `/perf/processed-self-profile?commit=${commit}&benchmark=${benchmark}&profile=${profile}&scenario=${scenario}&parallel=${frontendThreads}&backend=${backend}&target=${target}&type=${type}`;
+  return `/perf/processed-self-profile?commit=${commit}&benchmark=${benchmark}&profile=${profile}&scenario=${scenario}&frontendThreads=${frontendThreads}&backend=${backend}&target=${target}&type=${type}`;
 }

--- a/site/frontend/src/self-profile.ts
+++ b/site/frontend/src/self-profile.ts
@@ -4,7 +4,7 @@ export function chromeProfileUrl(
   commit: string,
   benchmark: string,
   scenario: string,
-  parallel: string,
+  frontendThreads: string,
   profile: string,
   backend: string,
   target: string,
@@ -13,7 +13,7 @@ export function chromeProfileUrl(
     commit,
     benchmark,
     scenario,
-    parallel,
+    frontendThreads,
     profile,
     backend,
     target,
@@ -26,11 +26,11 @@ export function processedSelfProfileRelativeUrl(
   commit: string,
   benchmark: string,
   scenario: string,
-  parallel: string,
+  frontendThreads: string,
   profile: string,
   backend: string,
   target: string,
   type: string,
 ): string {
-  return `/perf/processed-self-profile?commit=${commit}&benchmark=${benchmark}&profile=${profile}&scenario=${scenario}&parallel=${parallel}&backend=${backend}&target=${target}&type=${type}`;
+  return `/perf/processed-self-profile?commit=${commit}&benchmark=${benchmark}&profile=${profile}&scenario=${scenario}&parallel=${frontendThreads}&backend=${backend}&target=${target}&type=${type}`;
 }

--- a/site/frontend/src/typings/vue.d.ts
+++ b/site/frontend/src/typings/vue.d.ts
@@ -1,0 +1,7 @@
+declare module "*.vue";
+// TODO: fix names
+declare module "*.ts";
+
+type Dict<T> = {
+  [key: string]: T;
+};

--- a/site/frontend/src/typings/vue.ts
+++ b/site/frontend/src/typings/vue.ts
@@ -1,5 +1,0 @@
-declare module "*.vue";
-
-interface Dict<T> {
-  [key: string]: T;
-}

--- a/site/frontend/src/utils/getType.ts
+++ b/site/frontend/src/utils/getType.ts
@@ -6,6 +6,13 @@ export function isObject(maybeObject: any): maybeObject is object {
   );
 }
 
+export function hasKey<T extends object, K extends string>(
+  obj: T,
+  key: K
+): obj is T & Record<K, unknown> {
+  return obj !== null && key in obj;
+}
+
 export function isString(maybeString: any): maybeString is string {
   return typeof maybeString === "string";
 }

--- a/site/frontend/src/utils/map-wrapper.ts
+++ b/site/frontend/src/utils/map-wrapper.ts
@@ -1,3 +1,5 @@
+import {hasKey, isObject} from "./getType.ts";
+
 export class MapWrapper<K extends string, V> {
   private readonly data: Map<K, V>;
 
@@ -12,7 +14,8 @@ export class MapWrapper<K extends string, V> {
     const result: V | undefined = this.data.get(key);
     if (result === undefined) {
       console.debug(
-        `unknown key: '${key}'. Existing keys: ${JSON.stringify(this.keys())}`
+        `unknown key: '${key}'. Existing keys:`,
+        Array.from(this.keys())
       );
       throw new EvalError(`unknown key: '${key}'`);
     }
@@ -69,8 +72,24 @@ export class MapWrapper<K extends string, V> {
     return new MapWrapper(result);
   }
 
-  toDict(): Dict<V> {
-    return Object.fromEntries(this.data.entries());
+  toJSON(): Record<K, V | string> {
+    let obj = Object.create(null) as Record<K, V | string>;
+    for (let [k, v] of this.data.entries()) {
+      if (v && isObject(v)) {
+        if (
+          hasKey(v, "toJSON") &&
+          typeof v.toJSON == "function" &&
+          v.toJSON.length == 0
+        ) {
+          obj[k] = v.toJSON();
+        } else {
+          obj[k] = v;
+        }
+      } else {
+        obj[k] = JSON.stringify(v);
+      }
+    }
+    return obj;
   }
 }
 
@@ -78,9 +97,15 @@ export class MapWrapper<K extends string, V> {
  * Helper function for creating Maps from json presentation when we know how to create children
  * from json presentation
  */
-export function mapFromJSON<S, T>(
-  json: Dict<S>,
-  valueFromJSON: (value: S) => T
-): Map<string, T> {
-  return new Map(Object.entries(json).map(([k, v]) => [k, valueFromJSON(v)]));
+export function mapFromJSON<K extends string, S, T>(
+  json: Record<K, S>,
+  keyConverter: (key: string) => K,
+  valueConverter: (value: S) => T
+): Map<K, T> {
+  return new Map(
+    Object.entries(json).map(([k, v]) => [
+      keyConverter(k),
+      valueConverter(v as S),
+    ])
+  );
 }

--- a/site/frontend/src/utils/map-wrapper.ts
+++ b/site/frontend/src/utils/map-wrapper.ts
@@ -1,5 +1,5 @@
 export class MapWrapper<K extends string, V> {
-  readonly data: Map<K, V>;
+  private readonly data: Map<K, V>;
 
   constructor(data: Map<K, V>);
   constructor(data: Dict<V>);
@@ -8,8 +8,15 @@ export class MapWrapper<K extends string, V> {
       data instanceof Map ? data : new Map(Object.entries(data) as [K, V][]);
   }
 
-  get(key: K): V | undefined {
-    return this.data.get(key);
+  get(key: K): V {
+    const result: V | undefined = this.data.get(key);
+    if (result === undefined) {
+      console.debug(
+        `unknown key: '${key}'. Existing keys: ${JSON.stringify(this.keys())}`
+      );
+      throw new EvalError(`unknown key: '${key}'`);
+    }
+    return result;
   }
   set(key: K, value): this {
     this.data.set(key, value);

--- a/site/frontend/src/utils/map-wrapper.ts
+++ b/site/frontend/src/utils/map-wrapper.ts
@@ -1,51 +1,52 @@
-export class MapWrapper<T> {
-  readonly data: Map<string, T>;
+export class MapWrapper<K extends string, V> {
+  readonly data: Map<K, V>;
 
-  constructor(data: Map<string, T>);
-  constructor(data: Dict<T>);
-  constructor(data: Map<string, T> | Dict<T>) {
-    this.data = data instanceof Map ? data : new Map(Object.entries(data));
+  constructor(data: Map<K, V>);
+  constructor(data: Dict<V>);
+  constructor(data: Map<K, V> | Dict<V>) {
+    this.data =
+      data instanceof Map ? data : new Map(Object.entries(data) as [K, V][]);
   }
 
-  get(key: string): T | undefined {
+  get(key: K): V | undefined {
     return this.data.get(key);
   }
-  set(key: string, value): this {
+  set(key: K, value): this {
     this.data.set(key, value);
     return this;
   }
-  delete(key: string): boolean {
+  delete(key: K): boolean {
     return this.data.delete(key);
   }
 
-  has(key: string): boolean {
+  has(key: K): boolean {
     return this.data.has(key);
   }
-  keys(): MapIterator<string> {
+  keys(): MapIterator<K> {
     return this.data.keys();
   }
-  values(): MapIterator<T> {
+  values(): MapIterator<V> {
     return this.data.values();
   }
-  entries(): MapIterator<[string, T]> {
+  entries(): MapIterator<[K, V]> {
     return this.data.entries();
   }
   get size(): number {
     return this.data.size;
   }
-  [Symbol.iterator](): MapIterator<[string, T]> {
+  [Symbol.iterator](): MapIterator<[K, V]> {
     return this.data[Symbol.iterator]();
   }
 
-  filter(predicate: (key: string, value: T) => boolean): this {
-    const result = new Map<string, T>();
+  filter(predicate: (key: K, value: V) => boolean): this {
+    const result = new Map<K, V>();
     for (const [key, value] of this.data) {
       if (predicate(key, value)) result.set(key, value);
     }
-    return new (this.constructor as new (data: Map<string, T>) => this)(result);
+    return new (this.constructor as new (data: Map<K, V>) => this)(result);
   }
 
-  reduce_entries<R>(f: (acc: R, key: string, value: T) => R, initial: R): R {
+  reduce_entries<V2>(f: (acc: V2, key: K, value: V) => V2, initial: V2): V2 {
     let acc = initial;
     for (const [key, value] of this.data) {
       acc = f(acc, key, value);
@@ -53,15 +54,15 @@ export class MapWrapper<T> {
     return acc;
   }
 
-  map_entries<R>(f: (key: string, value: T) => R): MapWrapper<R> {
-    const result = new Map<string, R>();
+  map_entries<V2>(f: (key: K, value: V) => V2): MapWrapper<K, V2> {
+    const result = new Map<K, V2>();
     for (const [key, value] of this.data) {
       result.set(key, f(key, value));
     }
     return new MapWrapper(result);
   }
 
-  toDict(): Dict<T> {
+  toDict(): Dict<V> {
     return Object.fromEntries(this.data.entries());
   }
 }

--- a/site/frontend/src/utils/map-wrapper.ts
+++ b/site/frontend/src/utils/map-wrapper.ts
@@ -10,6 +10,14 @@ export class MapWrapper<T> {
   get(key: string): T | undefined {
     return this.data.get(key);
   }
+  set(key: string, value): this {
+    this.data.set(key, value);
+    return this;
+  }
+  delete(key: string): boolean {
+    return this.data.delete(key);
+  }
+
   has(key: string): boolean {
     return this.data.has(key);
   }
@@ -29,12 +37,12 @@ export class MapWrapper<T> {
     return this.data[Symbol.iterator]();
   }
 
-  filter(predicate: (key: string, value: T) => boolean): MapWrapper<T> {
+  filter(predicate: (key: string, value: T) => boolean): this {
     const result = new Map<string, T>();
     for (const [key, value] of this.data) {
       if (predicate(key, value)) result.set(key, value);
     }
-    return new MapWrapper(result);
+    return new (this.constructor as new (data: Map<string, T>) => this)(result);
   }
 
   reduce_entries<R>(f: (acc: R, key: string, value: T) => R, initial: R): R {

--- a/site/frontend/src/utils/map-wrapper.ts
+++ b/site/frontend/src/utils/map-wrapper.ts
@@ -1,0 +1,48 @@
+export class MapWrapperE<T> {
+  constructor(public readonly data: Map<string, T>) {}
+
+  get(key: string): T | undefined {
+    return this.data.get(key);
+  }
+  has(key: string): boolean {
+    return this.data.has(key);
+  }
+  keys(): MapIterator<string> {
+    return this.data.keys();
+  }
+  values(): MapIterator<T> {
+    return this.data.values();
+  }
+  entries(): MapIterator<[string, T]> {
+    return this.data.entries();
+  }
+  get size(): number {
+    return this.data.size;
+  }
+  [Symbol.iterator](): MapIterator<[string, T]> {
+    return this.data[Symbol.iterator]();
+  }
+
+  filter(predicate: (key: string, value: T) => boolean): Map<string, T> {
+    const result = new Map<string, T>();
+    for (const [key, value] of this.data) {
+      if (predicate(key, value)) result.set(key, value);
+    }
+    return result;
+  }
+
+  toJSON(): Dict<T> {
+    return Object.fromEntries(this.data.entries());
+  }
+}
+
+/**
+ * Helper function for creating Maps from json presentation when we know how to create children
+ * from json presentation
+ */
+export function mapFromJSON<S, T>(
+  json: Dict<S>,
+  valueFromJSON: (value: S) => T
+): Map<string, T> {
+  return new Map(Object.entries(json).map(([k, v]) => [k, valueFromJSON(v)]));
+}

--- a/site/frontend/src/utils/map-wrapper.ts
+++ b/site/frontend/src/utils/map-wrapper.ts
@@ -1,5 +1,11 @@
-export class MapWrapperE<T> {
-  constructor(public readonly data: Map<string, T>) {}
+export class MapWrapper<T> {
+  readonly data: Map<string, T>;
+
+  constructor(data: Map<string, T>);
+  constructor(data: Dict<T>);
+  constructor(data: Map<string, T> | Dict<T>) {
+    this.data = data instanceof Map ? data : new Map(Object.entries(data));
+  }
 
   get(key: string): T | undefined {
     return this.data.get(key);
@@ -23,15 +29,31 @@ export class MapWrapperE<T> {
     return this.data[Symbol.iterator]();
   }
 
-  filter(predicate: (key: string, value: T) => boolean): Map<string, T> {
+  filter(predicate: (key: string, value: T) => boolean): MapWrapper<T> {
     const result = new Map<string, T>();
     for (const [key, value] of this.data) {
       if (predicate(key, value)) result.set(key, value);
     }
-    return result;
+    return new MapWrapper(result);
   }
 
-  toJSON(): Dict<T> {
+  reduce_entries<R>(f: (acc: R, key: string, value: T) => R, initial: R): R {
+    let acc = initial;
+    for (const [key, value] of this.data) {
+      acc = f(acc, key, value);
+    }
+    return acc;
+  }
+
+  map_entries<R>(f: (key: string, value: T) => R): MapWrapper<R> {
+    const result = new Map<string, R>();
+    for (const [key, value] of this.data) {
+      result.set(key, f(key, value));
+    }
+    return new MapWrapper(result);
+  }
+
+  toDict(): Dict<T> {
     return Object.fromEntries(this.data.entries());
   }
 }

--- a/site/frontend/src/utils/map-wrapper.ts
+++ b/site/frontend/src/utils/map-wrapper.ts
@@ -4,8 +4,8 @@ export class MapWrapper<K extends string, V> {
   private readonly data: Map<K, V>;
 
   constructor(data: Map<K, V>);
-  constructor(data: Dict<V>);
-  constructor(data: Map<K, V> | Dict<V>) {
+  constructor(data: Record<K, V>);
+  constructor(data: Map<K, V> | Record<K, V>) {
     this.data =
       data instanceof Map ? data : new Map(Object.entries(data) as [K, V][]);
   }

--- a/site/frontend/src/utils/requests.ts
+++ b/site/frontend/src/utils/requests.ts
@@ -69,7 +69,11 @@ export async function getJson<T>(
   return json as T;
 }
 
-export async function postMsgpack<T>(path: string, body: any): Promise<T> {
+export async function postMsgpack<T>(
+  path: string,
+  body: any,
+  doAlert: boolean = true
+): Promise<T> {
   const response = await fetch(path, {
     method: "POST",
     body: JSON.stringify(body),
@@ -80,7 +84,9 @@ export async function postMsgpack<T>(path: string, body: any): Promise<T> {
     return decode(new Uint8Array(buffer));
   } else {
     const text = await response.text();
-    alert(text);
+    if (doAlert) {
+      alert(text);
+    }
     throw new Error(`Invalid response from server: ${text}`);
   }
 }

--- a/site/frontend/tsconfig.json
+++ b/site/frontend/tsconfig.json
@@ -8,6 +8,7 @@
     "esModuleInterop": true,
     "jsx": "preserve",
     "jsxFactory": "h",
+    "jsxImportSource": "vue",
     "noUnusedLocals": true,
     "noUnusedParameters": true
   }

--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -136,6 +136,10 @@ pub mod graphs {
         PercentRelative,
     }
 
+    // The collection nesting looks like this:
+    // Benchmarks(String) -> ProfileSeries(Profile) -> ScenarioSeries(String)
+    //     -> FrontendThreadsSeries(String) -> Series
+
     #[derive(Debug, PartialEq, Clone, Serialize)]
     pub struct Series {
         // y-values
@@ -144,15 +148,27 @@ pub mod graphs {
         pub interpolated_indices: HashSet<u16>,
     }
 
-    pub type FrontendThreadsSeries = HashMap<String, Series>;
-    pub type ScenarioSeries = HashMap<String, FrontendThreadsSeries>;
-    pub type ProfileSeries = HashMap<database::Profile, ScenarioSeries>;
+    #[derive(Debug, PartialEq, Clone, Serialize, Default)]
+    #[serde(transparent)]
+    pub struct FrontendThreadsSeries(pub HashMap<String, Series>);
+
+    #[derive(Debug, PartialEq, Clone, Serialize, Default)]
+    #[serde(transparent)]
+    pub struct ScenarioSeries(pub HashMap<String, FrontendThreadsSeries>);
+
+    #[derive(Debug, PartialEq, Clone, Serialize, Default)]
+    #[serde(transparent)]
+    pub struct ProfileSeries(pub HashMap<database::Profile, ScenarioSeries>);
+
+    #[derive(Debug, PartialEq, Clone, Serialize, Default)]
+    #[serde(transparent)]
+    pub struct Benchmarks(pub HashMap<String, ProfileSeries>);
 
     #[derive(Debug, PartialEq, Clone, Serialize)]
     pub struct Response {
         // (UTC timestamp in seconds, sha)
         pub commits: Vec<(i64, String)>,
-        pub benchmarks: HashMap<String, ProfileSeries>,
+        pub benchmarks: Benchmarks,
     }
 }
 

--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -93,6 +93,7 @@ pub mod graph {
         pub benchmark: String,
         pub profile: String,
         pub scenario: String,
+        pub parallel: String,
         pub metric: String,
         pub start: Bound,
         pub end: Bound,
@@ -118,6 +119,7 @@ pub mod graphs {
         pub kind: GraphKind,
         pub benchmark: Option<String>,
         pub scenario: Option<String>,
+        pub parallel: Option<String>,
         pub profile: Option<String>,
         pub backend: Option<String>,
         pub target: Option<String>,
@@ -142,11 +144,15 @@ pub mod graphs {
         pub interpolated_indices: HashSet<u16>,
     }
 
+    pub type ParallelSeries = HashMap<String, Series>;
+    pub type ScenarioSeries = HashMap<String, ParallelSeries>;
+    pub type ProfileSeries = HashMap<database::Profile, ScenarioSeries>;
+
     #[derive(Debug, PartialEq, Clone, Serialize)]
     pub struct Response {
         // (UTC timestamp in seconds, sha)
         pub commits: Vec<(i64, String)>,
-        pub benchmarks: HashMap<String, HashMap<database::Profile, HashMap<String, Series>>>,
+        pub benchmarks: HashMap<String, ProfileSeries>,
     }
 }
 
@@ -163,6 +169,7 @@ pub mod detail_graphs {
         pub stat: String,
         pub benchmark: String,
         pub scenario: String,
+        pub parallel: String,
         pub profile: String,
         pub backend: String,
         pub target: String,
@@ -187,6 +194,7 @@ pub mod detail_sections {
         pub end: Bound,
         pub benchmark: String,
         pub scenario: String,
+        pub parallel: String,
         pub profile: String,
         pub backend: String,
         pub target: String,
@@ -344,6 +352,7 @@ pub mod comparison {
         pub benchmark: String,
         pub profile: String,
         pub scenario: String,
+        pub parallel: String,
         pub backend: String,
         pub target: String,
         pub comparison: StatComparison,
@@ -458,6 +467,7 @@ pub mod self_profile_raw {
         pub profile: String,
         #[serde(alias = "run_name")]
         pub scenario: String,
+        pub parallel: String,
         pub backend: String,
         pub target: String,
     }
@@ -481,6 +491,7 @@ pub mod self_profile_processed {
         pub benchmark: String,
         #[serde(alias = "run_name")]
         pub scenario: String,
+        pub parallel: String,
         pub profile: String,
         pub backend: String,
         pub target: String,
@@ -503,6 +514,7 @@ pub mod self_profile {
         pub profile: String,
         #[serde(alias = "run_name")]
         pub scenario: String,
+        pub parallel: String,
         // These fields are kept optional for backwards compatibility
         // They can be made required in Q3 2026
         #[serde(default)]

--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -93,7 +93,7 @@ pub mod graph {
         pub benchmark: String,
         pub profile: String,
         pub scenario: String,
-        pub parallel: String,
+        pub frontend_threads: String,
         pub metric: String,
         pub start: Bound,
         pub end: Bound,
@@ -119,7 +119,7 @@ pub mod graphs {
         pub kind: GraphKind,
         pub benchmark: Option<String>,
         pub scenario: Option<String>,
-        pub parallel: Option<String>,
+        pub frontend_threads: Option<String>,
         pub profile: Option<String>,
         pub backend: Option<String>,
         pub target: Option<String>,
@@ -144,8 +144,8 @@ pub mod graphs {
         pub interpolated_indices: HashSet<u16>,
     }
 
-    pub type ParallelSeries = HashMap<String, Series>;
-    pub type ScenarioSeries = HashMap<String, ParallelSeries>;
+    pub type FrontendThreadsSeries = HashMap<String, Series>;
+    pub type ScenarioSeries = HashMap<String, FrontendThreadsSeries>;
     pub type ProfileSeries = HashMap<database::Profile, ScenarioSeries>;
 
     #[derive(Debug, PartialEq, Clone, Serialize)]
@@ -169,7 +169,7 @@ pub mod detail_graphs {
         pub stat: String,
         pub benchmark: String,
         pub scenario: String,
-        pub parallel: String,
+        pub frontend_threads: String,
         pub profile: String,
         pub backend: String,
         pub target: String,
@@ -194,7 +194,7 @@ pub mod detail_sections {
         pub end: Bound,
         pub benchmark: String,
         pub scenario: String,
-        pub parallel: String,
+        pub frontend_threads: String,
         pub profile: String,
         pub backend: String,
         pub target: String,
@@ -352,7 +352,7 @@ pub mod comparison {
         pub benchmark: String,
         pub profile: String,
         pub scenario: String,
-        pub parallel: String,
+        pub frontend_threads: String,
         pub backend: String,
         pub target: String,
         pub comparison: StatComparison,
@@ -467,7 +467,7 @@ pub mod self_profile_raw {
         pub profile: String,
         #[serde(alias = "run_name")]
         pub scenario: String,
-        pub parallel: String,
+        pub frontend_threads: String,
         pub backend: String,
         pub target: String,
     }
@@ -491,7 +491,7 @@ pub mod self_profile_processed {
         pub benchmark: String,
         #[serde(alias = "run_name")]
         pub scenario: String,
-        pub parallel: String,
+        pub frontend_threads: String,
         pub profile: String,
         pub backend: String,
         pub target: String,
@@ -514,7 +514,7 @@ pub mod self_profile {
         pub profile: String,
         #[serde(alias = "run_name")]
         pub scenario: String,
-        pub parallel: String,
+        pub frontend_threads: String,
         // These fields are kept optional for backwards compatibility
         // They can be made required in Q3 2026
         #[serde(default)]

--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -13,7 +13,7 @@ use database::{
     selector::{self, BenchmarkQuery, CompileBenchmarkQuery, RuntimeBenchmarkQuery, TestCase},
     Target,
 };
-use database::{ArtifactId, Benchmark, Lookup, Profile, Scenario};
+use database::{ArtifactId, Benchmark, Lookup, Parallel, Profile, Scenario};
 use serde::Serialize;
 
 use crate::api::comparison::CompileBenchmarkMetadata;
@@ -152,6 +152,7 @@ pub async fn handle_compare(
             benchmark: comparison.benchmark.to_string(),
             profile: comparison.profile.to_string(),
             scenario: comparison.scenario.to_string(),
+            parallel: comparison.parallel.0.to_string(),
             backend: comparison.backend.to_string(),
             target: comparison.target.to_string(),
             comparison: comparison.comparison.into(),
@@ -743,6 +744,7 @@ async fn compare_given_commits(
         |test_case, comparison| CompileTestResultComparison {
             profile: test_case.profile,
             scenario: test_case.scenario,
+            parallel: test_case.parallel,
             benchmark: test_case.benchmark,
             backend: test_case.backend,
             target: test_case.target,
@@ -1319,6 +1321,7 @@ pub struct CompileTestResultComparison {
     benchmark: Benchmark,
     profile: Profile,
     scenario: Scenario,
+    parallel: Parallel,
     backend: CodegenBackend,
     target: Target,
     comparison: TestResultComparison,
@@ -1335,6 +1338,7 @@ impl cmp::PartialEq for CompileTestResultComparison {
         self.benchmark == other.benchmark
             && self.profile == other.profile
             && self.scenario == other.scenario
+            && self.parallel == other.parallel
             && self.backend == other.backend
     }
 }
@@ -1346,6 +1350,7 @@ impl std::hash::Hash for CompileTestResultComparison {
         self.benchmark.hash(state);
         self.profile.hash(state);
         self.scenario.hash(state);
+        self.parallel.hash(state);
         self.backend.hash(state);
     }
 }

--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -13,7 +13,7 @@ use database::{
     selector::{self, BenchmarkQuery, CompileBenchmarkQuery, RuntimeBenchmarkQuery, TestCase},
     Target,
 };
-use database::{ArtifactId, Benchmark, Lookup, Parallel, Profile, Scenario};
+use database::{ArtifactId, Benchmark, FrontendThreads, Lookup, Profile, Scenario};
 use serde::Serialize;
 
 use crate::api::comparison::CompileBenchmarkMetadata;
@@ -152,7 +152,7 @@ pub async fn handle_compare(
             benchmark: comparison.benchmark.to_string(),
             profile: comparison.profile.to_string(),
             scenario: comparison.scenario.to_string(),
-            parallel: comparison.parallel.0.to_string(),
+            frontend_threads: comparison.frontend_threads.0.to_string(),
             backend: comparison.backend.to_string(),
             target: comparison.target.to_string(),
             comparison: comparison.comparison.into(),
@@ -744,7 +744,7 @@ async fn compare_given_commits(
         |test_case, comparison| CompileTestResultComparison {
             profile: test_case.profile,
             scenario: test_case.scenario,
-            parallel: test_case.parallel,
+            frontend_threads: test_case.frontend_threads,
             benchmark: test_case.benchmark,
             backend: test_case.backend,
             target: test_case.target,
@@ -1321,7 +1321,7 @@ pub struct CompileTestResultComparison {
     benchmark: Benchmark,
     profile: Profile,
     scenario: Scenario,
-    parallel: Parallel,
+    frontend_threads: FrontendThreads,
     backend: CodegenBackend,
     target: Target,
     comparison: TestResultComparison,
@@ -1338,7 +1338,7 @@ impl cmp::PartialEq for CompileTestResultComparison {
         self.benchmark == other.benchmark
             && self.profile == other.profile
             && self.scenario == other.scenario
-            && self.parallel == other.parallel
+            && self.frontend_threads == other.frontend_threads
             && self.backend == other.backend
     }
 }
@@ -1350,7 +1350,7 @@ impl std::hash::Hash for CompileTestResultComparison {
         self.benchmark.hash(state);
         self.profile.hash(state);
         self.scenario.hash(state);
-        self.parallel.hash(state);
+        self.frontend_threads.hash(state);
         self.backend.hash(state);
     }
 }

--- a/site/src/request_handlers/graph.rs
+++ b/site/src/request_handlers/graph.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use collector::{Bound, SelfProfileId};
 
-use crate::api::graphs::GraphKind;
+use crate::api::graphs::{Benchmarks, FrontendThreadsSeries, GraphKind, ScenarioSeries};
 use crate::api::{detail_graphs, detail_sections, graphs, runtime_detail_graphs, ServerResult};
 use crate::api::{detail_sections::CompilationSections, graphs::ProfileSeries};
 use crate::load::SiteCtxt;
@@ -241,7 +241,7 @@ async fn create_graphs(
         request.start,
         request.end,
     ));
-    let mut benchmarks: HashMap<String, ProfileSeries> = HashMap::new();
+    let mut benchmarks = Benchmarks::default();
 
     fn create_selector<T: FromStr>(filter: &Option<String>) -> Option<Result<Selector<T>, T::Err>> {
         filter
@@ -289,7 +289,9 @@ async fn create_graphs(
             .transpose()?;
         let summary_benchmark =
             create_summary(ctxt, &interpolated_responses, request.kind, request_profile)?;
-        benchmarks.insert("Summary".to_string(), summary_benchmark);
+        benchmarks
+            .0
+            .insert("Summary".to_string(), summary_benchmark);
     }
 
     for response in interpolated_responses {
@@ -300,12 +302,16 @@ async fn create_graphs(
         let graph_series = graph_series(response.series.into_iter(), request.kind);
 
         benchmarks
+            .0
             .entry(benchmark)
-            .or_insert_with(HashMap::new)
+            .or_insert_with(ProfileSeries::default)
+            .0
             .entry(profile)
-            .or_insert_with(HashMap::new)
+            .or_insert_with(ScenarioSeries::default)
+            .0
             .entry(frontend_threads)
-            .or_insert_with(HashMap::new)
+            .or_insert_with(FrontendThreadsSeries::default)
+            .0
             .insert(scenario, graph_series);
     }
 
@@ -346,9 +352,9 @@ fn create_summary(
     >],
     graph_kind: GraphKind,
     profile: Option<Profile>,
-) -> ServerResult<HashMap<Profile, HashMap<String, HashMap<String, graphs::Series>>>> {
+) -> ServerResult<ProfileSeries> {
     let mut baselines = HashMap::new();
-    let mut summary_benchmark = HashMap::new();
+    let mut summary_benchmark = ProfileSeries::default();
     let summary_query_cases = iproduct!(
         ctxt.summary_scenarios(),
         profile.map_or_else(Profile::default_profiles, |p| vec![p]),
@@ -393,10 +399,13 @@ fn create_summary(
         let graph_series = graph_series(avg_vs_baseline, graph_kind);
 
         summary_benchmark
+            .0
             .entry(profile)
-            .or_insert_with(HashMap::new)
+            .or_insert_with(ScenarioSeries::default)
+            .0
             .entry(format!("{}", frontend_threads.0))
-            .or_insert_with(HashMap::new)
+            .or_insert_with(FrontendThreadsSeries::default)
+            .0
             .insert(scenario.to_string(), graph_series);
     }
     Ok(summary_benchmark)

--- a/site/src/request_handlers/graph.rs
+++ b/site/src/request_handlers/graph.rs
@@ -4,9 +4,9 @@ use std::sync::Arc;
 
 use collector::{Bound, SelfProfileId};
 
-use crate::api::detail_sections::CompilationSections;
 use crate::api::graphs::GraphKind;
 use crate::api::{detail_graphs, detail_sections, graphs, runtime_detail_graphs, ServerResult};
+use crate::api::{detail_sections::CompilationSections, graphs::ProfileSeries};
 use crate::load::SiteCtxt;
 use crate::self_profile::fetch_self_profile;
 
@@ -39,6 +39,7 @@ pub async fn handle_compile_detail_graphs(
                 .scenario(Selector::One(scenario))
                 .backend(Selector::One(request.backend.parse()?))
                 .target(Selector::One(request.target.parse()?))
+                .frontend_threads(Selector::One(request.frontend_threads.parse()?))
                 .metric(Selector::One(request.stat.parse()?)),
             artifact_ids.clone(),
         )
@@ -89,6 +90,7 @@ pub async fn handle_compile_detail_sections(
     let profile: Profile = request.profile.parse()?;
     let backend: CodegenBackend = request.backend.parse()?;
     let target: Target = request.target.parse()?;
+    let frontend_threads: FrontendThreads = request.frontend_threads.parse()?;
 
     async fn calculate_sections(
         ctxt: &SiteCtxt,
@@ -98,8 +100,8 @@ pub async fn handle_compile_detail_sections(
         scenario: Scenario,
         backend: CodegenBackend,
         target: Target,
+        frontend_threads: FrontendThreads,
     ) -> Option<CompilationSections> {
-        const MOCK_FRONTEND_THREADS: FrontendThreads = FrontendThreads(1);
         let id = SelfProfileId::Simple {
             artifact_id: aid,
             benchmark: benchmark.into(),
@@ -107,7 +109,7 @@ pub async fn handle_compile_detail_sections(
             scenario,
             backend,
             target,
-            frontend_threads: MOCK_FRONTEND_THREADS,
+            frontend_threads,
         };
         fetch_self_profile(ctxt, id, None)
             .await
@@ -132,7 +134,8 @@ pub async fn handle_compile_detail_sections(
                 profile,
                 scenario,
                 backend,
-                target
+                target,
+                frontend_threads
             ),
             calculate_sections(
                 &ctxt,
@@ -141,7 +144,8 @@ pub async fn handle_compile_detail_sections(
                 profile,
                 scenario,
                 backend,
-                target
+                target,
+                frontend_threads
             )
         )
     } else {
@@ -210,6 +214,7 @@ pub async fn handle_graphs(
             profile: None,
             backend: None,
             target: None,
+            frontend_threads: None,
         };
 
     if is_default_query {
@@ -236,7 +241,7 @@ async fn create_graphs(
         request.start,
         request.end,
     ));
-    let mut benchmarks = HashMap::new();
+    let mut benchmarks: HashMap<String, ProfileSeries> = HashMap::new();
 
     fn create_selector<T: FromStr>(filter: &Option<String>) -> Option<Result<Selector<T>, T::Err>> {
         filter
@@ -255,7 +260,10 @@ async fn create_graphs(
         .unwrap_or(Ok(Selector::One(Target::X86_64UnknownLinuxGnu)))?;
     let backend_selector =
         create_selector(&request.backend).unwrap_or(Ok(Selector::One(CodegenBackend::Llvm)))?;
-
+    let frontend_threads_selector = request
+        .frontend_threads
+        .map(|v| Selector::One(v.parse::<FrontendThreads>().unwrap()))
+        .unwrap_or_else(|| Selector::Subset(FrontendThreads::default_threads_counts()));
     let interpolated_responses: Vec<_> = ctxt
         .statistic_series(
             CompileBenchmarkQuery::default()
@@ -264,6 +272,7 @@ async fn create_graphs(
                 .scenario(scenario_selector)
                 .backend(backend_selector)
                 .target(target_selector)
+                .frontend_threads(frontend_threads_selector)
                 .metric(Selector::One(request.stat.parse()?)),
             artifact_ids.clone(),
         )
@@ -287,12 +296,15 @@ async fn create_graphs(
         let benchmark = response.test_case.benchmark.to_string();
         let profile = response.test_case.profile;
         let scenario = response.test_case.scenario.to_string();
+        let frontend_threads = format!("threads_{}", response.test_case.frontend_threads.0);
         let graph_series = graph_series(response.series.into_iter(), request.kind);
 
         benchmarks
             .entry(benchmark)
             .or_insert_with(HashMap::new)
             .entry(profile)
+            .or_insert_with(HashMap::new)
+            .entry(frontend_threads)
             .or_insert_with(HashMap::new)
             .insert(scenario, graph_series);
     }
@@ -334,15 +346,16 @@ fn create_summary(
     >],
     graph_kind: GraphKind,
     profile: Option<Profile>,
-) -> ServerResult<HashMap<Profile, HashMap<String, graphs::Series>>> {
+) -> ServerResult<HashMap<Profile, HashMap<String, HashMap<String, graphs::Series>>>> {
     let mut baselines = HashMap::new();
     let mut summary_benchmark = HashMap::new();
     let summary_query_cases = iproduct!(
         ctxt.summary_scenarios(),
-        profile.map_or_else(Profile::default_profiles, |p| vec![p])
+        profile.map_or_else(Profile::default_profiles, |p| vec![p]),
+        FrontendThreads::default_threads_counts()
     );
-    for (scenario, profile) in summary_query_cases {
-        let baseline = match baselines.entry((profile, scenario)) {
+    for (scenario, profile, frontend_threads) in summary_query_cases {
+        let baseline = match baselines.entry((profile, scenario, frontend_threads)) {
             std::collections::hash_map::Entry::Occupied(o) => *o.get(),
             std::collections::hash_map::Entry::Vacant(v) => {
                 let baseline_responses = interpolated_responses
@@ -350,7 +363,8 @@ fn create_summary(
                     .filter(|sr| {
                         let p = sr.test_case.profile;
                         let s = sr.test_case.scenario;
-                        p == profile && s == Scenario::Empty
+                        let threads = sr.test_case.frontend_threads;
+                        p == profile && s == Scenario::Empty && threads.single()
                     })
                     .map(|sr| sr.series.iter().cloned())
                     .collect();
@@ -367,7 +381,8 @@ fn create_summary(
             .filter(|sr| {
                 let p = sr.test_case.profile;
                 let s = sr.test_case.scenario;
-                p == profile && s == scenario
+                let threads = sr.test_case.frontend_threads;
+                p == profile && s == scenario && threads == frontend_threads
             })
             .map(|sr| sr.series.iter().cloned())
             .collect();
@@ -379,6 +394,8 @@ fn create_summary(
 
         summary_benchmark
             .entry(profile)
+            .or_insert_with(HashMap::new)
+            .entry(format!("{}", frontend_threads.0))
             .or_insert_with(HashMap::new)
             .insert(scenario.to_string(), graph_series);
     }


### PR DESCRIPTION
It got pretty big despite not being finished still, so i decided to open a pr just to track things.

The work is based primarily on https://github.com/rust-lang/rustc-perf/pull/2421 and is the second part of bringing parallel frontend metrics to rustc-perf with the first being https://github.com/rust-lang/rustc-perf/pull/2491.

While the most important obvious part is adding a new dimension (new url params, database queries, deserialization, filters, etc.) some structural changes were made.
1. The main being strict type enforcement of nested records of data received from the database. Recall having the following nesting structure before:
   ```
   benchmark -> profile -> scenario -> series
   ```
   This was represented as `Dict<Dict<Dict<Series>>>`. @ azhogin introduced this change:
   ```
   benchmark -> profile -> parallel -> scenario -> series
   ```
   which was represented as `Dict<Dict<Dict<Dict<Series>>>>` respectively. Recall also it's been decided in https://github.com/rust-lang/rustc-perf/pull/2491 to transpose this layout to
   ```
   benchmark -> profile -> scenario -> frontend_threads -> series
   ```
   Now imagine the amount of bugs and inconsistencies i encountered when trying to apply this change to simple nested records. I simply couldn't have caught them without the linter warning me what was wrong where. Therefore a new type-safe structure is introduced as an attempt to mitigate this errors now and in the future.
2. Due to inherent typescript's lack of ability to enforce typing for record keys and operations on entries, a specific wrapper class was introduced (currently residing in `site/frontend/src/utils/map-wrapper.ts`). It's a `Map` underneath with... well, more type safety. We extend this class as a form of newtype pattern, like 
   ```ts
   export class ProfileSeries extends MapWrapper<Profile, ScenarioSeries>
   ```
   for type enforcement.
3. Said `Map`'s keys are also typed. Handling of said keys in different contexts varied. Sometimes we needed `profile` to be lowercased, sometimes capitalized. And we had no idea what format our input data was in. This is especially confusing to a person not familiar with the codebase. So it's necessary to enforce a single format (like `Profile` or `FrontendThreads`) that is some kind of string wrapper, with proper casting (like `site/frontend/src/graph/data.ts: toProfile` function).
4. rename `site/frontend/src/typings/{vue.ts -> vue.d.ts}` to satisfy Deno linter and follow TS conventions.

Of course, all this goes beyond just adding a new dimension. Unfortunately, i wasn't able to do otherwise as i was just lost in lots of bugs arising out of the blue before bringing a decent amount of lint time safety.

Some changes made by @ azhogin are left intact, for instance additional error handling in `site/frontend/src/pages/detailed-query/page.vue` as well as in many other places.

---

### TODO (needs discussion)
- [ ]  well, it still doesn't work 😅
- [ ] integrate renaming from https://github.com/rust-lang/rustc-perf/pull/2512;
- [ ] consistent string enumeration values for map keys / display data (like `type Scenario = "full" | "incr-full" | ...`) instead of branding. Will need other conversion functions;
- [ ] move type definitions from `site/frontend/src/graph/data.ts`: they're used outside of graphs context;
- [ ] further fixing inconsistencies in string enumerations usage;
   - [ ] maybe we could remove lots of checks in `site/frontend/src/pages/compare/compile/common.ts` (like `computeCompileComparisonsWithNonRelevant().profileFilter()`) as a result;
- [ ] extend changes symmetrically to runtime benchmarks.