### PR TITLE
Correctly store targets of benchmark requests into the database

### DIFF
--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -676,6 +676,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn benchmark_request_roundtrip() {
+        run_postgres_test(|ctx| async {
+            let db = ctx.db();
+
+            let req = BenchmarkRequest::create_try_without_artifacts(
+                42, "backends", "profiles", "targets",
+            );
+
+            db.insert_benchmark_request(&req).await.unwrap();
+            assert!(db
+                .attach_shas_to_try_benchmark_request(42, "sha1", "sha-parent-1", Utc::now())
+                .await
+                .unwrap());
+
+            let loaded = db
+                .load_pending_benchmark_requests()
+                .await
+                .unwrap()
+                .requests
+                .into_iter()
+                .next()
+                .unwrap();
+            assert_eq!(req.profiles, loaded.profiles);
+            assert_eq!(req.backends, loaded.backends);
+            assert_eq!(req.targets, loaded.targets);
+
+            Ok(ctx)
+        })
+        .await;
+    }
+
+    #[tokio::test]
     async fn attach_shas_missing_try_request() {
         run_postgres_test(|ctx| async {
             let db = ctx.db();

--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -1439,6 +1439,16 @@ where
         &self,
         benchmark_request: &BenchmarkRequest,
     ) -> anyhow::Result<BenchmarkRequestInsertResult> {
+        let BenchmarkRequest {
+            commit_type,
+            commit_date,
+            created_at,
+            status,
+            backends,
+            profiles,
+            targets,
+        } = benchmark_request;
+
         let row_insert_count = self
             .conn()
             .execute(
@@ -1452,21 +1462,23 @@ where
                     created_at,
                     backends,
                     profiles,
+                    targets,
                     commit_date
                 )
-                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
                 ON CONFLICT DO NOTHING;
             "#,
                 &[
                     &benchmark_request.tag(),
                     &benchmark_request.parent_sha(),
                     &benchmark_request.pr().map(|it| it as i32),
-                    &benchmark_request.commit_type,
-                    &benchmark_request.status.as_str(),
-                    &benchmark_request.created_at,
-                    &benchmark_request.backends,
-                    &benchmark_request.profiles,
-                    &benchmark_request.commit_date,
+                    commit_type,
+                    &status.as_str(),
+                    created_at,
+                    backends,
+                    profiles,
+                    targets,
+                    commit_date,
                 ],
             )
             .await


### PR DESCRIPTION
Turns out that we just weren't storing them at all.. :)
