### PR TITLE
Only run changed benchmarks during triage

### DIFF
--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -28,7 +28,6 @@ use std::error::Error;
 use std::fmt::Write;
 use std::hash::Hash;
 use std::iter;
-use std::ops::Deref;
 use std::sync::Arc;
 
 type BoxedError = Box<dyn Error + Send + Sync>;
@@ -1062,7 +1061,7 @@ impl ArtifactComparison {
         ) = self
             .compile_comparisons
             .into_iter()
-            .partition(|s| category_map.get(&s.benchmark()) == Some(&Category::Primary));
+            .partition(|s| category_map.get(&s.test_case.benchmark) == Some(&Category::Primary));
         (
             ArtifactComparisonSummary::summarize(
                 primary
@@ -1256,7 +1255,7 @@ impl TestResultComparison {
     }
 
     /// Whether the comparison yielded a statistically significant result
-    pub fn is_significant(&self) -> bool {
+    fn is_significant(&self) -> bool {
         self.relative_change().abs() >= self.significance_threshold()
     }
 
@@ -1285,7 +1284,7 @@ impl TestResultComparison {
     /// Whether the comparison is relevant or not.
     ///
     /// Relevance is a function of significance and magnitude.
-    fn is_relevant(&self) -> bool {
+    pub fn is_relevant(&self) -> bool {
         self.is_significant() && self.magnitude().is_small_or_above()
     }
 
@@ -1359,14 +1358,8 @@ impl From<TestResultComparison> for StatComparison {
 
 #[derive(Debug, Clone)]
 pub struct CompileTestResultComparison {
-    test_case: CompileTestCase,
-    comparison: TestResultComparison,
-}
-
-impl CompileTestResultComparison {
-    pub fn benchmark(&self) -> Benchmark {
-        self.test_case.benchmark
-    }
+    pub test_case: CompileTestCase,
+    pub comparison: TestResultComparison,
 }
 
 impl cmp::PartialEq for CompileTestResultComparison {
@@ -1393,16 +1386,8 @@ impl std::hash::Hash for CompileTestResultComparison {
 
 #[derive(Debug, Clone)]
 pub struct RuntimeTestResultComparison {
-    test_case: RuntimeTestCase,
-    comparison: TestResultComparison,
-}
-
-impl Deref for RuntimeTestResultComparison {
-    type Target = TestResultComparison;
-
-    fn deref(&self) -> &Self::Target {
-        &self.comparison
-    }
+    pub test_case: RuntimeTestCase,
+    pub comparison: TestResultComparison,
 }
 
 impl cmp::PartialEq for RuntimeTestResultComparison {

--- a/site/src/github/comparison_summary.rs
+++ b/site/src/github/comparison_summary.rs
@@ -90,12 +90,13 @@ fn make_comparison_url(commit: &QueuedCommit, stat: Metric) -> String {
 
 pub(crate) async fn calculate_metric_comparison(
     ctxt: &SiteCtxt,
-    commit: &QueuedCommit,
+    parent_sha: &str,
+    head_sha: &str,
     metric: Metric,
 ) -> Result<ArtifactComparison, String> {
     match crate::comparison::compare(
-        collector::Bound::Commit(commit.parent_sha.clone()),
-        collector::Bound::Commit(commit.sha.clone()),
+        collector::Bound::Commit(parent_sha.to_string()),
+        collector::Bound::Commit(head_sha.to_string()),
         metric,
         ctxt,
     )
@@ -152,8 +153,13 @@ async fn summarize_run(
     )
     .unwrap();
 
-    let inst_comparison =
-        calculate_metric_comparison(ctxt, &commit, Metric::InstructionsUser).await?;
+    let inst_comparison = calculate_metric_comparison(
+        ctxt,
+        &commit.parent_sha,
+        &commit.sha,
+        Metric::InstructionsUser,
+    )
+    .await?;
 
     let has_broken_benchmarks = !inst_comparison.newly_failed_benchmarks.is_empty();
     let errors = if has_broken_benchmarks {
@@ -234,25 +240,39 @@ pub async fn metrics_result(ctxt: &SiteCtxt, commit: &QueuedCommit) -> Result<St
             "Instruction count",
             Metric::InstructionsUser,
             DefaultMetricVisibility::Shown,
-            calculate_metric_comparison(ctxt, commit, Metric::InstructionsUser).await?,
+            calculate_metric_comparison(
+                ctxt,
+                &commit.parent_sha,
+                &commit.sha,
+                Metric::InstructionsUser,
+            )
+            .await?,
         ),
         (
             "Max RSS (memory usage)",
             Metric::MaxRSS,
             DefaultMetricVisibility::Hidden,
-            calculate_metric_comparison(ctxt, commit, Metric::MaxRSS).await?,
+            calculate_metric_comparison(ctxt, &commit.parent_sha, &commit.sha, Metric::MaxRSS)
+                .await?,
         ),
         (
             "Cycles",
             Metric::CyclesUser,
             DefaultMetricVisibility::Hidden,
-            calculate_metric_comparison(ctxt, commit, Metric::CyclesUser).await?,
+            calculate_metric_comparison(ctxt, &commit.parent_sha, &commit.sha, Metric::CyclesUser)
+                .await?,
         ),
         (
             "Binary size",
             Metric::LinkedArtifactSize,
             DefaultMetricVisibility::Hidden,
-            calculate_metric_comparison(ctxt, commit, Metric::LinkedArtifactSize).await?,
+            calculate_metric_comparison(
+                ctxt,
+                &commit.parent_sha,
+                &commit.sha,
+                Metric::LinkedArtifactSize,
+            )
+            .await?,
         ),
     ];
 

--- a/site/src/github/comparison_summary.rs
+++ b/site/src/github/comparison_summary.rs
@@ -88,7 +88,7 @@ fn make_comparison_url(commit: &QueuedCommit, stat: Metric) -> String {
     )
 }
 
-async fn calculate_metric_comparison(
+pub(crate) async fn calculate_metric_comparison(
     ctxt: &SiteCtxt,
     commit: &QueuedCommit,
     metric: Metric,
@@ -103,10 +103,10 @@ async fn calculate_metric_comparison(
     {
         Ok(Some(c)) => Ok(c),
         Ok(None) => {
-            Err("Error occured while categorizing benchmark run (missing comparison).".to_string())
+            Err("Error occurred while categorizing benchmark run (missing comparison).".to_string())
         }
         Err(error) => Err(format!(
-            "Error occured while categorizing benchmark run:\n\n```{error}```"
+            "Error occurred while categorizing benchmark run:\n\n```{error}```"
         )),
     }
 }

--- a/site/src/github/triage.rs
+++ b/site/src/github/triage.rs
@@ -78,7 +78,7 @@ pub async fn changed_benchmarks_in_rollup(
         .find(|commit| commit.pr.is_some_and(|pr| pr == rollup))
         .cloned()
     else {
-        bail!("The `@rust-timer triage` command can only be executed in rollups. If this is a rollup, it might be too old.")
+        bail!("The `@rust-timer triage` command can only be executed in merged rollups. If this is a merged rollup, it might be too old.")
     };
     drop(master_commits);
 
@@ -96,6 +96,7 @@ pub async fn changed_benchmarks_in_rollup(
             .is_relevant()
             .then_some(c.test_case.benchmark.to_string())
     });
+    // Include newly failed benchmarks so we can triage which PRs broke them
     let newly_failed_benchmarks = comparison.newly_failed_benchmarks.into_keys();
     let changed_benchmarks = compile_benchmarks.chain(newly_failed_benchmarks);
     Ok(changed_benchmarks.collect())

--- a/site/src/github/triage.rs
+++ b/site/src/github/triage.rs
@@ -1,6 +1,9 @@
 use crate::github::client::{Client, GraphQLClient, ResponseComment};
+use crate::github::comparison_summary::calculate_metric_comparison;
+use crate::load::SiteCtxt;
 use crate::request_handlers::parse_unrolled_build_message;
 use anyhow::bail;
+use database::metric::Metric;
 use database::QueuedCommit;
 
 pub struct TriageBuild {
@@ -62,6 +65,50 @@ pub fn update_triage_body(
 
     body.replace_range(body_start..body_end, &triage_summary);
     Ok(())
+}
+
+pub async fn changed_benchmarks_in_rollup(
+    ctxt: &SiteCtxt,
+    rollup: u32,
+) -> anyhow::Result<Vec<String>> {
+    let master_commits = ctxt.get_master_commits();
+    let Some(rollup) = master_commits
+        .commits
+        .iter()
+        .find(|commit| commit.pr.is_some_and(|pr| pr == rollup))
+        .cloned()
+    else {
+        bail!("The `@rust-timer triage` command can only be executed in rollups. If this is a rollup, it might be too old.")
+    };
+    drop(master_commits);
+
+    let comparison = calculate_metric_comparison(
+        ctxt,
+        &QueuedCommit {
+            sha: rollup.sha,
+            parent_sha: rollup.parent_sha,
+
+            // Fields that are not used by `calculate_metric_comparison`
+            pr: 0,
+            include: None,
+            exclude: None,
+            runs: None,
+            commit_date: None,
+            backends: None,
+        },
+        Metric::InstructionsUser,
+    )
+    .await
+    .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    let compile_benchmarks = comparison.compile_comparisons.iter().flat_map(|c| {
+        c.comparison
+            .is_relevant()
+            .then_some(c.test_case.benchmark.to_string())
+    });
+    let newly_failed_benchmarks = comparison.newly_failed_benchmarks.into_keys();
+    let changed_benchmarks = compile_benchmarks.chain(newly_failed_benchmarks);
+    Ok(changed_benchmarks.collect())
 }
 
 #[cfg(test)]

--- a/site/src/github/triage.rs
+++ b/site/src/github/triage.rs
@@ -84,18 +84,8 @@ pub async fn changed_benchmarks_in_rollup(
 
     let comparison = calculate_metric_comparison(
         ctxt,
-        &QueuedCommit {
-            sha: rollup.sha,
-            parent_sha: rollup.parent_sha,
-
-            // Fields that are not used by `calculate_metric_comparison`
-            pr: 0,
-            include: None,
-            exclude: None,
-            runs: None,
-            commit_date: None,
-            backends: None,
-        },
+        &rollup.parent_sha,
+        &rollup.sha,
         Metric::InstructionsUser,
     )
     .await

--- a/site/src/request_handlers/github.rs
+++ b/site/src/request_handlers/github.rs
@@ -241,7 +241,11 @@ async fn handle_rust_timer(
                     return Ok(github::Response);
                 }
             };
-            let plural = if benchmarks_to_run.len() == 1 { "" } else { "s" };
+            let plural = if benchmarks_to_run.len() == 1 {
+                ""
+            } else {
+                "s"
+            };
             writeln!(&mut result, "<details>
 <summary>Running triage with {} benchmark{plural}</summary>
 

--- a/site/src/request_handlers/github.rs
+++ b/site/src/request_handlers/github.rs
@@ -254,7 +254,7 @@ For this rollup, these benchmarks are:\n", benchmarks_to_run.len()).unwrap();
             for benchmark in &benchmarks_to_run {
                 writeln!(&mut result, "* {benchmark}").unwrap();
             }
-            writeln!(&mut result, "</details>").unwrap();
+            writeln!(&mut result, "</details>\n").unwrap();
 
             for (i, sha) in cmd.shas.iter().enumerate() {
                 // Add separator between PRs

--- a/site/src/request_handlers/github.rs
+++ b/site/src/request_handlers/github.rs
@@ -7,7 +7,9 @@ use std::fmt::Write;
 
 use crate::benchmark_metadata::get_compile_benchmarks_metadata;
 use crate::github::client::Client;
-use crate::github::triage::{triage_body_end_marker, triage_body_start_marker, TRIAGE_MARKER};
+use crate::github::triage::{
+    changed_benchmarks_in_rollup, triage_body_end_marker, triage_body_start_marker, TRIAGE_MARKER,
+};
 use database::{
     parse_backends, parse_benchmarks, parse_profiles, parse_targets, BenchmarkRequest,
     BenchmarkRequestInsertResult, CodegenBackend, Profile, Target,
@@ -229,6 +231,27 @@ async fn handle_rust_timer(
         }
         Ok(RustTimerCommand::Triage(cmd)) => {
             let mut result = String::new();
+
+            let benchmarks_to_run = match changed_benchmarks_in_rollup(&ctxt, issue.number).await {
+                Ok(benches) => benches,
+                Err(err) => {
+                    main_client
+                        .post_comment(issue.number, format!("{err}"))
+                        .await;
+                    return Ok(github::Response);
+                }
+            };
+            let plural = if benchmarks_to_run.len() == 1 { "" } else { "s" };
+            writeln!(&mut result, "<details>
+<summary>Running triage with {} benchmark{plural}</summary>
+
+Triage only executes the benchmarks on rollup members, that were changed significantly on the rollup.
+For this rollup, these benchmarks are:\n", benchmarks_to_run.len()).unwrap();
+            for benchmark in &benchmarks_to_run {
+                writeln!(&mut result, "* {benchmark}").unwrap();
+            }
+            writeln!(&mut result, "</details>").unwrap();
+
             for (i, sha) in cmd.shas.iter().enumerate() {
                 // Add separator between PRs
                 if i != 0 {
@@ -283,7 +306,10 @@ async fn handle_rust_timer(
                     unrolled_build_message.member_pr_number,
                     &BuildCommand {
                         sha,
-                        params: Default::default(),
+                        params: BenchmarkParameters {
+                            benchmarks: Some(&benchmarks_to_run.join(",")),
+                            ..Default::default()
+                        },
                     },
                 )
                 .await;


### PR DESCRIPTION
This PR is based on https://github.com/rust-lang/rustc-perf/pull/2552, and because stacked PRs aren't working cross-fork also contains it's commits :c

I recommend reviewing commit by commit. Every commit has a single purpose, compiles and passes tests.

This implements step 3 of [#t-compiler/performance > Proposal for `@rust-timer triage` command](https://rust-lang.zulipchat.com/#narrow/channel/247081-t-compiler.2Fperformance/topic/Proposal.20for.20.60.40rust-timer.20triage.60.20command/with/619288960)

r? @Kobzol