### PR TITLE
Fix "detailed results" button for doc-json benchmarks

### DIFF
--- a/site/frontend/src/pages/detailed-query/page.vue
+++ b/site/frontend/src/pages/detailed-query/page.vue
@@ -197,7 +197,12 @@ async function loadData() {
   // To maintain backwards compatibility of URLs, parse the profile from the
   // benchmark URL parameter
   // We turn <benchmark>-<profile> into two separate parameters for the backend
-  const parts = benchmark.split("-");
+  let parts: string[];
+  if (benchmark.endsWith("-doc-json")) {
+    parts = [benchmark.slice(0, -"-doc-json"), "doc-json"];
+  } else {
+    parts = benchmark.split("-");
+  }
   const profile = parts[parts.length - 1];
   const benchmarkSeparate = parts.slice(0, parts.length - 1).join("-");
 

--- a/site/frontend/src/pages/detailed-query/page.vue
+++ b/site/frontend/src/pages/detailed-query/page.vue
@@ -199,7 +199,7 @@ async function loadData() {
   // We turn <benchmark>-<profile> into two separate parameters for the backend
   let parts: string[];
   if (benchmark.endsWith("-doc-json")) {
-    parts = [benchmark.slice(0, -"-doc-json"), "doc-json"];
+    parts = [benchmark.slice(0, -"-doc-json".length), "doc-json"];
   } else {
     parts = benchmark.split("-");
   }


### PR DESCRIPTION
Clicking "detailed results" on one of the doc-json benchmarks, for example [in this run](https://perf.rust-lang.org/compare.html?start=93c9086fdd5b80d286480a19ac047746ecc5fa1f&end=059bf4a660ddea5bd8302ecdd4f7e40dd7a04313&stat=instructions:u), returns an error:
```
invalid profile: "json is not a profile"
```

r? @Kobzol 