### PR TITLE
Add `benchmarks` parameter to `@rust-timer queue/build`

### DIFF
--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -1689,10 +1689,17 @@ async fn create_benchmark_configs(
         }
     }
 
+    let benchmark_filter_accepts = |benchmark: &str| {
+        job.benchmarks().is_empty() || job.benchmarks().iter().any(|b| b == benchmark)
+    };
+
     let benchmarks: Vec<Benchmark> = all_compile_benchmarks
         .iter()
         .filter(|b| {
             if !bench_compile_benchmarks.contains(&b.name) {
+                return false;
+            }
+            if !benchmark_filter_accepts(&b.name.0) {
                 return false;
             }
             // Run stable benchmarks for releases and non-stable benchmarks for everything
@@ -1702,6 +1709,10 @@ async fn create_benchmark_configs(
         })
         .cloned()
         .collect();
+
+    if !benchmark_filter_accepts("rustc") {
+        bench_rustc = false;
+    }
 
     let compile_config = if bench_rustc || !benchmarks.is_empty() {
         if toolchain.components.rustdoc.is_none()
@@ -1757,7 +1768,7 @@ async fn create_benchmark_configs(
         .await?;
         Some(RuntimeBenchmarkConfig {
             runtime_suite,
-            filter: RuntimeBenchmarkFilter::keep_all(),
+            filter: RuntimeBenchmarkFilter::new(vec![], job.benchmarks().to_vec()),
             iterations: DEFAULT_RUNTIME_ITERATIONS,
             target: job.target().into(),
         })

--- a/database/schema.md
+++ b/database/schema.md
@@ -270,6 +270,7 @@ Columns:
   test (e.g. llvm, cranelift).
 * **benchmark_set** (`int NOT NULL`): ID of the predefined benchmark suite to
   execute.
+* **benchmarks** (`string NOT NULL`): Comma-separated list of benchmarks to execute. If empty, all benchmarks in `benchmark_set` will be executed.
 * **collector_name** (`text`): Name of the collector that claimed the job
   (populated once the job is started).
 * **created_at** (`timestamptz NOT NULL`): Datetime when the job was queued.

--- a/database/schema.md
+++ b/database/schema.md
@@ -233,6 +233,7 @@ Columns:
 * **backends** (`text NOT NULL`): Comma-separated list of codegen backends to benchmark. If empty, the default set of codegen backends will be benchmarked.
 * **profiles** (`text NOT NULL`): Comma-separated list of profiles to benchmark. If empty, the default set of profiles will be benchmarked.
 * **targets** (`text NOT NULL`): Comma-separated list of targets to benchmark. If empty, the default set of targets will be benchmarked.
+* **benchmarks** (`text NOT NULL`): Comma-separated list of benchmarks to execute. If empty, all benchmarks will be executed.
 
 ### collector_config
 

--- a/database/schema.md
+++ b/database/schema.md
@@ -270,7 +270,7 @@ Columns:
   test (e.g. llvm, cranelift).
 * **benchmark_set** (`int NOT NULL`): ID of the predefined benchmark suite to
   execute.
-* **benchmarks** (`string NOT NULL`): Comma-separated list of benchmarks to execute. If empty, all benchmarks in `benchmark_set` will be executed.
+* **benchmarks** (`string NOT NULL`): Comma-separated list of benchmarks that are a subset of the given `benchmark_set` to execute. If empty, all benchmarks in `benchmark_set` will be executed.
 * **collector_name** (`text`): Name of the collector that claimed the job
   (populated once the job is started).
 * **created_at** (`timestamptz NOT NULL`): Datetime when the job was queued.

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -1009,6 +1009,7 @@ pub struct BenchmarkRequest {
     backends: String,
     profiles: String,
     targets: String,
+    benchmarks: String,
 }
 
 impl BenchmarkRequest {
@@ -1024,6 +1025,7 @@ impl BenchmarkRequest {
             backends: String::new(),
             profiles: String::new(),
             targets: String::new(),
+            benchmarks: String::new(),
         }
     }
 
@@ -1046,6 +1048,7 @@ impl BenchmarkRequest {
             backends: backends.to_string(),
             profiles: profiles.to_string(),
             targets: targets.to_string(),
+            benchmarks: String::new(),
         }
     }
 
@@ -1063,6 +1066,7 @@ impl BenchmarkRequest {
             backends: String::new(),
             profiles: String::new(),
             targets: String::new(),
+            benchmarks: String::new(),
         }
     }
 

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -1035,6 +1035,7 @@ impl BenchmarkRequest {
         backends: &str,
         profiles: &str,
         targets: &str,
+        benchmarks: &str,
     ) -> Self {
         Self {
             commit_type: BenchmarkRequestType::Try {
@@ -1048,7 +1049,7 @@ impl BenchmarkRequest {
             backends: backends.to_string(),
             profiles: profiles.to_string(),
             targets: targets.to_string(),
-            benchmarks: String::new(),
+            benchmarks: benchmarks.to_string(),
         }
     }
 

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -1155,7 +1155,7 @@ impl BenchmarkRequest {
         parse_targets(&self.targets).map_err(|e| anyhow::anyhow!("{e}"))
     }
 
-    /// Get the targets for the request
+    /// Get the benchmarks for the request
     pub fn benchmarks(&self) -> anyhow::Result<Vec<String>> {
         let benchmarks = parse_benchmarks(&self.benchmarks).map_err(|e| anyhow::anyhow!("{e}"))?;
         Ok(benchmarks)

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -1155,6 +1155,12 @@ impl BenchmarkRequest {
         parse_targets(&self.targets).map_err(|e| anyhow::anyhow!("{e}"))
     }
 
+    /// Get the targets for the request
+    pub fn benchmarks(&self) -> anyhow::Result<Vec<String>> {
+        let benchmarks = parse_benchmarks(&self.benchmarks).map_err(|e| anyhow::anyhow!("{e}"))?;
+        Ok(benchmarks)
+    }
+
     pub fn is_completed(&self) -> bool {
         matches!(self.status, BenchmarkRequestStatus::Completed { .. })
     }
@@ -1206,6 +1212,10 @@ pub fn parse_targets(targets: &str) -> Result<Vec<Target>, String> {
         ));
     }
     Ok(targets)
+}
+
+pub fn parse_benchmarks(benchmarks: &str) -> Result<Vec<String>, String> {
+    parse_comma_separated(benchmarks, "benchmark")
 }
 
 /// Cached information about benchmark requests in the DB
@@ -1298,6 +1308,7 @@ pub struct BenchmarkJob {
     profile: Profile,
     request_tag: String,
     benchmark_set: BenchmarkSet,
+    benchmarks: Vec<String>,
     created_at: DateTime<Utc>,
     status: BenchmarkJobStatus,
     deque_counter: u32,
@@ -1328,6 +1339,10 @@ impl BenchmarkJob {
 
     pub fn benchmark_set(&self) -> BenchmarkSet {
         self.benchmark_set
+    }
+
+    pub fn benchmarks(&self) -> &[String] {
+        &self.benchmarks
     }
 
     pub fn collector_name(&self) -> Option<&str> {

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -1155,7 +1155,7 @@ impl BenchmarkRequest {
         parse_targets(&self.targets).map_err(|e| anyhow::anyhow!("{e}"))
     }
 
-    /// Get the benchmarks for the request
+    /// Get the targets for the request
     pub fn benchmarks(&self) -> anyhow::Result<Vec<String>> {
         let benchmarks = parse_benchmarks(&self.benchmarks).map_err(|e| anyhow::anyhow!("{e}"))?;
         Ok(benchmarks)

--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -540,7 +540,7 @@ mod tests {
             // But this should fail, as we can't have two queued requests at once
             let result = db
                 .insert_benchmark_request(&BenchmarkRequest::create_try_without_artifacts(
-                    42, "", "", "",
+                    42, "", "", "", "",
                 ))
                 .await
                 .unwrap();
@@ -639,7 +639,7 @@ mod tests {
         run_postgres_test(|ctx| async {
             let db = ctx.db();
 
-            let req = BenchmarkRequest::create_try_without_artifacts(42, "", "", "");
+            let req = BenchmarkRequest::create_try_without_artifacts(42, "", "", "", "");
 
             db.insert_benchmark_request(&req).await.unwrap();
             assert!(db
@@ -680,7 +680,13 @@ mod tests {
         run_postgres_test(|ctx| async {
             let db = ctx.db();
 
-            let req = BenchmarkRequest::create_try_without_artifacts(42, "backends", "profiles", "targets");
+            let req = BenchmarkRequest::create_try_without_artifacts(
+                42,
+                "backends",
+                "profiles",
+                "targets",
+                "benchmarks",
+            );
 
             db.insert_benchmark_request(&req).await.unwrap();
             assert!(db

--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -680,9 +680,7 @@ mod tests {
         run_postgres_test(|ctx| async {
             let db = ctx.db();
 
-            let req = BenchmarkRequest::create_try_without_artifacts(
-                42, "backends", "profiles", "targets",
-            );
+            let req = BenchmarkRequest::create_try_without_artifacts(42, "backends", "profiles", "targets");
 
             db.insert_benchmark_request(&req).await.unwrap();
             assert!(db
@@ -701,6 +699,7 @@ mod tests {
             assert_eq!(req.profiles, loaded.profiles);
             assert_eq!(req.backends, loaded.backends);
             assert_eq!(req.targets, loaded.targets);
+            assert_eq!(req.benchmarks, loaded.benchmarks);
 
             Ok(ctx)
         })

--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -200,6 +200,7 @@ pub trait Connection: Send + Sync {
         backend: CodegenBackend,
         profile: Profile,
         benchmark_set: u32,
+        benchmarks: &[String],
         kind: BenchmarkJobKind,
         is_optional: bool,
     ) -> JobEnqueueResult;
@@ -749,6 +750,7 @@ mod tests {
                     CodegenBackend::Llvm,
                     Profile::Opt,
                     0u32,
+                    &[],
                     BenchmarkJobKind::Runtime,
                     false,
                 )
@@ -905,6 +907,7 @@ mod tests {
                 .unwrap();
 
             // Now we can insert the job
+            let example_benchmarks = vec!["benchmark1".into(), "benchmark2".into()];
             match db
                 .enqueue_benchmark_job(
                     benchmark_request.tag().unwrap(),
@@ -912,6 +915,7 @@ mod tests {
                     CodegenBackend::Llvm,
                     Profile::Opt,
                     1u32,
+                    &example_benchmarks,
                     BenchmarkJobKind::Runtime,
                     false,
                 )
@@ -945,6 +949,7 @@ mod tests {
                 benchmark_job.collector_name().unwrap(),
                 collector_config.name(),
             );
+            assert_eq!(benchmark_job.benchmarks(), example_benchmarks);
 
             assert_eq!(
                 artifact_id,
@@ -1013,6 +1018,7 @@ mod tests {
                 CodegenBackend::Llvm,
                 Profile::Opt,
                 benchmark_set.0,
+                &[],
                 BenchmarkJobKind::Runtime,
                 false,
             )
@@ -1268,6 +1274,7 @@ mod tests {
                 CodegenBackend::Llvm,
                 Profile::Check,
                 0,
+                &[],
                 BenchmarkJobKind::Compiletime,
                 false,
             )
@@ -1325,6 +1332,7 @@ mod tests {
                 CodegenBackend::Llvm,
                 Profile::Opt,
                 benchmark_set.0,
+                &[],
                 BenchmarkJobKind::Runtime,
                 false,
             )
@@ -1339,6 +1347,7 @@ mod tests {
                 CodegenBackend::Llvm,
                 Profile::Doc,
                 benchmark_set.0,
+                &[],
                 BenchmarkJobKind::Runtime,
                 true,
             )

--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -3,12 +3,12 @@ use crate::pool::{
 };
 use crate::selector::{CompileTestCase, RuntimeTestCase};
 use crate::{
-    ArtifactId, ArtifactIdNumber, Benchmark, BenchmarkJob, BenchmarkJobConclusion,
-    BenchmarkJobKind, BenchmarkJobStatus, BenchmarkRequest, BenchmarkRequestIndex,
-    BenchmarkRequestInsertResult, BenchmarkRequestStatus, BenchmarkRequestType,
-    BenchmarkRequestWithErrors, BenchmarkSet, CodegenBackend, CollectionId, CollectorConfig,
-    Commit, CommitType, CompileBenchmark, Date, FrontendThreads, Index, PendingBenchmarkRequests,
-    Profile, Scenario, Target, BENCHMARK_JOB_STATUS_FAILURE_STR,
+    parse_benchmarks, ArtifactId, ArtifactIdNumber, Benchmark, BenchmarkJob,
+    BenchmarkJobConclusion, BenchmarkJobKind, BenchmarkJobStatus, BenchmarkRequest,
+    BenchmarkRequestIndex, BenchmarkRequestInsertResult, BenchmarkRequestStatus,
+    BenchmarkRequestType, BenchmarkRequestWithErrors, BenchmarkSet, CodegenBackend, CollectionId,
+    CollectorConfig, Commit, CommitType, CompileBenchmark, Date, FrontendThreads, Index,
+    PendingBenchmarkRequests, Profile, Scenario, Target, BENCHMARK_JOB_STATUS_FAILURE_STR,
     BENCHMARK_JOB_STATUS_IN_PROGRESS_STR, BENCHMARK_JOB_STATUS_QUEUED_STR,
     BENCHMARK_JOB_STATUS_SUCCESS_STR, BENCHMARK_REQUEST_MASTER_STR, BENCHMARK_REQUEST_RELEASE_STR,
     BENCHMARK_REQUEST_STATUS_ARTIFACTS_READY_STR, BENCHMARK_REQUEST_STATUS_COMPLETED_STR,
@@ -451,6 +451,7 @@ static MIGRATIONS: &[&str] = &[
     "#,
     // Add benchmarks to benchmark_request
     r#"ALTER TABLE benchmark_request ADD COLUMN benchmarks TEXT NOT NULL DEFAULT ''"#,
+    r#"ALTER TABLE job_queue ADD COLUMN benchmarks TEXT NOT NULL DEFAULT ''"#,
 ];
 
 #[async_trait::async_trait]
@@ -839,6 +840,7 @@ fn parse_benchmark_job_from_row(row: &Row) -> anyhow::Result<BenchmarkJob> {
         deque_counter: row.get::<_, i32>(10) as u32,
         kind: BenchmarkJobKind::from_str(row.get::<_, &str>(12)).map_err(|e| anyhow::anyhow!(e))?,
         is_optional: row.get::<_, bool>(13),
+        benchmarks: parse_benchmarks(&row.get::<_, String>(14)).map_err(|e| anyhow::anyhow!(e))?,
     })
 }
 
@@ -1612,6 +1614,7 @@ where
         backend: CodegenBackend,
         profile: Profile,
         benchmark_set: u32,
+        benchmarks: &[String],
         kind: BenchmarkJobKind,
         is_optional: bool,
     ) -> JobEnqueueResult {
@@ -1632,9 +1635,10 @@ where
                 benchmark_set,
                 status,
                 kind,
-                is_optional
+                is_optional,
+                benchmarks
             )
-            SELECT $1, $2, $3, $4, $5, $6, $7, $8
+            SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9
             WHERE EXISTS (SELECT 1 FROM benchmark_request WHERE benchmark_request.tag = $1)
             ON CONFLICT DO NOTHING
             RETURNING job_queue.id
@@ -1648,6 +1652,7 @@ where
                     &BENCHMARK_JOB_STATUS_QUEUED_STR,
                     &kind,
                     &is_optional,
+                    &benchmarks.join(","),
                 ],
             )
             .await;
@@ -1861,6 +1866,7 @@ where
                     updated.retry,
                     updated.kind,
                     updated.is_optional,
+                    updated.benchmarks,
                     br.commit_type,
                     br.commit_date
                 FROM updated
@@ -1897,9 +1903,11 @@ where
                     kind: BenchmarkJobKind::from_str(row.get::<_, &str>(7))
                         .map_err(|e| anyhow::anyhow!(e))?,
                     is_optional: row.get::<_, bool>(8),
+                    benchmarks: parse_benchmarks(&row.get::<_, String>(9))
+                        .map_err(|e| anyhow::anyhow!(e))?,
                 };
-                let commit_type = row.get::<_, &str>(9);
-                let commit_date = row.get::<_, Option<DateTime<Utc>>>(10);
+                let commit_type = row.get::<_, &str>(10);
+                let commit_date = row.get::<_, Option<DateTime<Utc>>>(11);
 
                 let commit_date = Date(commit_date.ok_or_else(|| {
                     anyhow::anyhow!("Dequeuing job for a benchmark request without commit date")

--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -2201,45 +2201,30 @@ fn row_to_benchmark_request(row: &Row, row_offset: Option<usize>) -> BenchmarkRe
                 panic!("Invalid BenchmarkRequestStatus data in the database for tag {tag:?}: {e:?}")
             });
 
-    match commit_type {
-        BENCHMARK_REQUEST_TRY_STR => BenchmarkRequest {
-            commit_type: BenchmarkRequestType::Try {
-                sha: tag,
-                parent_sha,
-                pr: pr.expect("Try commit in the DB without a PR"),
-            },
-            commit_date,
-            created_at,
-            status,
-            backends,
-            profiles,
-            targets,
+    let commit_type = match commit_type {
+        BENCHMARK_REQUEST_TRY_STR => BenchmarkRequestType::Try {
+            sha: tag,
+            parent_sha,
+            pr: pr.expect("Try commit in the DB without a PR"),
         },
-        BENCHMARK_REQUEST_MASTER_STR => BenchmarkRequest {
-            commit_type: BenchmarkRequestType::Master {
-                sha: tag.expect("Master commit in the DB without a SHA"),
-                parent_sha: parent_sha.expect("Master commit in the DB without a parent SHA"),
-                pr: pr.expect("Master commit in the DB without a PR"),
-            },
-            commit_date,
-            created_at,
-            status,
-            backends,
-            profiles,
-            targets,
+        BENCHMARK_REQUEST_MASTER_STR => BenchmarkRequestType::Master {
+            sha: tag.expect("Master commit in the DB without a SHA"),
+            parent_sha: parent_sha.expect("Master commit in the DB without a parent SHA"),
+            pr: pr.expect("Master commit in the DB without a PR"),
         },
-        BENCHMARK_REQUEST_RELEASE_STR => BenchmarkRequest {
-            commit_type: BenchmarkRequestType::Release {
-                tag: tag.expect("Release commit in the DB without a SHA"),
-            },
-            commit_date,
-            created_at,
-            status,
-            backends,
-            profiles,
-            targets,
+        BENCHMARK_REQUEST_RELEASE_STR => BenchmarkRequestType::Release {
+            tag: tag.expect("Release commit in the DB without a SHA"),
         },
         _ => panic!("Invalid `commit_type` for `BenchmarkRequest` {commit_type}",),
+    };
+    BenchmarkRequest {
+        commit_type,
+        commit_date,
+        created_at,
+        status,
+        backends,
+        profiles,
+        targets,
     }
 }
 

--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -449,6 +449,8 @@ static MIGRATIONS: &[&str] = &[
     ALTER TABLE pstat_series DROP CONSTRAINT test_case;
     ALTER TABLE pstat_series ADD CONSTRAINT test_case UNIQUE(crate, profile, scenario, backend, target, frontend_threads, metric);
     "#,
+    // Add benchmarks to benchmark_request
+    r#"ALTER TABLE benchmark_request ADD COLUMN benchmarks TEXT NOT NULL DEFAULT ''"#,
 ];
 
 #[async_trait::async_trait]
@@ -800,7 +802,7 @@ impl PostgresConnection {
 
 // `tag` should be kept as the first column
 const BENCHMARK_REQUEST_COLUMNS: &str =
-    "tag, parent_sha, pr, commit_type, status, created_at, completed_at, backends, profiles, commit_date, duration_ms, targets";
+    "tag, parent_sha, pr, commit_type, status, created_at, completed_at, backends, profiles, commit_date, duration_ms, targets, benchmarks";
 
 /// Parse a benchmark job out of a row.
 /// Expects to be used with `SELECT * FROM job_queue`.
@@ -1447,6 +1449,7 @@ where
             backends,
             profiles,
             targets,
+            benchmarks,
         } = benchmark_request;
 
         let row_insert_count = self
@@ -1463,9 +1466,10 @@ where
                     backends,
                     profiles,
                     targets,
-                    commit_date
+                    commit_date,
+                    benchmarks
                 )
-                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
                 ON CONFLICT DO NOTHING;
             "#,
                 &[
@@ -1479,6 +1483,7 @@ where
                     profiles,
                     targets,
                     commit_date,
+                    benchmarks,
                 ],
             )
             .await
@@ -2025,8 +2030,8 @@ where
 
         for row in rows {
             let tag = row.get::<_, &str>(0);
-            let error_benchmark = row.get::<_, Option<String>>(12);
-            let error_content = row.get::<_, Option<String>>(13);
+            let error_benchmark = row.get::<_, Option<String>>(13);
+            let error_content = row.get::<_, Option<String>>(14);
 
             // We already saw this request, just add errors
             if let Some(errors) = errors.get_mut(tag) {
@@ -2192,6 +2197,7 @@ fn row_to_benchmark_request(row: &Row, row_offset: Option<usize>) -> BenchmarkRe
     let commit_date = row.get::<_, Option<DateTime<Utc>>>(9 + row_offset);
     let duration_ms = row.get::<_, Option<i32>>(10 + row_offset);
     let targets = row.get::<_, String>(11 + row_offset);
+    let benchmarks = row.get::<_, String>(12 + row_offset);
 
     let pr = pr.map(|v| v as u32);
 
@@ -2225,6 +2231,7 @@ fn row_to_benchmark_request(row: &Row, row_offset: Option<usize>) -> BenchmarkRe
         backends,
         profiles,
         targets,
+        benchmarks,
     }
 }
 

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -1126,6 +1126,7 @@ impl Connection for SqliteConnection {
         _backend: CodegenBackend,
         _profile: Profile,
         _benchmark_set: u32,
+        _benchmarks: &[String],
         _kind: BenchmarkJobKind,
         _is_optional: bool,
     ) -> JobEnqueueResult {

--- a/database/src/tests/builder.rs
+++ b/database/src/tests/builder.rs
@@ -48,6 +48,7 @@ impl RequestBuilder {
                     job.backend,
                     job.profile,
                     job.benchmark_set,
+                    &job.benchmarks,
                     job.kind,
                     false,
                 )
@@ -115,6 +116,7 @@ pub struct JobBuilder {
     backend: CodegenBackend,
     profile: Profile,
     benchmark_set: u32,
+    benchmarks: Vec<String>,
     conclusion: BenchmarkJobConclusion,
     kind: BenchmarkJobKind,
     is_optional: bool,
@@ -139,6 +141,7 @@ impl Default for JobBuilder {
             backend: CodegenBackend::Llvm,
             profile: Profile::Check,
             benchmark_set: 0,
+            benchmarks: Vec::new(),
             conclusion: BenchmarkJobConclusion::Success,
             kind: BenchmarkJobKind::Compiletime,
             is_optional: false,

--- a/database/src/tests/mod.rs
+++ b/database/src/tests/mod.rs
@@ -153,7 +153,7 @@ impl TestContext {
 
     /// Create a new try benchmark request without artifacts and add it to the DB.
     pub async fn insert_try_request(&self, pr: u32) -> BenchmarkRequest {
-        let req = BenchmarkRequest::create_try_without_artifacts(pr, "", "", "");
+        let req = BenchmarkRequest::create_try_without_artifacts(pr, "", "", "", "");
         self.db().insert_benchmark_request(&req).await.unwrap();
         req
     }

--- a/site/frontend/templates/pages/help.html
+++ b/site/frontend/templates/pages/help.html
@@ -42,6 +42,9 @@
       If no targets are provided <code>x86_64-unknown-linux-gnu</code> is the default.
       Presently, valid targets are <code>x86_64-unknown-linux-gnu</code> and <code>aarch64-unknown-linux-gnu</code>.
     </li>
+    <li><code>benchmarks=&lt;BENCHMARKS&gt;</code> configures which benchmarks should be benchmarked.
+      If no benchmarks are provided, all benchmarks will be executed.
+    </li>
   </ul>
   <p><code>@rust-timer build $commit</code> will queue a perf run for the given commit
     <code>$commit</code>.

--- a/site/src/job_queue/mod.rs
+++ b/site/src/job_queue/mod.rs
@@ -260,6 +260,7 @@ pub async fn enqueue_benchmark_request(
     let backends = request.backends()?;
     let profiles = request.profiles()?;
     let targets = request.targets()?;
+    let benchmarks = request.benchmarks()?;
 
     #[derive(PartialEq, Debug)]
     enum EnqueueMode {
@@ -273,6 +274,7 @@ pub async fn enqueue_benchmark_request(
                              backend,
                              profile,
                              benchmark_set,
+                             benchmarks,
                              kind,
                              mode: EnqueueMode,
                              is_optional: bool| {
@@ -284,6 +286,7 @@ pub async fn enqueue_benchmark_request(
                 backend,
                 profile,
                 benchmark_set,
+                benchmarks,
                 kind,
                 is_optional,
             )
@@ -330,6 +333,7 @@ pub async fn enqueue_benchmark_request(
                         backend,
                         profile,
                         benchmark_set as u32,
+                        &benchmarks,
                         BenchmarkJobKind::Compiletime,
                         EnqueueMode::Commit,
                         is_optional,
@@ -349,6 +353,7 @@ pub async fn enqueue_benchmark_request(
                             backend,
                             profile,
                             benchmark_set as u32,
+                            &benchmarks,
                             BenchmarkJobKind::Compiletime,
                             EnqueueMode::Parent,
                             is_optional,
@@ -368,6 +373,7 @@ pub async fn enqueue_benchmark_request(
             CodegenBackend::Llvm,
             Profile::Opt,
             BENCHMARK_SET_RUNTIME_BENCHMARKS,
+            &benchmarks,
             BenchmarkJobKind::Runtime,
             EnqueueMode::Commit,
             is_optional,
@@ -386,6 +392,7 @@ pub async fn enqueue_benchmark_request(
                 CodegenBackend::Llvm,
                 Profile::Opt,
                 BENCHMARK_SET_RUSTC,
+                &benchmarks,
                 BenchmarkJobKind::Rustc,
                 EnqueueMode::Commit,
                 false,
@@ -646,6 +653,7 @@ mod tests {
                 CodegenBackend::Llvm,
                 Profile::Opt,
                 benchmark_set,
+                &[],
                 BenchmarkJobKind::Compiletime,
                 false,
             )

--- a/site/src/job_queue/mod.rs
+++ b/site/src/job_queue/mod.rs
@@ -615,7 +615,7 @@ mod tests {
     }
 
     fn create_try(pr: u32) -> BenchmarkRequest {
-        BenchmarkRequest::create_try_without_artifacts(pr, "", "", "")
+        BenchmarkRequest::create_try_without_artifacts(pr, "", "", "", "")
     }
 
     fn create_release(tag: &str) -> BenchmarkRequest {

--- a/site/src/request_handlers/github.rs
+++ b/site/src/request_handlers/github.rs
@@ -8,8 +8,8 @@ use std::fmt::Write;
 use crate::github::client::Client;
 use crate::github::triage::{triage_body_end_marker, triage_body_start_marker, TRIAGE_MARKER};
 use database::{
-    parse_backends, parse_profiles, parse_targets, BenchmarkRequest, BenchmarkRequestInsertResult,
-    CodegenBackend, Profile, Target,
+    parse_backends, parse_benchmarks, parse_profiles, parse_targets, BenchmarkRequest,
+    BenchmarkRequestInsertResult, CodegenBackend, Profile, Target,
 };
 use futures::stream::{FuturesUnordered, StreamExt};
 use hashbrown::HashMap;
@@ -495,6 +495,10 @@ fn parse_benchmark_parameters<'a>(
                     .join(", ")
             )
         })?;
+    }
+
+    if let Some(benchmarks) = &params.benchmarks {
+        parse_benchmarks(benchmarks).map_err(|e| format!("Cannot parse benchmarks: {e}"))?;
     }
 
     if !args.is_empty() {

--- a/site/src/request_handlers/github.rs
+++ b/site/src/request_handlers/github.rs
@@ -5,6 +5,7 @@ use crate::github::{
 use crate::load::SiteCtxt;
 use std::fmt::Write;
 
+use crate::benchmark_metadata::get_compile_benchmarks_metadata;
 use crate::github::client::Client;
 use crate::github::triage::{triage_body_end_marker, triage_body_start_marker, TRIAGE_MARKER};
 use database::{
@@ -498,7 +499,15 @@ fn parse_benchmark_parameters<'a>(
     }
 
     if let Some(benchmarks) = &params.benchmarks {
-        parse_benchmarks(benchmarks).map_err(|e| format!("Cannot parse benchmarks: {e}"))?;
+        let benchmarks =
+            parse_benchmarks(benchmarks).map_err(|e| format!("Cannot parse benchmarks: {e}"))?;
+        // FIXME This should be validated in `parse_benchmarks` but we don't have access to `get_compile_benchmarks_metadata` there
+        let valid_benchmarks = get_compile_benchmarks_metadata();
+        for benchmark in &benchmarks {
+            if !valid_benchmarks.contains_key(benchmark) {
+                return Err(format!("Unknown compile-time benchmark: {benchmark}"));
+            }
+        }
     }
 
     if !args.is_empty() {
@@ -704,8 +713,10 @@ Otherwise LGTM."#),
             @r#"Ok(Build(BuildCommand { sha: "23936af287657fa4148aeab40cc2a780810fae5B", params: BenchmarkParameters { backends: Some("Cranelift"), profiles: None, targets: None, benchmarks: None } }))"#);
         insta::assert_compact_debug_snapshot!(parse_command(r#"@rust-timer build 23936af287657fa4148aeab40cc2a780810fae5C backends=Cranelift,Llvm"#),
             @r#"Ok(Build(BuildCommand { sha: "23936af287657fa4148aeab40cc2a780810fae5C", params: BenchmarkParameters { backends: Some("Cranelift,Llvm"), profiles: None, targets: None, benchmarks: None } }))"#);
-        insta::assert_compact_debug_snapshot!(parse_command(r#"@rust-timer build 23936af287657fa4148aeab40cc2a780810fae5C benchmarks=syn-1.0.89,clap-3.1.6"#),
-            @r#"Ok(Build(BuildCommand { sha: "23936af287657fa4148aeab40cc2a780810fae5C", params: BenchmarkParameters { backends: None, profiles: None, targets: None, benchmarks: Some("syn-1.0.89,clap-3.1.6") } }))"#);
+        insta::assert_compact_debug_snapshot!(parse_command(r#"@rust-timer build 23936af287657fa4148aeab40cc2a780810fae5C benchmarks=syn-2.0.101,clap_derive-4.5.32"#),
+            @r#"Ok(Build(BuildCommand { sha: "23936af287657fa4148aeab40cc2a780810fae5C", params: BenchmarkParameters { backends: None, profiles: None, targets: None, benchmarks: Some("syn-2.0.101,clap_derive-4.5.32") } }))"#);
+        insta::assert_compact_debug_snapshot!(parse_command(r#"@rust-timer build 23936af287657fa4148aeab40cc2a780810fae5C benchmarks=syn-2.0.101,notreal,clap_derive-4.5.32"#),
+            @r#"Err("Unknown compile-time benchmark: notreal")"#);
     }
 
     #[test]
@@ -716,10 +727,12 @@ Otherwise LGTM."#),
             @r#"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: Some("Cranelift"), profiles: None, targets: None, benchmarks: None } }))"#);
         insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue backends=Cranelift,Llvm"),
             @r#"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: Some("Cranelift,Llvm"), profiles: None, targets: None, benchmarks: None } }))"#);
-        insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue benchmarks=syn-1.0.89,clap-3.1.6"),
-            @r#"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: None, profiles: None, targets: None, benchmarks: Some("syn-1.0.89,clap-3.1.6") } }))"#);
+        insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue benchmarks=syn-2.0.101,clap_derive-4.5.32"),
+            @r#"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: None, profiles: None, targets: None, benchmarks: Some("syn-2.0.101,clap_derive-4.5.32") } }))"#);
         insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue"),
             @"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: None, profiles: None, targets: None, benchmarks: None } }))");
+        insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue benchmarks=syn-2.0.101,notreal,clap_derive-4.5.32"),
+            @r#"Err("Unknown compile-time benchmark: notreal")"#);
     }
 
     #[test]

--- a/site/src/request_handlers/github.rs
+++ b/site/src/request_handlers/github.rs
@@ -84,9 +84,10 @@ async fn record_try_benchmark_request_without_artifacts(
     backends: &str,
     profiles: &str,
     targets: &str,
+    benchmarks: &str,
 ) -> String {
     let try_request =
-        BenchmarkRequest::create_try_without_artifacts(pr, backends, profiles, targets, "");
+        BenchmarkRequest::create_try_without_artifacts(pr, backends, profiles, targets, benchmarks);
     log::info!("Inserting try benchmark request {try_request:?}");
 
     match conn.insert_benchmark_request(&try_request).await {
@@ -208,6 +209,7 @@ async fn handle_rust_timer(
                 cmd.params.backends.unwrap_or(""),
                 cmd.params.profiles.unwrap_or(""),
                 cmd.params.targets.unwrap_or(""),
+                cmd.params.benchmarks.unwrap_or(""),
             )
             .await;
             main_client.post_comment(issue.number, comment).await;
@@ -361,6 +363,7 @@ async fn enqueue_sha_build(
             cmd.params.backends.unwrap_or(""),
             cmd.params.profiles.unwrap_or(""),
             cmd.params.targets.unwrap_or(""),
+            cmd.params.benchmarks.unwrap_or(""),
         )
         .await;
     }
@@ -449,6 +452,7 @@ fn parse_benchmark_parameters<'a>(
         backends: args.remove("backends").filter(|s| !s.is_empty()),
         profiles: args.remove("profiles").filter(|s| !s.is_empty()),
         targets: args.remove("targets").filter(|s| !s.is_empty()),
+        benchmarks: args.remove("benchmarks").filter(|s| !s.is_empty()),
     };
 
     if let Some(backends) = &params.backends {
@@ -558,6 +562,7 @@ struct BenchmarkParameters<'a> {
     backends: Option<&'a str>,
     profiles: Option<&'a str>,
     targets: Option<&'a str>,
+    benchmarks: Option<&'a str>,
 }
 
 pub async fn get_authorized_users() -> Result<Vec<u64>, String> {
@@ -601,7 +606,7 @@ mod tests {
     #[test]
     fn build_command() {
         insta::assert_compact_debug_snapshot!(parse_command("@rust-timer build 5832462aa1d9373b24ace96ad2c50b7a18af9952"),
-            @r#"Ok(Build(BuildCommand { sha: "5832462aa1d9373b24ace96ad2c50b7a18af9952", params: BenchmarkParameters { backends: None, profiles: None, targets: None } }))"#);
+            @r#"Ok(Build(BuildCommand { sha: "5832462aa1d9373b24ace96ad2c50b7a18af9952", params: BenchmarkParameters { backends: None, profiles: None, targets: None, benchmarks: None } }))"#);
     }
 
     #[test]
@@ -629,13 +634,13 @@ mod tests {
     fn build_command_link() {
         insta::assert_compact_debug_snapshot!(parse_command(r#"
 @rust-timer build https://github.com/rust-lang/rust/commit/323f521bc6d8f2b966ba7838a3f3ee364e760b7e"#),
-            @r#"Ok(Build(BuildCommand { sha: "323f521bc6d8f2b966ba7838a3f3ee364e760b7e", params: BenchmarkParameters { backends: None, profiles: None, targets: None } }))"#);
+            @r#"Ok(Build(BuildCommand { sha: "323f521bc6d8f2b966ba7838a3f3ee364e760b7e", params: BenchmarkParameters { backends: None, profiles: None, targets: None, benchmarks: None } }))"#);
     }
 
     #[test]
     fn queue_command() {
         insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue"),
-            @"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: None, profiles: None, targets: None } }))");
+            @"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: None, profiles: None, targets: None, benchmarks: None } }))");
     }
 
     #[test]
@@ -659,19 +664,19 @@ mod tests {
     #[test]
     fn queue_command_spaces() {
         insta::assert_compact_debug_snapshot!(parse_command("@rust-timer     queue     backends=llvm   "),
-            @r#"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: Some("llvm"), profiles: None, targets: None } }))"#);
+            @r#"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: Some("llvm"), profiles: None, targets: None, benchmarks: None } }))"#);
     }
 
     #[test]
     fn queue_command_with_bors() {
         insta::assert_compact_debug_snapshot!(parse_command("@bors try @rust-timer queue backends=llvm"),
-            @r#"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: Some("llvm"), profiles: None, targets: None } }))"#);
+            @r#"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: Some("llvm"), profiles: None, targets: None, benchmarks: None } }))"#);
     }
 
     #[test]
     fn queue_command_parameter_order() {
         insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue profiles=Doc backends=llvm"),
-            @r#"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: Some("llvm"), profiles: Some("Doc"), targets: None } }))"#);
+            @r#"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: Some("llvm"), profiles: Some("Doc"), targets: None, benchmarks: None } }))"#);
     }
 
     #[test]
@@ -682,51 +687,55 @@ Let's do a perf run quickly and then we can merge it.
 @bors try @rust-timer queue
 
 Otherwise LGTM."#),
-            @"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: None, profiles: None, targets: None } }))");
+            @"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: None, profiles: None, targets: None, benchmarks: None } }))");
     }
 
     #[test]
     fn build_command_with_backends() {
         insta::assert_compact_debug_snapshot!(parse_command(r#"@rust-timer build 5832462aa1d9373b24ace96ad2c50b7a18af995G"#),
-            @r#"Ok(Build(BuildCommand { sha: "5832462aa1d9373b24ace96ad2c50b7a18af995G", params: BenchmarkParameters { backends: None, profiles: None, targets: None } }))"#);
+            @r#"Ok(Build(BuildCommand { sha: "5832462aa1d9373b24ace96ad2c50b7a18af995G", params: BenchmarkParameters { backends: None, profiles: None, targets: None, benchmarks: None } }))"#);
         insta::assert_compact_debug_snapshot!(parse_command(r#"@rust-timer build 5832462aa1d9373b24ace96ad2c50b7a18af995A backends=Llvm"#),
-            @r#"Ok(Build(BuildCommand { sha: "5832462aa1d9373b24ace96ad2c50b7a18af995A", params: BenchmarkParameters { backends: Some("Llvm"), profiles: None, targets: None } }))"#);
+            @r#"Ok(Build(BuildCommand { sha: "5832462aa1d9373b24ace96ad2c50b7a18af995A", params: BenchmarkParameters { backends: Some("Llvm"), profiles: None, targets: None, benchmarks: None } }))"#);
         insta::assert_compact_debug_snapshot!(parse_command(r#"@rust-timer build 23936af287657fa4148aeab40cc2a780810fae5B backends=Cranelift"#),
-            @r#"Ok(Build(BuildCommand { sha: "23936af287657fa4148aeab40cc2a780810fae5B", params: BenchmarkParameters { backends: Some("Cranelift"), profiles: None, targets: None } }))"#);
+            @r#"Ok(Build(BuildCommand { sha: "23936af287657fa4148aeab40cc2a780810fae5B", params: BenchmarkParameters { backends: Some("Cranelift"), profiles: None, targets: None, benchmarks: None } }))"#);
         insta::assert_compact_debug_snapshot!(parse_command(r#"@rust-timer build 23936af287657fa4148aeab40cc2a780810fae5C backends=Cranelift,Llvm"#),
-            @r#"Ok(Build(BuildCommand { sha: "23936af287657fa4148aeab40cc2a780810fae5C", params: BenchmarkParameters { backends: Some("Cranelift,Llvm"), profiles: None, targets: None } }))"#);
+            @r#"Ok(Build(BuildCommand { sha: "23936af287657fa4148aeab40cc2a780810fae5C", params: BenchmarkParameters { backends: Some("Cranelift,Llvm"), profiles: None, targets: None, benchmarks: None } }))"#);
+        insta::assert_compact_debug_snapshot!(parse_command(r#"@rust-timer build 23936af287657fa4148aeab40cc2a780810fae5C benchmarks=syn-1.0.89,clap-3.1.6"#),
+            @r#"Ok(Build(BuildCommand { sha: "23936af287657fa4148aeab40cc2a780810fae5C", params: BenchmarkParameters { backends: None, profiles: None, targets: None, benchmarks: Some("syn-1.0.89,clap-3.1.6") } }))"#);
     }
 
     #[test]
     fn queue_command_with_backends() {
         insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue backends=Llvm"),
-            @r#"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: Some("Llvm"), profiles: None, targets: None } }))"#);
+            @r#"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: Some("Llvm"), profiles: None, targets: None, benchmarks: None } }))"#);
         insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue backends=Cranelift"),
-            @r#"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: Some("Cranelift"), profiles: None, targets: None } }))"#);
+            @r#"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: Some("Cranelift"), profiles: None, targets: None, benchmarks: None } }))"#);
         insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue backends=Cranelift,Llvm"),
-            @r#"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: Some("Cranelift,Llvm"), profiles: None, targets: None } }))"#);
+            @r#"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: Some("Cranelift,Llvm"), profiles: None, targets: None, benchmarks: None } }))"#);
+        insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue benchmarks=syn-1.0.89,clap-3.1.6"),
+            @r#"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: None, profiles: None, targets: None, benchmarks: Some("syn-1.0.89,clap-3.1.6") } }))"#);
         insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue"),
-            @"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: None, profiles: None, targets: None } }))");
+            @"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: None, profiles: None, targets: None, benchmarks: None } }))");
     }
 
     #[test]
     fn queue_command_with_profiles() {
         insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue profiles=Doc"),
-            @r#"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: None, profiles: Some("Doc"), targets: None } }))"#);
+            @r#"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: None, profiles: Some("Doc"), targets: None, benchmarks: None } }))"#);
         insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue profiles=Check,Clippy"),
-            @r#"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: None, profiles: Some("Check,Clippy"), targets: None } }))"#);
+            @r#"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: None, profiles: Some("Check,Clippy"), targets: None, benchmarks: None } }))"#);
         insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue profiles=Doc,Clippy,Opt backends=Cranelift,Llvm"),
-            @r#"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: Some("Cranelift,Llvm"), profiles: Some("Doc,Clippy,Opt"), targets: None } }))"#);
+            @r#"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: Some("Cranelift,Llvm"), profiles: Some("Doc,Clippy,Opt"), targets: None, benchmarks: None } }))"#);
         insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue profiles=Foo"),
             @r#"Err("Cannot parse profiles: Invalid profile: Foo. Valid values are: check, debug, opt, doc, doc-json, clippy")"#);
         insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue profiles=check"),
-            @r#"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: None, profiles: Some("check"), targets: None } }))"#);
+            @r#"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: None, profiles: Some("check"), targets: None, benchmarks: None } }))"#);
     }
 
     #[test]
     fn queue_command_with_targets() {
         insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue targets=x86_64-unknown-linux-gnu"),
-            @r#"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: None, profiles: None, targets: Some("x86_64-unknown-linux-gnu") } }))"#);
+            @r#"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: None, profiles: None, targets: Some("x86_64-unknown-linux-gnu"), benchmarks: None } }))"#);
         insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue targets=x86_64-unknown-linux-gnu,67-unknown-none"),
             @r#"Err("Cannot parse targets: Only the available targets `x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu` can be specified. Valid values are: x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu")"#);
     }
@@ -734,11 +743,13 @@ Otherwise LGTM."#),
     #[test]
     fn no_empty_arguments_thank_you() {
         insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue backends="),
-            @"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: None, profiles: None, targets: None } }))");
+            @"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: None, profiles: None, targets: None, benchmarks: None } }))");
         insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue targets="),
-            @"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: None, profiles: None, targets: None } }))");
+            @"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: None, profiles: None, targets: None, benchmarks: None } }))");
         insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue profiles="),
-            @"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: None, profiles: None, targets: None } }))");
+            @"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: None, profiles: None, targets: None, benchmarks: None } }))");
+        insta::assert_compact_debug_snapshot!(parse_command("@rust-timer queue benchmarks="),
+            @"Ok(Queue(QueueCommand { params: BenchmarkParameters { backends: None, profiles: None, targets: None, benchmarks: None } }))");
     }
 
     #[test]

--- a/site/src/request_handlers/github.rs
+++ b/site/src/request_handlers/github.rs
@@ -86,7 +86,7 @@ async fn record_try_benchmark_request_without_artifacts(
     targets: &str,
 ) -> String {
     let try_request =
-        BenchmarkRequest::create_try_without_artifacts(pr, backends, profiles, targets);
+        BenchmarkRequest::create_try_without_artifacts(pr, backends, profiles, targets, "");
     log::info!("Inserting try benchmark request {try_request:?}");
 
     match conn.insert_benchmark_request(&try_request).await {


### PR DESCRIPTION
I recommend reviewing commit by commit. Every commit has a single purpose, compiles and passes tests.
This modifies the database schema, but provides defaults for the new `benchmarks` column, and the default matches the old behavior, so I believe this should migrate fine.

This work prepares for implementing step 3 of [#t-compiler/performance > Proposal for &#96;@rust-timer triage&#96; command](https://rust-lang.zulipchat.com/#narrow/channel/247081-t-compiler.2Fperformance/topic/Proposal.20for.20.60.40rust-timer.20triage.60.20command/with/619288960)

r? @Kobzol 