### PR TITLE
Replace archived actions-rs/cargo with cargo directly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -45,10 +45,7 @@ jobs:
           npm run build
 
       - name: Compile site
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
-        with:
-          command: build
-          args: --release --bin site
+        run: cargo build --release --bin site
 
       - name: Prepare archive
         id: archive


### PR DESCRIPTION
actions-rs/cargo has been archived for a while now, so this swaps it in CI for cargo directly. The toolchain is already installed via rustup earlier in the job, so the build runs the same as before.
This only touches .github/workflows/nightly.yml. The other archived-action references under collector/compile-benchmarks/ are vendored benchmark crates, not rustc-perf's own CI, so they're intentionally left as-is.
This is part of a wider effort to remove archived actions across rust-lang repos, tracked in rust-lang/crabwatch#49.
