### PR TITLE
Respect optional job attribute when checking parent jobs

### DIFF
--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -1977,6 +1977,7 @@ where
                             WHERE
                                 job_queue.request_tag = benchmark_request.parent_sha
                                 AND job_queue.status NOT IN ($3, $4)
+                                AND job_queue.is_optional = FALSE
                        )
                 )
                 RETURNING


### PR DESCRIPTION
When deciding whether we should wait for a benchmark request to be completed or not, we should ignore optional jobs. However, we were not doing that for parent commit jobs, and since if you have optional jobs, they usually have to backfill and produce optional parent jobs, the optional property was effectively ignored, and we were waiting even for optional (AArch64) jobs to complete.
This PR fixes that.
