### PR TITLE
Fix triage comment update

### DIFF
--- a/site/src/github/client.rs
+++ b/site/src/github/client.rs
@@ -131,6 +131,7 @@ impl GraphQLClient {
                         comments(first: 100, after: $cursor) {
                             nodes {
                                 id
+                                fullDatabaseId
                                 body
                                 isMinimized
                                 viewerDidAuthor
@@ -291,6 +292,7 @@ struct GraphPageInfo {
 #[serde(rename_all = "camelCase")]
 pub struct ResponseComment {
     pub id: String,
+    pub full_database_id: String,
     pub body: String,
     pub is_minimized: bool,
     // Is the account that fetches this comment also the original author of the comment?

--- a/site/src/github/comparison_summary.rs
+++ b/site/src/github/comparison_summary.rs
@@ -413,7 +413,7 @@ fn triage_run_body(build: &TriageBuild, is_regression: bool) -> String {
         \n\n\
         {}",
         build.rollup_pr_number,
-        build.triage_comment.id,
+        build.triage_comment.full_database_id,
         master_run_body(is_regression)
     )
 }

--- a/site/src/github/comparison_summary.rs
+++ b/site/src/github/comparison_summary.rs
@@ -45,7 +45,11 @@ pub async fn post_comparison_comment(
         let triage_summary = metrics_result(ctxt, &commit)
             .await
             .unwrap_or_else(|error| error);
-        match update_triage_body(&mut triage_run.triage_comment.body, pr, triage_summary) {
+        match update_triage_body(
+            &mut triage_run.triage_comment.body,
+            pr,
+            format!("{}\n", triage_summary),
+        ) {
             Ok(()) => {
                 // While in theory this is racy (the comment could have been edited since querying it),
                 // in practice this should never happen

--- a/site/src/github/comparison_summary.rs
+++ b/site/src/github/comparison_summary.rs
@@ -134,11 +134,23 @@ async fn summarize_run(
 ) -> Result<String, String> {
     let benchmark_map = ctxt.get_benchmark_category_map().await;
 
-    let mut message = format!(
+    let mut message = String::new();
+    if let PerfRunSource::TriageBuild(build) = &source {
+        write!(
+            &mut message,
+            "> [!NOTE]\n> This PR was benchmarked as part of triage of its containing rollup: [triage URL](/rust-lang/rust/pull/{}#issuecomment-{}).\n\n",
+            build.rollup_pr_number,
+            build.triage_comment.full_database_id
+        ).unwrap();
+    }
+
+    write!(
+        &mut message,
         "Finished benchmarking commit ({sha}): [comparison URL]({comparison_url}).\n\n",
         sha = commit.sha,
         comparison_url = make_comparison_url(&commit, Metric::InstructionsUser)
-    );
+    )
+    .unwrap();
 
     let inst_comparison =
         calculate_metric_comparison(ctxt, &commit, Metric::InstructionsUser).await?;
@@ -191,8 +203,9 @@ async fn summarize_run(
 
     let next_steps = match &source {
         PerfRunSource::TryBuild => try_run_body(is_regression, deserves_attention),
-        PerfRunSource::MasterCommit => master_run_body(is_regression),
-        PerfRunSource::TriageBuild(triage_build) => triage_run_body(triage_build, is_regression),
+        PerfRunSource::MasterCommit | PerfRunSource::TriageBuild(..) => {
+            master_run_body(is_regression)
+        }
     };
     writeln!(&mut message, "{next_steps}\n").unwrap();
 
@@ -402,18 +415,5 @@ Benchmarking means the PR may be perf-sensitive. \
 
 {rollup_never}
 @rustbot label: -S-waiting-on-perf {sign}perf-regression",
-    )
-}
-
-fn triage_run_body(build: &TriageBuild, is_regression: bool) -> String {
-    // The triage url deliberately not prefixed with "https://github.com/" as to not trigger the
-    // "mentioned this pull request" github entry on the rollup
-    format!(
-        "This PR was benchmarked as part of triage of its containing rollup: [triage URL](/rust-lang/rust/pull/{}#issuecomment-{}).\
-        \n\n\
-        {}",
-        build.rollup_pr_number,
-        build.triage_comment.full_database_id,
-        master_run_body(is_regression)
     )
 }


### PR DESCRIPTION
Fixes:
- There are not enough newlines in the `triage_summary`, causing the title of the next entry to not be rendered (because markdown titles require two newlines before them)
- The triage URL needs to have the comment database ID, not the ID
- Move the triage comment to be just below "Finished benchmarking commit"

r? @Kobzol 