### PR TITLE
Include profile in error message about unavailable artifacts

### DIFF
--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -1594,10 +1594,11 @@ async fn run_benchmark_job(
                 Ok(sysroot) => sysroot,
                 Err(SysrootDownloadError::SysrootShaNotFound) => {
                     return Err(BenchmarkJobError::Permanent(anyhow::anyhow!(
-                        "Artifacts for SHA `{}`, target `{}` and backend `{}` were not found on CI servers",
+                        "Artifacts for SHA `{}`, target `{}`, backend `{}` and profile `{}` were not found on CI servers",
                         commit.sha,
                         job.target().as_str(),
-                        job.backend().as_str()
+                        job.backend().as_str(),
+                        job.profile().as_str()
                     )))
                 }
                 Err(SysrootDownloadError::IO(error)) => return Err(error.into()),


### PR DESCRIPTION
Sometimes, the profile can be the problem (e.g. a missing Clippy component), but before that was not obvious from the error message.
