### PR TITLE
More refactoring + Implement step 1 of triage command

### DIFF
--- a/site/frontend/templates/pages/help.html
+++ b/site/frontend/templates/pages/help.html
@@ -50,5 +50,11 @@
     "try" run's commit for the <code>build</code> command)
     This command also supports the same options as <code>@rust-timer queue</code>.
   </p>
+  <p><code>@rust-timer triage $commits</code> is meant to be executed on a rollup,
+    to help identify the culprit of performance regressions/improvements of that rollup.
+    It takes a space-separated list of `$commits` SHAs, and queues a perf run for each commit.
+    The results are reported on the corresponding PRs, and in the future will also be reported in the rollup itself.
+    This command does not (yet) support options.
+  </p>
 </div>
 {% endblock %}

--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -227,79 +227,63 @@ pub async fn rollup_pr_number(
 }
 
 /// Enqueues the given SHAs and returns the SHAs that were actually enqueued.
-pub async fn enqueue_shas<'a>(
+pub async fn enqueue_sha<'a>(
     ctxt: &SiteCtxt,
     gh_client: &client::Client,
     pr_number: u32,
-    commits: impl Iterator<Item = &'a str>,
-) -> Result<Vec<&'a str>, String> {
-    let mut enqueued = vec![];
-    let mut msg = String::new();
-    for commit in commits {
-        let mut commit_response = gh_client
-            .get_commit(commit)
-            .await
-            .map_err(|e| e.to_string())?;
-        if commit_response.parents.len() != 2 {
-            log::error!(
-                "Bors try commit {} unexpectedly has {} parents.",
-                commit_response.sha,
-                commit_response.parents.len()
-            );
-            continue;
-        }
-        let try_commit = TryCommit {
-            sha: commit_response.sha,
-            parent_sha: commit_response.parents.remove(0).sha,
-        };
-        let conn = ctxt.conn().await;
+    commit_sha: &'a str,
+) -> Result<String, String> {
+    let mut commit = gh_client
+        .get_commit(commit_sha)
+        .await
+        .map_err(|e| e.to_string())?;
+    if commit.parents.len() != 2 {
+        return Err(format!(
+            "Bors try commit {} unexpectedly has {} parents.",
+            commit.sha,
+            commit.parents.len()
+        ));
+    }
+    let try_commit = TryCommit {
+        sha: commit.sha,
+        parent_sha: commit.parents.remove(0).sha,
+    };
+    let conn = ctxt.conn().await;
 
-        let queued = conn.attach_shas_to_try_benchmark_request(
-                pr_number,
-                &try_commit.sha,
-                &try_commit.parent_sha,
-                commit_response.commit.committer.date,
+    let queued = conn.attach_shas_to_try_benchmark_request(
+            pr_number,
+            &try_commit.sha,
+            &try_commit.parent_sha,
+            commit.commit.committer.date,
             )
             .await
             .map_err(|error| format!("Cannot attach SHAs to try benchmark request on PR {pr_number} and SHA {}: {error:?}", try_commit.sha))?;
-        if queued {
-            enqueued.push(commit);
-            if !msg.is_empty() {
-                msg.push('\n');
-            }
+    if !queued {
+        return Err("Commit was not enqueued, since no benchmark request was found".to_string());
+    }
 
-            let (preceding_artifacts, expected_duration) =
-                estimate_queue_info(conn.as_ref(), &try_commit)
-                    .await
-                    .map_err(|e| format!("{e:?}"))?;
+    let (preceding_artifacts, expected_duration) = estimate_queue_info(conn.as_ref(), &try_commit)
+        .await
+        .map_err(|e| format!("{e:?}"))?;
 
-            let verb = if preceding_artifacts == 1 {
-                "is"
-            } else {
-                "are"
-            };
-            let suffix = if preceding_artifacts == 1 { "" } else { "s" };
-            let queue_msg = format!(
-                r#"There {verb} currently {preceding_artifacts} preceding artifact{suffix} in the [queue](https://perf.rust-lang.org/status.html).
+    let verb = if preceding_artifacts == 1 {
+        "is"
+    } else {
+        "are"
+    };
+    let suffix = if preceding_artifacts == 1 { "" } else { "s" };
+    let queue_msg = format!(
+        r#"There {verb} currently {preceding_artifacts} preceding artifact{suffix} in the [queue](https://perf.rust-lang.org/status.html).
 It will probably take at least ~{:.1} hours until the benchmark run finishes."#,
-                expected_duration.as_secs_f64() / 3600.0
-            );
+        expected_duration.as_secs_f64() / 3600.0
+    );
 
-            msg.push_str(&format!(
-                "Queued {} with parent {}, future [comparison URL]({}).\n{queue_msg}",
-                try_commit.sha,
-                try_commit.parent_sha,
-                try_commit.comparison_url(),
-            ));
-        }
-    }
-
-    if !msg.is_empty() {
-        msg.push_str(&format!("\n{COMMENT_MARK_TEMPORARY}"));
-        gh_client.post_comment(pr_number, msg).await;
-    }
-
-    Ok(enqueued)
+    Ok(format!(
+        "Queued {} with parent {}, future [comparison URL]({}).\n{queue_msg}",
+        try_commit.sha,
+        try_commit.parent_sha,
+        try_commit.comparison_url(),
+    ))
 }
 
 /// Counts how many artifacts are in the queue before the specified commit, and what is the expected

