### PR TITLE
Improve support for ARM benchmarks

### DIFF
--- a/database/schema.md
+++ b/database/schema.md
@@ -232,7 +232,7 @@ Columns:
   * `completed`: Completed request.
 * **backends** (`text NOT NULL`): Comma-separated list of codegen backends to benchmark. If empty, the default set of codegen backends will be benchmarked.
 * **profiles** (`text NOT NULL`): Comma-separated list of profiles to benchmark. If empty, the default set of profiles will be benchmarked.
-* **targets** (`text NOT NULL`): Comma-separated list of targets to benchmark. If empty, the default `x86_64-unknown-linux-gnu` will be benchmarked.
+* **targets** (`text NOT NULL`): Comma-separated list of targets to benchmark. If empty, the default set of targets will be benchmarked.
 
 ### collector_config
 

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -421,8 +421,8 @@ impl Target {
         }
     }
 
-    /// Targets that we primarily support in the website.
-    pub fn primary_targets() -> Vec<Self> {
+    /// Targets that we currently support.
+    pub fn available_targets() -> Vec<Self> {
         vec![Self::X86_64UnknownLinuxGnu, Self::AArch64UnknownLinuxGnu]
     }
 
@@ -1188,10 +1188,17 @@ pub fn parse_profiles(profiles: &str) -> Result<Vec<Profile>, String> {
 }
 
 pub fn parse_targets(targets: &str) -> Result<Vec<Target>, String> {
-    let primary = Target::primary_targets();
+    let available = Target::available_targets();
     let targets = parse_comma_separated(targets, "target")?;
-    if !targets.iter().all(|t| primary.contains(t)) {
-        return Err("Only primary targets can be specified".to_string());
+    if !targets.iter().all(|t| available.contains(t)) {
+        return Err(format!(
+            "Only the available targets `{}` can be specified",
+            available
+                .iter()
+                .map(|t| t.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
     }
     Ok(targets)
 }

--- a/database/src/selector.rs
+++ b/database/src/selector.rs
@@ -244,6 +244,18 @@ impl CompileBenchmarkQuery {
             metric: Selector::One(metric.as_str().into()),
         }
     }
+
+    pub fn all_for_metric_and_target(metric: Metric, target: Target) -> Self {
+        Self {
+            benchmark: Selector::All,
+            profile: Selector::All,
+            scenario: Selector::All,
+            backend: Selector::All,
+            target: Selector::One(target),
+            frontend_threads: Selector::All,
+            metric: Selector::One(metric.as_str().into()),
+        }
+    }
 }
 
 impl Default for CompileBenchmarkQuery {
@@ -384,6 +396,14 @@ impl RuntimeBenchmarkQuery {
         Self {
             benchmark: Selector::All,
             target: Selector::All,
+            metric: Selector::One(metric.as_str().into()),
+        }
+    }
+
+    pub fn all_for_metric_and_target(metric: Metric, target: Target) -> Self {
+        Self {
+            benchmark: Selector::All,
+            target: Selector::One(target),
             metric: Selector::One(metric.as_str().into()),
         }
     }

--- a/site/frontend/src/pages/compare/compile/benchmarks.vue
+++ b/site/frontend/src/pages/compare/compile/benchmarks.vue
@@ -16,7 +16,6 @@ export interface BenchmarkProps {
   benchmarkMap: CompileBenchmarkMap;
   filter: CompileBenchmarkFilter;
   stat: string;
-  showBackend: boolean;
 }
 
 const props = defineProps<BenchmarkProps>();
@@ -78,7 +77,6 @@ const secondaryHasNonRelevant = computed(
       :commit-b="data.b"
       :stat="stat"
       :benchmark-map="benchmarkMap"
-      :show-backend="showBackend"
     >
       <template #header>
         <Section title="Primary" link="secondary" :linkUp="false"></Section>
@@ -94,7 +92,6 @@ const secondaryHasNonRelevant = computed(
       :commit-b="data.b"
       :stat="stat"
       :benchmark-map="benchmarkMap"
-      :show-backend="showBackend"
     >
       <template #header>
         <Section title="Secondary" link="primary" :linkUp="true"></Section>

--- a/site/frontend/src/pages/compare/compile/common.ts
+++ b/site/frontend/src/pages/compare/compile/common.ts
@@ -34,7 +34,7 @@ export type CompileBenchmarkFilter = {
     regressions: boolean;
     improvements: boolean;
   };
-  selfCompareBackend: boolean;
+  selfCompareParameter: string | null;
 } & BenchmarkFilter;
 
 export const defaultCompileFilter: CompileBenchmarkFilter = {
@@ -71,7 +71,7 @@ export const defaultCompileFilter: CompileBenchmarkFilter = {
     regressions: true,
     improvements: true,
   },
-  selfCompareBackend: false,
+  selfCompareParameter: null,
 };
 
 export type Profile = "check" | "debug" | "opt" | "doc";

--- a/site/frontend/src/pages/compare/compile/common.ts
+++ b/site/frontend/src/pages/compare/compile/common.ts
@@ -81,6 +81,13 @@ export type Target = "x86_64-unknown-linux-gnu" | "aarch64-unknown-linux-gnu";
 
 export type CompileBenchmarkMap = Dict<CompileBenchmarkMetadata>;
 
+export type SelfCompareData = {
+  // Which benchmark parameter are we comparing?
+  parameter: "backend" | "target";
+  // Which value of the parameter is the baseline?
+  baseline: string;
+};
+
 export interface CargoProfileMetadata {
   debug: string | null;
   lto: string | null;
@@ -162,7 +169,7 @@ export function computeCompileComparisonsWithNonRelevant(
   }
 
   function artifactFilter(metadata: CompileBenchmarkMetadata | null): boolean {
-    if (metadata?.binary === null) return true;
+    if (metadata === null || metadata?.binary === null) return true;
 
     const isBinary = metadata.binary;
     const isLibrary = !isBinary;
@@ -231,7 +238,7 @@ export function computeCompileComparisonsWithNonRelevant(
 export function createCompileBenchmarkMap(
   data: CompareResponse
 ): CompileBenchmarkMap {
-  const benchmarks = {};
+  const benchmarks: CompileBenchmarkMap = {};
   for (const benchmark of data.compile_benchmark_metadata) {
     benchmarks[benchmark.name] = {...benchmark};
   }
@@ -242,57 +249,66 @@ export function testCaseKey(testCase: CompileTestCase): string {
   return `${testCase.benchmark};${testCase.profile};${testCase.scenario};${testCase.backend};${testCase.category}`;
 }
 
-// Transform compile comparisons to compare LLVM vs Cranelift, instead of
-// before/after. Assumes that the data comes from the same commit.
-export function transformDataForBackendComparison(
-  comparisons: CompileBenchmarkComparison[]
+// Transform compile comparisons to compare treat the given benchmark
+// parameter's baseline value as the previous commit data.
+// Assumes that the data comes from the same commit.
+export function transformDataForSelfComparison(
+  comparisons: CompileBenchmarkComparison[],
+  selfCompare: SelfCompareData
 ): CompileBenchmarkComparison[] {
-  const benchmarkMap: Map<
-    string,
-    {
-      llvm: number | null;
-      cranelift: number | null;
-      benchmark: string;
-      profile: Profile;
-      target: Target;
-      scenario: string;
-    }
-  > = new Map();
+  function computeKey(comparison: CompileBenchmarkComparison): string {
+    // Create a key out of the comparison entry
+    const object: any = {...comparison};
+    // Remove metric comparison
+    delete object["comparison"];
+    // Remove the self-compare parameter
+    delete object[selfCompare.parameter];
+
+    const keys = Object.keys(object);
+    keys.sort();
+    return keys.map((k) => `${object[k]}`).join(";");
+  }
+
+  const baselineValues: Map<string, CompileBenchmarkComparison> = new Map();
+  // Record baselines
   for (const comparison of comparisons) {
-    const key = `${comparison.benchmark};${comparison.profile};${comparison.scenario};${comparison.target}`;
-    if (!benchmarkMap.has(key)) {
-      benchmarkMap.set(key, {
-        llvm: null,
-        cranelift: null,
-        benchmark: comparison.benchmark,
-        profile: comparison.profile,
-        scenario: comparison.scenario,
-        target: comparison.target,
-      });
-    }
-    const record = benchmarkMap.get(key);
-    if (comparison.backend === "llvm") {
-      record.llvm = comparison.comparison.statistics[0];
-    } else if (comparison.backend === "cranelift") {
-      record.cranelift = comparison.comparison.statistics[0];
+    const key = computeKey(comparison);
+    if (comparison[selfCompare.parameter] === selfCompare.baseline) {
+      baselineValues.set(key, comparison);
     }
   }
 
-  return Array.from(benchmarkMap, ([_, entry]) => {
-    const comparison: CompileBenchmarkComparison = {
-      benchmark: entry.benchmark,
-      profile: entry.profile,
-      scenario: entry.scenario,
-      // Treat LLVM as the baseline
-      backend: "llvm",
-      target: entry.target,
+  // Construct new entries
+  const result = [];
+  for (const comparison of comparisons) {
+    // Ignore comparison if it is the baseline
+    if (comparison[selfCompare.parameter] === selfCompare.baseline) {
+      continue;
+    }
+    // Find corresponding baseline for this comparison
+    const key = computeKey(comparison);
+    const baseline = baselineValues.get(key);
+    // No baseline found
+    if (baseline === undefined) {
+      console.warn(
+        `No baseline found for parameter ${selfCompare.parameter} and key ${key}.`
+      );
+      continue;
+    }
+    // Replace baseline entry
+    const updated: CompileBenchmarkComparison = {
+      ...comparison,
       comparison: {
-        statistics: [entry.llvm, entry.cranelift],
-        is_relevant: true,
-        significance_factor: 1.0,
-        significance_threshold: 1.0,
+        ...comparison.comparison,
+        statistics: [
+          // Baseline value
+          baseline.comparison.statistics[0],
+          // Current value
+          comparison.comparison.statistics[1],
+        ],
       },
     };
-    return comparison;
-  });
+    result.push(updated);
+  }
+  return result;
 }

--- a/site/frontend/src/pages/compare/compile/compile-page.vue
+++ b/site/frontend/src/pages/compare/compile/compile-page.vue
@@ -22,8 +22,9 @@ import {
   getBoolOrDefault,
   isSameStringArray,
   loadTargetsFromUrl,
-  storeOrResetBool,
+  storeOrResetValue,
   storeOrResetStringArray,
+  getStringOrDefault,
 } from "../shared";
 
 const props = defineProps<{
@@ -140,10 +141,10 @@ function loadFilterFromUrl(
         defaultCompileFilter.changes.improvements
       ),
     },
-    selfCompareBackend: getBoolOrDefault(
+    selfCompareParameter: getStringOrDefault(
       urlParams,
-      "selfCompareBackend",
-      defaultFilter.selfCompareBackend
+      "selfCompareParameter",
+      defaultFilter.selfCompareParameter
     ),
   };
 }
@@ -157,80 +158,80 @@ function storeFilterToUrl(
   defaultFilter: CompileBenchmarkFilter,
   urlParams: Dict<string>
 ) {
-  storeOrResetBool(urlParams, "name", filter.name || null, defaultFilter.name);
-  storeOrResetBool(
+  storeOrResetValue(urlParams, "name", filter.name, defaultFilter.name);
+  storeOrResetValue(
     urlParams,
     "nonRelevant",
     filter.nonRelevant,
     defaultFilter.nonRelevant
   );
-  storeOrResetBool(
+  storeOrResetValue(
     urlParams,
     "showRawData",
     filter.showRawData,
     defaultFilter.showRawData
   );
-  storeOrResetBool(
+  storeOrResetValue(
     urlParams,
     "check",
     filter.profile.check,
     defaultFilter.profile.check
   );
-  storeOrResetBool(
+  storeOrResetValue(
     urlParams,
     "debug",
     filter.profile.debug,
     defaultFilter.profile.debug
   );
-  storeOrResetBool(
+  storeOrResetValue(
     urlParams,
     "opt",
     filter.profile.opt,
     defaultFilter.profile.opt
   );
-  storeOrResetBool(
+  storeOrResetValue(
     urlParams,
     "doc",
     filter.profile.doc,
     defaultFilter.profile.doc
   );
-  storeOrResetBool(
+  storeOrResetValue(
     urlParams,
     "doc-json",
     filter.profile.docJson,
     defaultFilter.profile.docJson
   );
-  storeOrResetBool(
+  storeOrResetValue(
     urlParams,
     "full",
     filter.scenario.full,
     defaultFilter.scenario.full
   );
-  storeOrResetBool(
+  storeOrResetValue(
     urlParams,
     "incrFull",
     filter.scenario.incrFull,
     defaultFilter.scenario.incrFull
   );
-  storeOrResetBool(
+  storeOrResetValue(
     urlParams,
     "incrUnchanged",
     filter.scenario.incrUnchanged,
     defaultFilter.scenario.incrUnchanged
   );
-  storeOrResetBool(
+  storeOrResetValue(
     urlParams,
     "incrPatched",
     filter.scenario.incrPatched,
     defaultFilter.scenario.incrPatched
   );
-  storeOrResetBool(
+  storeOrResetValue(
     urlParams,
     "backend-llvm",
     filter.backend.llvm,
     defaultFilter.backend.llvm
   );
-  storeOrResetBool(
+  storeOrResetValue(
     urlParams,
     "backend-clif",
     filter.backend.cranelift,
@@ -242,47 +243,47 @@ function storeFilterToUrl(
     filter.target,
     defaultFilter.target
   );
-  storeOrResetBool(
+  storeOrResetValue(
     urlParams,
     "primary",
     filter.category.primary,
     defaultFilter.category.primary
   );
-  storeOrResetBool(
+  storeOrResetValue(
     urlParams,
     "secondary",
     filter.category.secondary,
     defaultFilter.category.secondary
   );
-  storeOrResetBool(
+  storeOrResetValue(
     urlParams,
     "binary",
     filter.artifact.binary,
     defaultFilter.artifact.binary
   );
-  storeOrResetBool(
+  storeOrResetValue(
     urlParams,
     "library",
     filter.artifact.library,
     defaultFilter.artifact.library
   );
-  storeOrResetBool(
+  storeOrResetValue(
     urlParams,
     "regressions",
     filter.changes.regressions,
     defaultFilter.changes.regressions
   );
-  storeOrResetBool(
+  storeOrResetValue(
     urlParams,
     "improvements",
     filter.changes.improvements,
     defaultFilter.changes.improvements
   );
-  storeOrResetBool(
+  storeOrResetValue(
     urlParams,
-    "selfCompareBackend",
-    filter.selfCompareBackend,
-    defaultFilter.selfCompareBackend
+    "selfCompareParameter",
+    filter.selfCompareParameter,
+    defaultFilter.selfCompareParameter
   );
 
   changeUrl(urlParams);
@@ -311,7 +312,9 @@ const filter = ref(loadFilterFromUrl(urlParams, defaultCompileFilter));
 
 // Should we use the backend as the source of before/after data?
 const selfCompareBackend = computed(() => {
-  return canCompareBackends.value && filter.value.selfCompareBackend;
+  return (
+    canCompareBackends.value && filter.value.selfCompareParameter === "backend"
+  );
 });
 const canCompareBackends = computed(() => {
   const hasMultipleBackends =

--- a/site/frontend/src/pages/compare/compile/compile-page.vue
+++ b/site/frontend/src/pages/compare/compile/compile-page.vue
@@ -14,7 +14,8 @@ import {
   computeCompileComparisonsWithNonRelevant,
   createCompileBenchmarkMap,
   defaultCompileFilter,
-  transformDataForBackendComparison,
+  SelfCompareData,
+  transformDataForSelfComparison,
 } from "./common";
 import {BenchmarkInfo, DEFAULT_COMPILE_TARGET_TRIPLE} from "../../../api";
 import {importantCompileMetrics} from "../metrics";
@@ -310,18 +311,31 @@ const urlParams = getUrlParams();
 const quickLinksKey = ref(0);
 const filter = ref(loadFilterFromUrl(urlParams, defaultCompileFilter));
 
-// Should we use the backend as the source of before/after data?
-const selfCompareBackend = computed(() => {
-  return (
-    canCompareBackends.value && filter.value.selfCompareParameter === "backend"
-  );
-});
-const canCompareBackends = computed(() => {
-  const hasMultipleBackends =
-    new Set(props.data.compile_comparisons.map((c) => c.backend)).size > 1;
+const selfCompareCanBeEnabled = computed(() => {
   // Are we currently comparing the same commit in the before/after toolchains?
-  const comparesSameCommit = props.data.a.commit === props.data.b.commit;
-  return hasMultipleBackends && comparesSameCommit;
+  return props.data.a.commit === props.data.b.commit;
+});
+
+// Should we use a given benchmark parameter as the source of before/after data?
+const selfCompareData = computed((): SelfCompareData | null => {
+  if (!selfCompareCanBeEnabled.value) return null;
+
+  const selfCompare = filter.value.selfCompareParameter;
+  if (selfCompare === null) return null;
+
+  if (selfCompare === "backend") {
+    return {
+      parameter: "backend",
+      baseline: "llvm",
+    };
+  } else if (selfCompare === "target") {
+    return {
+      parameter: "target",
+      baseline: DEFAULT_COMPILE_TARGET_TRIPLE,
+    };
+  } else {
+    return null;
+  }
 });
 
 function exportData() {
@@ -331,9 +345,14 @@ function exportData() {
 const benchmarkMap = createCompileBenchmarkMap(props.data);
 
 const compileComparisons = computed(() => {
-  // If requested, artificially restructure the data to create a comparison between backends
-  if (selfCompareBackend.value) {
-    return transformDataForBackendComparison(props.data.compile_comparisons);
+  // If requested, artificially restructure the data to create a comparison
+  // between the selected benchmark parameter
+  const selfCompare = selfCompareData.value;
+  if (selfCompare !== null) {
+    return transformDataForSelfComparison(
+      props.data.compile_comparisons,
+      selfCompare
+    );
   } else {
     return props.data.compile_comparisons;
   }
@@ -362,15 +381,15 @@ const filteredSummary = computed(() => computeSummary(comparisons.value));
     :info="benchmarkInfo"
     :default-filter="defaultCompileFilter"
     :initial-filter="filter"
-    :can-compare-backends="canCompareBackends"
+    :self-compare-enabled="selfCompareCanBeEnabled"
     @change="updateFilter"
     @export="exportData"
   />
   <OverallSummary :summary="filteredSummary" />
   <Aggregations :cases="comparisons" />
-  <div class="warning" v-if="selfCompareBackend">
-    Note: comparing results of the baseline LLVM backend to the Cranelift
-    backend.
+  <div class="warning" v-if="selfCompareData !== null">
+    Note: comparing results against the baseline {{ selfCompareData.baseline }}
+    {{ selfCompareData.parameter }}.
   </div>
   <Benchmarks
     :data="data"
@@ -379,7 +398,6 @@ const filteredSummary = computed(() => computeSummary(comparisons.value));
     :filter="filter"
     :stat="selector.stat"
     :benchmark-map="benchmarkMap"
-    :show-backend="!selfCompareBackend"
   ></Benchmarks>
 </template>
 <style lang="scss" scoped>

--- a/site/frontend/src/pages/compare/compile/filters.vue
+++ b/site/frontend/src/pages/compare/compile/filters.vue
@@ -14,7 +14,7 @@ const props = defineProps<{
   defaultFilter: CompileBenchmarkFilter;
   // Initialize the filter with this value
   initialFilter: CompileBenchmarkFilter;
-  canCompareBackends: boolean;
+  selfCompareEnabled: boolean;
 }>();
 const emit = defineEmits<{
   (e: "change", filter: CompileBenchmarkFilter): void;
@@ -38,13 +38,9 @@ function toggleTarget(target: Target) {
   }
 }
 
-function updateSelfCompareParameter(parameter: string, event: Event) {
-  const value = (event.target as HTMLInputElement).checked;
-  if (!value) {
-    filter.value.selfCompareParameter = null;
-  } else {
-    filter.value.selfCompareParameter = parameter;
-  }
+function updateSelfCompareParameter(event: Event) {
+  let rawValue = (event.target as HTMLSelectElement).value;
+  filter.value.selfCompareParameter = rawValue === "" ? null : rawValue;
 }
 
 let filter = ref(deepCopy(props.initialFilter));
@@ -376,16 +372,28 @@ const opened = createPersistedRef(PREF_FILTERS_OPENED);
           </div>
           <div
             class="section"
-            v-if="canCompareBackends"
-            title="Compare codegen backends for this commit"
+            v-if="selfCompareEnabled"
+            title="Compare different values of a single benchmark parameter for this commit"
           >
-            Compare codegen backends for this commit:
-            <input
-              type="checkbox"
-              :checked="filter.selfCompareParameter === 'backend'"
-              @change="(value) => updateSelfCompareParameter('backend', value)"
-              v-model="filter.selfCompareParameter"
-            />
+            Compare benchmark parameter for this commit:
+            <select @change="updateSelfCompareParameter">
+              <option
+                value=""
+                :selected="filter.selfCompareParameter === null"
+              ></option>
+              <option
+                value="backend"
+                :selected="filter.selfCompareParameter === 'backend'"
+              >
+                Codegen backend
+              </option>
+              <option
+                value="target"
+                :selected="filter.selfCompareParameter === 'target'"
+              >
+                Target
+              </option>
+            </select>
           </div>
           <button @click="reset" style="margin-right: 10px">
             Reset filters

--- a/site/frontend/src/pages/compare/compile/filters.vue
+++ b/site/frontend/src/pages/compare/compile/filters.vue
@@ -38,6 +38,15 @@ function toggleTarget(target: Target) {
   }
 }
 
+function updateSelfCompareParameter(parameter: string, event: Event) {
+  const value = (event.target as HTMLInputElement).checked;
+  if (!value) {
+    filter.value.selfCompareParameter = null;
+  } else {
+    filter.value.selfCompareParameter = parameter;
+  }
+}
+
 let filter = ref(deepCopy(props.initialFilter));
 watch(
   filter,
@@ -368,10 +377,15 @@ const opened = createPersistedRef(PREF_FILTERS_OPENED);
           <div
             class="section"
             v-if="canCompareBackends"
-            :title="`Compare codegen backends for this commit`"
+            title="Compare codegen backends for this commit"
           >
             Compare codegen backends for this commit:
-            <input type="checkbox" v-model="filter.selfCompareBackend" />
+            <input
+              type="checkbox"
+              :checked="filter.selfCompareParameter === 'backend'"
+              @change="(value) => updateSelfCompareParameter('backend', value)"
+              v-model="filter.selfCompareParameter"
+            />
           </div>
           <button @click="reset" style="margin-right: 10px">
             Reset filters

--- a/site/frontend/src/pages/compare/compile/table/comparisons-table.vue
+++ b/site/frontend/src/pages/compare/compile/table/comparisons-table.vue
@@ -18,7 +18,6 @@ const props = defineProps<{
   commitA: ArtifactDescription;
   commitB: ArtifactDescription;
   stat: string;
-  showBackend: boolean;
 }>();
 
 function prettifyRawNumber(number: number): string {
@@ -61,7 +60,7 @@ const unit = computed(() => {
           <th>Benchmark</th>
           <th>Profile</th>
           <th>Scenario</th>
-          <th v-if="showBackend">Backend</th>
+          <th>Backend</th>
           <th>Target</th>
           <th>% Change</th>
           <th class="narrow">
@@ -101,7 +100,7 @@ const unit = computed(() => {
                 {{ comparison.testCase.profile }}
               </td>
               <td>{{ comparison.testCase.scenario }}</td>
-              <td v-if="showBackend">{{ comparison.testCase.backend }}</td>
+              <td>{{ comparison.testCase.backend }}</td>
               <td :title="comparison.testCase.target">
                 {{ formatTarget(comparison.testCase.target) }}
               </td>

--- a/site/frontend/src/pages/compare/runtime/runtime-page.vue
+++ b/site/frontend/src/pages/compare/runtime/runtime-page.vue
@@ -15,7 +15,7 @@ import ComparisonsTable from "./comparisons-table.vue";
 import {
   getBoolOrDefault,
   loadTargetsFromUrl,
-  storeOrResetBool,
+  storeOrResetValue,
   storeOrResetStringArray,
 } from "../shared";
 import {changeUrl, getUrlParams} from "../../../utils/navigation";
@@ -56,7 +56,7 @@ function storeFilterToUrl(
   defaultFilter: RuntimeBenchmarkFilter,
   urlParams: Dict<string>
 ) {
-  storeOrResetBool(
+  storeOrResetValue(
     urlParams,
     "runtimeName",
     filter.name || null,
@@ -68,13 +68,13 @@ function storeFilterToUrl(
     filter.target,
     defaultFilter.target
   );
-  storeOrResetBool(
+  storeOrResetValue(
     urlParams,
     "nonRelevant",
     filter.nonRelevant,
     defaultFilter.nonRelevant
   );
-  storeOrResetBool(
+  storeOrResetValue(
     urlParams,
     "showRawData",
     filter.showRawData,

--- a/site/frontend/src/pages/compare/shared.ts
+++ b/site/frontend/src/pages/compare/shared.ts
@@ -81,6 +81,17 @@ export function getBoolOrDefault(
   return defaultValue;
 }
 
+export function getStringOrDefault(
+  params: Dict<string>,
+  name: string,
+  defaultValue: string | null
+): string | null {
+  if (params.hasOwnProperty(name)) {
+    return params[name];
+  }
+  return defaultValue;
+}
+
 export function getStringArrayOrDefault(
   params: Dict<string>,
   name: string,
@@ -114,9 +125,9 @@ export function targetMatchesFilter(
   return target_set.includes(target);
 }
 
-// Store the bool value into URL parameters, or reset it if it has the default
+// Store the bool or string value into URL parameters, or reset it if it has the default
 // value.
-export function storeOrResetBool<T extends boolean | string>(
+export function storeOrResetValue<T extends boolean | string | null>(
   urlParams: Dict<string>,
   name: string,
   value: T,
@@ -127,6 +138,11 @@ export function storeOrResetBool<T extends boolean | string>(
       delete urlParams[name];
     }
   } else {
+    if (value === null) {
+      throw new Error(
+        `Cannot store value null for property ${name} into the URL`
+      );
+    }
     urlParams[name] = value.toString();
   }
 }

--- a/site/frontend/src/pages/status/page.vue
+++ b/site/frontend/src/pages/status/page.vue
@@ -1,5 +1,5 @@
 <script setup lang="tsx">
-import {h, ref, Ref} from "vue";
+import {computed, h, ref, Ref} from "vue";
 import {differenceInSeconds} from "date-fns";
 
 import {getJson} from "../../utils/requests";
@@ -23,6 +23,7 @@ import Collector from "./collector.vue";
 import CommitSha from "./commit-sha.vue";
 import DateFmtPicker from "./date-format-selection.vue";
 import {DATE_FMT_12HR, DATE_FMT_24HR} from "../../utils/date-formats";
+import {DEFAULT_COMPILE_TARGET_TRIPLE} from "../../api";
 
 const loading = ref(true);
 
@@ -217,6 +218,29 @@ function toggleDate() {
   preferredDateTimeFormat.value = nextDateFmt;
 }
 
+const sortedCollectors = computed(() => {
+  // We want to see x64 collectors first
+  const collectors = data?.value?.collectors ?? [];
+  collectors.sort((a, b) => {
+    if (a.isActive && !b.isActive) return -1;
+    if (!a.isActive && b.isActive) return 1;
+
+    if (
+      a.target == DEFAULT_COMPILE_TARGET_TRIPLE &&
+      b.target != DEFAULT_COMPILE_TARGET_TRIPLE
+    )
+      return -1;
+    if (
+      a.target != DEFAULT_COMPILE_TARGET_TRIPLE &&
+      b.target == DEFAULT_COMPILE_TARGET_TRIPLE
+    )
+      return 1;
+
+    return a.name.localeCompare(b.name);
+  });
+  return collectors;
+});
+
 loadStatusData(loading);
 </script>
 
@@ -312,7 +336,7 @@ loadStatusData(loading);
       <div class="collector-wrapper">
         <h1>Collectors</h1>
         <div class="collectors-grid">
-          <div v-for="collector in data.collectors" :key="collector.name">
+          <div v-for="collector in sortedCollectors" :key="collector.name">
             <Collector :collector="collector" />
           </div>
         </div>

--- a/site/frontend/templates/pages/help.html
+++ b/site/frontend/templates/pages/help.html
@@ -40,7 +40,7 @@
     </li>
     <li><code>targets=&lt;TARGETS&gt;</code> configures which targets should be benchmarked.
       If no targets are provided <code>x86_64-unknown-linux-gnu</code> is the default.
-      Please note presently the only valid option is <code>x86_64-unknown-linux-gnu</code>.
+      Presently, valid targets are <code>x86_64-unknown-linux-gnu</code> and <code>aarch64-unknown-linux-gnu</code>.
     </li>
   </ul>
   <p><code>@rust-timer build $commit</code> will queue a perf run for the given commit
@@ -53,7 +53,8 @@
   <p><code>@rust-timer triage $commits</code> is meant to be executed on a rollup,
     to help identify the culprit of performance regressions/improvements of that rollup.
     It takes a space-separated list of `$commits` SHAs, and queues a perf run for each commit.
-    The results are reported on the corresponding PRs, and in the future will also be reported in the rollup itself.
+    The results are reported on the corresponding PRs, and in the future will also be reported in
+    the rollup itself.
     This command does not (yet) support options.
   </p>
 </div>

--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -291,7 +291,7 @@ pub mod comparison {
         pub dev_profile: Option<ProfileMetadata>,
     }
 
-    #[derive(Debug, Clone, Serialize)]
+    #[derive(Debug, Serialize)]
     pub struct Response {
         /// The names for the previous artifact before `a`, if any.
         pub prev: Option<String>,
@@ -330,7 +330,7 @@ pub mod comparison {
         pub component_sizes: HashMap<String, u64>,
     }
 
-    #[derive(Debug, Clone, Serialize)]
+    #[derive(Debug, Serialize)]
     pub struct StatComparison {
         pub is_relevant: bool,
         pub significance_threshold: f64,
@@ -339,7 +339,7 @@ pub mod comparison {
     }
 
     /// A serializable wrapper for a comparison between two compile-time test results.
-    #[derive(Debug, Clone, Serialize)]
+    #[derive(Debug, Serialize)]
     pub struct CompileBenchmarkComparison {
         pub benchmark: String,
         pub profile: String,
@@ -350,7 +350,7 @@ pub mod comparison {
     }
 
     /// A serializable wrapper for a comparison between two runtime test results.
-    #[derive(Debug, Clone, Serialize)]
+    #[derive(Debug, Serialize)]
     pub struct RuntimeBenchmarkComparison {
         pub benchmark: String,
         pub target: String,

--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -13,14 +13,15 @@ use database::{
     selector::{self, BenchmarkQuery, CompileBenchmarkQuery, RuntimeBenchmarkQuery, TestCase},
     Target,
 };
-use database::{ArtifactId, Benchmark, Lookup, Profile, Scenario};
+use database::{ArtifactId, Benchmark, Lookup};
 use serde::Serialize;
 
 use crate::api::comparison::CompileBenchmarkMetadata;
 use crate::benchmark_metadata::get_compile_benchmarks_metadata;
 use crate::server::comparison::StatComparison;
 use collector::compile::benchmark::ArtifactType;
-use database::{CodegenBackend, CommitType, CompileBenchmark};
+use database::selector::{CompileTestCase, RuntimeTestCase};
+use database::{CommitType, CompileBenchmark};
 use std::cmp;
 use std::collections::{HashMap, HashSet};
 use std::error::Error;
@@ -149,11 +150,11 @@ pub async fn handle_compare(
         .compile_comparisons
         .into_iter()
         .map(|comparison| api::comparison::CompileBenchmarkComparison {
-            benchmark: comparison.benchmark.to_string(),
-            profile: comparison.profile.to_string(),
-            scenario: comparison.scenario.to_string(),
-            backend: comparison.backend.to_string(),
-            target: comparison.target.to_string(),
+            benchmark: comparison.test_case.benchmark.to_string(),
+            profile: comparison.test_case.profile.to_string(),
+            scenario: comparison.test_case.scenario.to_string(),
+            backend: comparison.test_case.backend.to_string(),
+            target: comparison.test_case.target.to_string(),
             comparison: comparison.comparison.into(),
         })
         .collect();
@@ -162,8 +163,8 @@ pub async fn handle_compare(
         .runtime_comparisons
         .into_iter()
         .map(|comparison| api::comparison::RuntimeBenchmarkComparison {
-            benchmark: comparison.benchmark.to_string(),
-            target: comparison.target.to_string(),
+            benchmark: comparison.test_case.benchmark.to_string(),
+            target: comparison.test_case.target.to_string(),
             comparison: comparison.comparison.into(),
         })
         .collect();
@@ -741,11 +742,7 @@ async fn compare_given_commits(
         metric,
         master_commits,
         |test_case, comparison| CompileTestResultComparison {
-            profile: test_case.profile,
-            scenario: test_case.scenario,
-            benchmark: test_case.benchmark,
-            backend: test_case.backend,
-            target: test_case.target,
+            test_case,
             comparison,
         },
     )
@@ -760,8 +757,7 @@ async fn compare_given_commits(
         metric,
         master_commits,
         |test_case, comparison| RuntimeTestResultComparison {
-            benchmark: test_case.benchmark,
-            target: test_case.target,
+            test_case,
             comparison,
         },
     )
@@ -1316,26 +1312,23 @@ impl From<TestResultComparison> for StatComparison {
 
 #[derive(Debug, Clone)]
 pub struct CompileTestResultComparison {
-    benchmark: Benchmark,
-    profile: Profile,
-    scenario: Scenario,
-    backend: CodegenBackend,
-    target: Target,
+    test_case: CompileTestCase,
     comparison: TestResultComparison,
 }
 
 impl CompileTestResultComparison {
     pub fn benchmark(&self) -> Benchmark {
-        self.benchmark
+        self.test_case.benchmark
     }
 }
 
 impl cmp::PartialEq for CompileTestResultComparison {
     fn eq(&self, other: &Self) -> bool {
-        self.benchmark == other.benchmark
-            && self.profile == other.profile
-            && self.scenario == other.scenario
-            && self.backend == other.backend
+        let CompileTestResultComparison {
+            test_case,
+            comparison: _,
+        } = self;
+        test_case == &other.test_case
     }
 }
 
@@ -1343,17 +1336,17 @@ impl cmp::Eq for CompileTestResultComparison {}
 
 impl std::hash::Hash for CompileTestResultComparison {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.benchmark.hash(state);
-        self.profile.hash(state);
-        self.scenario.hash(state);
-        self.backend.hash(state);
+        let CompileTestResultComparison {
+            test_case,
+            comparison: _,
+        } = self;
+        test_case.hash(state);
     }
 }
 
 #[derive(Debug, Clone)]
 pub struct RuntimeTestResultComparison {
-    benchmark: Benchmark,
-    target: Target,
+    test_case: RuntimeTestCase,
     comparison: TestResultComparison,
 }
 
@@ -1367,7 +1360,11 @@ impl Deref for RuntimeTestResultComparison {
 
 impl cmp::PartialEq for RuntimeTestResultComparison {
     fn eq(&self, other: &Self) -> bool {
-        self.benchmark == other.benchmark
+        let RuntimeTestResultComparison {
+            test_case,
+            comparison: _,
+        } = self;
+        test_case == &other.test_case
     }
 }
 
@@ -1375,7 +1372,11 @@ impl cmp::Eq for RuntimeTestResultComparison {}
 
 impl std::hash::Hash for RuntimeTestResultComparison {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.benchmark.hash(state);
+        let RuntimeTestResultComparison {
+            test_case,
+            comparison: _,
+        } = self;
+        test_case.hash(state);
     }
 }
 

--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -64,20 +64,27 @@ pub async fn handle_triage(
     let benchmark_map = ctxt.get_benchmark_category_map().await;
 
     let end = loop {
-        let comparison =
-            match compare_given_commits(before.clone(), next.clone(), metric, ctxt, master_commits)
-                .await
-                .map_err(|e| format!("error comparing commits: {e}"))?
-            {
-                Some(c) => c,
-                None => {
-                    log::info!(
-                        "No data found for end bound {:?}. Ending comparison...",
-                        next
-                    );
-                    break before;
-                }
-            };
+        // For triage, we will only show x64 for now
+        let comparison = match compare_given_commits(
+            before.clone(),
+            next.clone(),
+            metric,
+            Some(Target::X86_64UnknownLinuxGnu),
+            ctxt,
+            master_commits,
+        )
+        .await
+        .map_err(|e| format!("error comparing commits: {e}"))?
+        {
+            Some(c) => c,
+            None => {
+                log::info!(
+                    "No data found for end bound {:?}. Ending comparison...",
+                    next
+                );
+                break before;
+            }
+        };
         num_comparisons += 1;
         log::info!(
             "Comparing {} to {}",
@@ -107,20 +114,26 @@ pub async fn handle_triage(
     };
 
     // Summarize the entire triage from start commit to end commit
-    let summary =
-        match compare_given_commits(start.clone(), end.clone(), metric, ctxt, master_commits)
-            .await
-            .map_err(|e| format!("error comparing beginning and ending commits: {e}"))?
-        {
-            Some(summary_comparison) => {
-                let (primary, secondary) =
-                    summary_comparison.summarize_compile_by_category(&benchmark_map);
-                let mut result = String::from("**Summary**:\n\n");
-                write_summary_table(&primary, &secondary, true, &mut result);
-                result
-            }
-            None => String::from("**ERROR**: no data found for end bound"),
-        };
+    let summary = match compare_given_commits(
+        start.clone(),
+        end.clone(),
+        metric,
+        Some(Target::X86_64UnknownLinuxGnu),
+        ctxt,
+        master_commits,
+    )
+    .await
+    .map_err(|e| format!("error comparing beginning and ending commits: {e}"))?
+    {
+        Some(summary_comparison) => {
+            let (primary, secondary) =
+                summary_comparison.summarize_compile_by_category(&benchmark_map);
+            let mut result = String::from("**Summary**:\n\n");
+            write_summary_table(&primary, &secondary, true, &mut result);
+            result
+        }
+        None => String::from("**ERROR**: no data found for end bound"),
+    };
 
     let report = generate_report(&start, &end, summary, report, num_comparisons).await;
     Ok(api::triage::Response(report))
@@ -134,11 +147,17 @@ pub async fn handle_compare(
     let master_commits = &ctxt.get_master_commits().commits;
 
     let end = body.end;
-    let comparison =
-        compare_given_commits(body.start, end.clone(), body.stat, ctxt, master_commits)
-            .await
-            .map_err(|e| format!("error comparing commits: {e}"))?
-            .ok_or_else(|| format!("could not find end commit for bound {end:?}"))?;
+    let comparison = compare_given_commits(
+        body.start,
+        end.clone(),
+        body.stat,
+        None,
+        ctxt,
+        master_commits,
+    )
+    .await
+    .map_err(|e| format!("error comparing commits: {e}"))?
+    .ok_or_else(|| format!("could not find end commit for bound {end:?}"))?;
 
     let conn = ctxt.conn().await;
     let prev = comparison.prev(master_commits);
@@ -712,14 +731,26 @@ pub async fn compare(
 ) -> Result<Option<ArtifactComparison>, BoxedError> {
     let master_commits = &ctxt.get_master_commits().commits;
 
-    compare_given_commits(start, end, metric, ctxt, master_commits).await
+    // For PR comments, we will only show x64 for now
+    compare_given_commits(
+        start,
+        end,
+        metric,
+        Some(Target::X86_64UnknownLinuxGnu),
+        ctxt,
+        master_commits,
+    )
+    .await
 }
 
 /// Compare two bounds on a given metric
+/// Optionally, you can select a target to query.
+/// If not specified, all targets will be selected.
 async fn compare_given_commits(
     start: Bound,
     end: Bound,
     metric: Metric,
+    target: Option<Target>,
     ctxt: &SiteCtxt,
     master_commits: &[collector::MasterCommit],
 ) -> Result<Option<ArtifactComparison>, BoxedError> {
@@ -733,10 +764,15 @@ async fn compare_given_commits(
     };
     let aids = Arc::new(vec![a.clone(), b.clone()]);
 
-    // get all crates, cache, and profile combinations for the given metric
+    let compile_query = match target {
+        Some(target) => CompileBenchmarkQuery::all_for_metric_and_target(metric, target),
+        None => CompileBenchmarkQuery::all_for_metric(metric),
+    };
+
+    // Get all crates, cache, and profile combinations for the given metric
     let compile_comparisons = get_comparison::<CompileTestResultComparison, _, _>(
         ctxt,
-        CompileBenchmarkQuery::all_for_metric(metric),
+        compile_query,
         a.clone(),
         aids.clone(),
         metric,
@@ -748,10 +784,15 @@ async fn compare_given_commits(
     )
     .await?;
 
-    // get all crates, cache, and profile combinations for the given metric
+    let runtime_query = match target {
+        Some(target) => RuntimeBenchmarkQuery::all_for_metric_and_target(metric, target),
+        None => RuntimeBenchmarkQuery::all_for_metric(metric),
+    };
+
+    // Get all crates, cache, and profile combinations for the given metric
     let runtime_comparisons = get_comparison::<RuntimeTestResultComparison, _, _>(
         ctxt,
-        RuntimeBenchmarkQuery::all_for_metric(metric),
+        runtime_query,
         a.clone(),
         aids,
         metric,

--- a/site/src/request_handlers/github.rs
+++ b/site/src/request_handlers/github.rs
@@ -484,7 +484,7 @@ fn parse_benchmark_parameters<'a>(
         parse_targets(targets).map_err(|e| {
             format!(
                 "Cannot parse targets: {e}. Valid values are: {}",
-                Target::primary_targets()
+                Target::available_targets()
                     .iter()
                     .map(|b| b.as_str())
                     .collect::<Vec<_>>()
@@ -728,7 +728,7 @@ Otherwise LGTM."#),
         insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue targets=x86_64-unknown-linux-gnu"),
             @r#"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: None, profiles: None, targets: Some("x86_64-unknown-linux-gnu") } }))"#);
         insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue targets=x86_64-unknown-linux-gnu,67-unknown-none"),
-            @r#"Err("Cannot parse targets: Only primary targets can be specified. Valid values are: x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu")"#);
+            @r#"Err("Cannot parse targets: Only the available targets `x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu` can be specified. Valid values are: x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu")"#);
     }
 
     #[test]


### PR DESCRIPTION
Since we now finally have an ARM machine for benchmarking, I tested having both x64 and ARM data locally, and found some issues, which this PR solves.

This PR:
- Ensures that both GitHub PR comments and perf. triage only considers x64, for now.
- Fixes a pretty nasty bug (https://github.com/rust-lang/rustc-perf/pull/2550/commits/6f2df118f27372ed55f94864796b00bd295b3382). If we got different target/frontend thread data into the DB without this fix, the compare page would start showing random subsets of data (yikes!). Found this out while testing the new self-comparison functionality locally.
- Allow self-comparing target results for the same commit (so that we can compare x64 vs ARM perf.).

It doesn't yet enable running ARM benchmarks by default, because we don't yet build aarch64 artifacts by default in try builds.