### PR TITLE
Add crate metadata to compare page quick links

### DIFF
--- a/site/frontend/src/pages/compare/metrics.ts
+++ b/site/frontend/src/pages/compare/metrics.ts
@@ -34,6 +34,11 @@ export const importantCompileMetrics: MetricDescription[] = [
     metric: "size:linked_artifact",
     description: "Size of the generated binary artifact",
   },
+  {
+    label: "Metadata size",
+    metric: "size:crate_metadata",
+    description: "Size of the generated crate metadata",
+  },
 ];
 
 export const importantRuntimeMetrics: MetricDescription[] = [...sharedMetrics];


### PR DESCRIPTION
After https://github.com/rust-lang/rust/pull/161273#issuecomment-5340372566, metadata will no longer be contained in the `Binary size` metric. That is good, because it was quite misleading, but it also makes crate metadata size changes a bit harder to detect. This PR adds a "Crate metadata" quick link to the compare page, to at least make it easier to access:

<img width="882" height="64" alt="image" src="https://github.com/user-attachments/assets/6fef06f5-f315-412a-b1b7-ca3e045f4f7a" />