--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -227,11 +227,11 @@ pub async fn rollup_pr_number(
 }
 
 /// Enqueues the given SHAs and returns the SHAs that were actually enqueued.
-pub async fn enqueue_sha<'a>(
+pub async fn enqueue_sha(
     ctxt: &SiteCtxt,
     gh_client: &client::Client,
     pr_number: u32,
-    commit_sha: &'a str,
+    commit_sha: &str,
 ) -> Result<String, String> {
     let mut commit = gh_client
         .get_commit(commit_sha)

--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -226,7 +226,7 @@ pub async fn rollup_pr_number(
         .then_some(issue.number))
 }
 
-/// Enqueues the given SHAs and returns the SHAs that were actually enqueued.
+/// Enqueues the given SHA and returns a message that should be sent as a comment to the corresponding PR.
 pub async fn enqueue_sha(
     ctxt: &SiteCtxt,
     gh_client: &client::Client,
@@ -259,7 +259,9 @@ pub async fn enqueue_sha(
             .await
             .map_err(|error| format!("Cannot attach SHAs to try benchmark request on PR {pr_number} and SHA {}: {error:?}", try_commit.sha))?;
     if !queued {
-        return Err("Commit was not enqueued, since no benchmark request was found".to_string());
+        return Err(
+            "Commit was not enqueued, since no previous benchmark request was found".to_string(),
+        );
     }
 
     let (preceding_artifacts, expected_duration) = estimate_queue_info(conn.as_ref(), &try_commit)

--- a/site/src/request_handlers/github.rs
+++ b/site/src/request_handlers/github.rs
@@ -309,7 +309,7 @@ async fn handle_rust_timer(
 fn find_pr_number_for_unrolled_build(commit_message: &str) -> Result<u32, String> {
     // Find PR number for this unrolled build sha
     const COMMIT_NAME_START: &str = "Unrolled build for #";
-    let first_line = commit_message.lines().next().unwrap();
+    let first_line = commit_message.lines().next().unwrap_or("");
     let Some(pr_number) = first_line.strip_prefix(COMMIT_NAME_START) else {
         return Err(format!(
             "Unexpected commit name `{first_line}`, did not find expected prefix. Is the commit an unrolled build?"
@@ -400,7 +400,10 @@ fn parse_triage_command_args(args: &str) -> Result<TriageCommand<'_>, String> {
         .map(parse_sha)
         .collect::<Result<Vec<_>, _>>()?;
     if shas.is_empty() {
-        return Err("The triage comment requires a list of SHAs as an argument.".to_string());
+        return Err(
+            "The triage comment requires a space-separated list of SHAs as an argument."
+                .to_string(),
+        );
     }
     Ok(TriageCommand { shas })
 }
@@ -497,8 +500,14 @@ fn parse_command_arguments(args: &str) -> Result<HashMap<&str, &str>, String> {
 
 #[derive(Debug)]
 enum RustTimerCommand<'a> {
+    /// This command is usually invoked as `@bors try @rust-timer queue`, which starts a bors "try build".
+    /// `@rust-timer` will wait for the try build to finish, and if it succeeds will then queue a perf run.
     Queue(QueueCommand<'a>),
+    /// `@rust-timer build $commit` will queue a perf run for the given `$commit`.
     Build(BuildCommand<'a>),
+    /// This command is meant to be executed on a rollup,
+    /// to help identify the culprit of performance regressions/improvements of that rollup.
+    /// It takes a space-separated list of `$commits` SHAs, and queues a perf run for each commit.
     Triage(TriageCommand<'a>),
 }
 
@@ -709,9 +718,9 @@ Otherwise LGTM."#),
     #[test]
     fn triage_command() {
         insta::assert_compact_debug_snapshot!(parse_command("@rust-timer triage"),
-            @r#"Err("The triage comment requires a list of SHAs as an argument.")"#);
+            @r#"Err("The triage comment requires a space-separated list of SHAs as an argument.")"#);
         insta::assert_compact_debug_snapshot!(parse_command("@rust-timer triage    "),
-            @r#"Err("The triage comment requires a list of SHAs as an argument.")"#);
+            @r#"Err("The triage comment requires a space-separated list of SHAs as an argument.")"#);
         insta::assert_compact_debug_snapshot!(parse_command("@rust-timer triage abcd"),
             @r#"Ok(Triage(TriageCommand { shas: ["abcd"] }))"#);
         insta::assert_compact_debug_snapshot!(parse_command("@rust-timer triage abcd efgh"),

--- a/site/src/request_handlers/github.rs
+++ b/site/src/request_handlers/github.rs
@@ -4,8 +4,8 @@ use crate::github::{
     COMMENT_MARK_TEMPORARY, RUST_REPO_GITHUB_API_URL,
 };
 use crate::load::SiteCtxt;
+use std::fmt::Write;
 
-use crate::api::github::Issue;
 use crate::github::client::Client;
 use database::{
     parse_backends, parse_profiles, parse_targets, BenchmarkRequest, BenchmarkRequestInsertResult,
@@ -252,7 +252,51 @@ async fn handle_rust_timer(
             };
         }
         Ok(RustTimerCommand::Triage(cmd)) => {
-            todo!()
+            let mut result = String::new();
+            for sha in cmd.shas {
+                // Get unrolled commit
+                let commit = match main_client.get_commit(sha).await {
+                    Ok(commit) => commit,
+                    Err(err) => {
+                        writeln!(&mut result, "### {sha}").unwrap();
+                        writeln!(&mut result, "Failed to get commit: {err}").unwrap();
+                        continue;
+                    }
+                };
+
+                // Find PR number from commit message
+                let pr_number = match find_pr_number_for_unrolled_build(&commit.commit.message) {
+                    Ok(r) => r,
+                    Err(err) => {
+                        writeln!(&mut result, "### {sha}").unwrap();
+                        writeln!(&mut result, "{err}").unwrap();
+                        continue;
+                    }
+                };
+
+                // Write header
+                let pr_title = &commit
+                    .commit
+                    .message
+                    .lines()
+                    .nth(3)
+                    .unwrap_or("<FAILED TO GET PR TITLE>");
+                writeln!(&mut result, "### #{pr_number} {sha} {pr_title}",).unwrap();
+
+                // Enqueue the sha build and write result
+                let (Ok(msg) | Err(msg)) = enqueue_sha_build(
+                    &ctxt,
+                    main_client,
+                    pr_number,
+                    &BuildCommand {
+                        sha,
+                        params: Default::default(),
+                    },
+                )
+                .await;
+                writeln!(&mut result, "{msg}\n").unwrap();
+            }
+            main_client.post_comment(issue.number, result).await;
         }
         Err(e) => {
             main_client.post_comment(issue.number, e).await;
@@ -260,6 +304,24 @@ async fn handle_rust_timer(
     }
 
     Ok(github::Response)
+}
+
+fn find_pr_number_for_unrolled_build(commit_message: &str) -> Result<u32, String> {
+    // Find PR number for this unrolled build sha
+    const COMMIT_NAME_START: &str = "Unrolled build for #";
+    let first_line = commit_message.lines().next().unwrap();
+    let Some(pr_number) = first_line.strip_prefix(COMMIT_NAME_START) else {
+        return Err(format!(
+            "Unexpected commit name `{first_line}`, did not find expected prefix. Is the commit an unrolled build?"
+        ));
+    };
+    let Ok(pr_number) = pr_number.parse::<u32>() else {
+        return Err(format!(
+            "Unexpected commit name, pr number `{pr_number}` was not parsable as u32. Is the commit an unrolled build?"
+        ));
+    };
+
+    Ok(pr_number)
 }
 
 async fn enqueue_sha_build(
@@ -338,7 +400,7 @@ fn parse_triage_command_args(args: &str) -> Result<TriageCommand<'_>, String> {
         .map(parse_sha)
         .collect::<Result<Vec<_>, _>>()?;
     if shas.is_empty() {
-        return Err("The triage comment requires a list of SHAs as an argument.".to_string())
+        return Err("The triage comment requires a list of SHAs as an argument.".to_string());
     }
     Ok(TriageCommand { shas })
 }
@@ -456,7 +518,7 @@ struct TriageCommand<'a> {
     shas: Vec<&'a str>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 struct BenchmarkParameters<'a> {
     backends: Option<&'a str>,
     profiles: Option<&'a str>,
@@ -660,5 +722,23 @@ Otherwise LGTM."#),
             @r#"Err("Sha `targets=Foo` is not alphanumeric")"#);
         insta::assert_compact_debug_snapshot!(parse_command("@rust-timer triage abcd  efgh"),
             @r#"Ok(Triage(TriageCommand { shas: ["abcd", "efgh"] }))"#);
+    }
+
+    #[test]
+    fn pr_number_from_unrolled_build() {
+        const EXAMPLE: &str = "Unrolled build for #157428
+Rollup merge of #157428 - nia-e:allocator-refactor, r=clarfonthey
+
+allocator: refactor for stabilisation
+
+Adds my current proposal per the doc in #156882 and follow-up Zulip conversations (notably for [dyn-compat](https://rust-lang.zulipchat.com/#narrow/channel/197181-t-libs.2Fwg-allocators/topic/Allocator.20dyn-safety/near/599555822)) unstably.
+
+r? libs";
+        insta::assert_compact_debug_snapshot!(find_pr_number_for_unrolled_build(EXAMPLE),
+            @"Ok(157428)");
+        insta::assert_compact_debug_snapshot!(find_pr_number_for_unrolled_build("Not a correct title"),
+            @r#"Err("Unexpected commit name `Not a correct title`, did not find expected prefix. Is the commit an unrolled build?")"#);
+        insta::assert_compact_debug_snapshot!(find_pr_number_for_unrolled_build("Unrolled build for #123almost"),
+            @r#"Err("Unexpected commit name, pr number `123almost` was not parsable as u32. Is the commit an unrolled build?")"#);
     }
 }

--- a/site/src/request_handlers/github.rs
+++ b/site/src/request_handlers/github.rs
@@ -1,10 +1,9 @@
 use crate::api::{github, ServerResult};
 use crate::github::{
-    client, enqueue_shas, parse_homu_comment, rollup_pr_number, unroll_rollup,
+    client, enqueue_sha, parse_homu_comment, rollup_pr_number, unroll_rollup,
     COMMENT_MARK_TEMPORARY, RUST_REPO_GITHUB_API_URL,
 };
 use crate::load::SiteCtxt;
-use std::iter;
 
 use database::{
     parse_backends, parse_profiles, parse_targets, BenchmarkRequest, BenchmarkRequestInsertResult,
@@ -76,13 +75,15 @@ async fn handle_issue(
     let gh_client = client::Client::from_ctxt(&ctxt, RUST_REPO_GITHUB_API_URL.to_owned());
     if comment.body.contains(" homu: ") {
         if let Some(sha) = parse_homu_comment(&comment.body).await {
-            enqueue_shas(
-                &ctxt,
-                &gh_client,
-                issue.number,
-                std::iter::once(sha.as_str()),
-            )
-            .await?;
+            match enqueue_sha(&ctxt, &gh_client, issue.number, &sha).await {
+                Ok(mut msg) => {
+                    msg.push_str(&format!("\n{COMMENT_MARK_TEMPORARY}"));
+                    gh_client.post_comment(issue.number, msg).await;
+                }
+                Err(err) => {
+                    gh_client.post_comment(issue.number, err).await;
+                }
+            }
             return Ok(github::Response);
         }
     }
@@ -255,33 +256,17 @@ async fn handle_rust_timer(
                 .await;
             }
 
-            let enqueued = match enqueue_shas(&ctxt, main_client, issue.number, iter::once(cmd.sha))
-                .await
-            {
-                Ok(enqueued) => enqueued,
+            match enqueue_sha(&ctxt, main_client, issue.number, &cmd.sha).await {
+                Ok(mut msg) => {
+                    msg.push_str(&format!("\n{COMMENT_MARK_TEMPORARY}"));
+                    main_client.post_comment(issue.number, msg).await;
+                }
                 Err(error) => {
-                    log::error!("Failed to enqueue SHAs on {}: {error:?}", issue.number);
-                    main_client
-                        .post_comment(
-                            issue.number,
-                            "Failed to enqueue some commit SHAs. Maybe they were already benchmarked?"
-                                .to_string(),
-                        )
-                        .await;
+                    log::error!("Failed to enqueue SHA on {}: {error:?}", issue.number);
+                    main_client.post_comment(issue.number, error).await;
                     return Ok(github::Response);
                 }
             };
-            if enqueued.is_empty() {
-                main_client
-                    .post_comment(
-                        issue.number,
-                        format!(
-                            "The commit was not enqueued, as it was probably already benchmarked: {}\n",
-                            cmd.sha
-                        ),
-                    )
-                    .await;
-            }
         }
         Err(e) => {
             main_client.post_comment(issue.number, e).await;

--- a/site/src/request_handlers/github.rs
+++ b/site/src/request_handlers/github.rs
@@ -251,6 +251,9 @@ async fn handle_rust_timer(
                 }
             };
         }
+        Ok(RustTimerCommand::Triage(cmd)) => {
+            todo!()
+        }
         Err(e) => {
             main_client.post_comment(issue.number, e).await;
         }
@@ -302,6 +305,7 @@ fn parse_command(body: &str) -> Result<RustTimerCommand<'_>, String> {
     Ok(match cmd {
         "queue" => RustTimerCommand::Queue(parse_queue_command_args(args)?),
         "build" => RustTimerCommand::Build(parse_build_command_args(args)?),
+        "triage" => RustTimerCommand::Triage(parse_triage_command_args(args)?),
         _ => return Err(format!("Unknown rust-timer command: {cmd}")),
     })
 }
@@ -325,6 +329,18 @@ fn parse_build_command_args(args: &str) -> Result<BuildCommand<'_>, String> {
     let args = parse_command_arguments(args)?;
     let params = parse_benchmark_parameters(args)?;
     Ok(BuildCommand { sha, params })
+}
+
+/// Parses the arguments of `@rust-timer triage <sha>+`
+fn parse_triage_command_args(args: &str) -> Result<TriageCommand<'_>, String> {
+    let shas = args
+        .split_whitespace()
+        .map(parse_sha)
+        .collect::<Result<Vec<_>, _>>()?;
+    if shas.is_empty() {
+        return Err("The triage comment requires a list of SHAs as an argument.".to_string())
+    }
+    Ok(TriageCommand { shas })
 }
 
 fn parse_sha(sha: &str) -> Result<&str, String> {
@@ -421,6 +437,7 @@ fn parse_command_arguments(args: &str) -> Result<HashMap<&str, &str>, String> {
 enum RustTimerCommand<'a> {
     Queue(QueueCommand<'a>),
     Build(BuildCommand<'a>),
+    Triage(TriageCommand<'a>),
 }
 
 #[derive(Debug)]
@@ -432,6 +449,11 @@ struct QueueCommand<'a> {
 struct BuildCommand<'a> {
     sha: &'a str,
     params: BenchmarkParameters<'a>,
+}
+
+#[derive(Debug)]
+struct TriageCommand<'a> {
+    shas: Vec<&'a str>,
 }
 
 #[derive(Debug)]
@@ -620,5 +642,23 @@ Otherwise LGTM."#),
             @"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: None, profiles: None, targets: None } }))");
         insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue profiles="),
             @"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: None, profiles: None, targets: None } }))");
+    }
+
+    #[test]
+    fn triage_command() {
+        insta::assert_compact_debug_snapshot!(parse_command("@rust-timer triage"),
+            @r#"Err("The triage comment requires a list of SHAs as an argument.")"#);
+        insta::assert_compact_debug_snapshot!(parse_command("@rust-timer triage    "),
+            @r#"Err("The triage comment requires a list of SHAs as an argument.")"#);
+        insta::assert_compact_debug_snapshot!(parse_command("@rust-timer triage abcd"),
+            @r#"Ok(Triage(TriageCommand { shas: ["abcd"] }))"#);
+        insta::assert_compact_debug_snapshot!(parse_command("@rust-timer triage abcd efgh"),
+            @r#"Ok(Triage(TriageCommand { shas: ["abcd", "efgh"] }))"#);
+        insta::assert_compact_debug_snapshot!(parse_command("@rust-timer triage abcd efgh ijkl"),
+            @r#"Ok(Triage(TriageCommand { shas: ["abcd", "efgh", "ijkl"] }))"#);
+        insta::assert_compact_debug_snapshot!(parse_command("@rust-timer triage abcd targets=Foo"),
+            @r#"Err("Sha `targets=Foo` is not alphanumeric")"#);
+        insta::assert_compact_debug_snapshot!(parse_command("@rust-timer triage abcd  efgh"),
+            @r#"Ok(Triage(TriageCommand { shas: ["abcd", "efgh"] }))"#);
     }
 }

--- a/site/src/request_handlers/github.rs
+++ b/site/src/request_handlers/github.rs
@@ -5,6 +5,8 @@ use crate::github::{
 };
 use crate::load::SiteCtxt;
 
+use crate::api::github::Issue;
+use crate::github::client::Client;
 use database::{
     parse_backends, parse_profiles, parse_targets, BenchmarkRequest, BenchmarkRequestInsertResult,
     CodegenBackend, Profile, Target,
@@ -238,25 +240,7 @@ async fn handle_rust_timer(
             main_client.post_comment(issue.number, comment).await;
         }
         Ok(RustTimerCommand::Build(cmd)) => {
-            // requested artifacts do not exist errors
-            if let Err(error) = validate_build_command(&cmd).await {
-                main_client.post_comment(issue.number, error).await;
-                return Ok(github::Response);
-            }
-
-            {
-                let conn = ctxt.conn().await;
-                record_try_benchmark_request_without_artifacts(
-                    &*conn,
-                    issue.number,
-                    cmd.params.backends.unwrap_or(""),
-                    cmd.params.profiles.unwrap_or(""),
-                    cmd.params.targets.unwrap_or(""),
-                )
-                .await;
-            }
-
-            match enqueue_sha(&ctxt, main_client, issue.number, &cmd.sha).await {
+            match enqueue_sha_build(&ctxt, main_client, issue.number, &cmd).await {
                 Ok(mut msg) => {
                     msg.push_str(&format!("\n{COMMENT_MARK_TEMPORARY}"));
                     main_client.post_comment(issue.number, msg).await;
@@ -264,17 +248,39 @@ async fn handle_rust_timer(
                 Err(error) => {
                     log::error!("Failed to enqueue SHA on {}: {error:?}", issue.number);
                     main_client.post_comment(issue.number, error).await;
-                    return Ok(github::Response);
                 }
             };
         }
         Err(e) => {
             main_client.post_comment(issue.number, e).await;
-            return Ok(github::Response);
         }
     }
 
     Ok(github::Response)
+}
+
+async fn enqueue_sha_build(
+    ctxt: &Arc<SiteCtxt>,
+    main_client: &Client,
+    issue_number: u32,
+    cmd: &BuildCommand<'_>,
+) -> Result<String, String> {
+    // requested artifacts do not exist errors
+    validate_build_command(cmd).await?;
+
+    {
+        let conn = ctxt.conn().await;
+        record_try_benchmark_request_without_artifacts(
+            &*conn,
+            issue_number,
+            cmd.params.backends.unwrap_or(""),
+            cmd.params.profiles.unwrap_or(""),
+            cmd.params.targets.unwrap_or(""),
+        )
+        .await;
+    }
+
+    enqueue_sha(ctxt, main_client, issue_number, cmd.sha).await
 }
 
 fn parse_command(body: &str) -> Result<RustTimerCommand<'_>, String> {


### PR DESCRIPTION
This PR implements step 1 of the triage command as described in the initial pitch [#t-compiler/performance > Proposal for &#96;@rust-timer triage&#96; command @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/247081-t-compiler.2Fperformance/topic/Proposal.20for.20.60.40rust-timer.20triage.60.20command/near/606899059).

It consists of 4 commits, which I recommend to review individually:
1. [Simplify enqueue_sha function](https://github.com/rust-lang/rustc-perf/commit/2b36ac3201a9626b8432c78479f61e115c113c1b) -> Simplifies the `enqueue_sha` by pushing the comment posting logic out of the function & removing to option to provide multiple commits. This PR benefits from "hide whitespace" during review again.
2. [Factor enqueue_sha_build into its own function](https://github.com/rust-lang/rustc-perf/commit/322ada1557b044f1e607a3aa7c63401c6a449d1c) -> Factor part of the `@rust-timer build` command into its own function, which can be re-used by the triage command.
3. [Add command parsing for triage command](https://github.com/rust-lang/rustc-perf/commit/65a83d0354647c380215d0b2495bc44a26908cc4)
4. [Implement triage command](https://github.com/rust-lang/rustc-perf/commit/65ed0ec052d914857301ee1ea29540244b6105f4)

r? @Kobzol 