### PR TITLE
Separate artifact size records by target

### DIFF
--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -2406,21 +2406,33 @@ async fn record_toolchain_sizes(
         aid: ArtifactIdNumber,
         component: &str,
         path: Option<&Path>,
+        target: database::Target,
     ) {
         if let Some(path) = path {
             if let Ok(size) = fs::metadata(path).map(|m| m.len()) {
-                conn.record_artifact_size(aid, component, size).await;
+                conn.record_artifact_size(aid, component, size, target)
+                    .await;
             }
         }
     }
 
+    let target = Target::from_str(&toolchain.triple).expect("Invalid target");
+    let target: database::Target = target.into();
+
     let paths = &toolchain.components;
-    record(conn, aid, "rustc", Some(&paths.rustc)).await;
-    record(conn, aid, "rustdoc", paths.rustdoc.as_deref()).await;
-    record(conn, aid, "cargo", Some(&paths.cargo)).await;
-    record(conn, aid, "librustc_driver", paths.lib_rustc.as_deref()).await;
-    record(conn, aid, "libstd", paths.lib_std.as_deref()).await;
-    record(conn, aid, "libLLVM", paths.lib_llvm.as_deref()).await;
+    record(conn, aid, "rustc", Some(&paths.rustc), target).await;
+    record(conn, aid, "rustdoc", paths.rustdoc.as_deref(), target).await;
+    record(conn, aid, "cargo", Some(&paths.cargo), target).await;
+    record(
+        conn,
+        aid,
+        "librustc_driver",
+        paths.lib_rustc.as_deref(),
+        target,
+    )
+    .await;
+    record(conn, aid, "libstd", paths.lib_std.as_deref(), target).await;
+    record(conn, aid, "libLLVM", paths.lib_llvm.as_deref(), target).await;
 }
 
 fn add_perf_config(directory: &Path, category: Category, artifact: ArtifactType) {

--- a/database/schema.md
+++ b/database/schema.md
@@ -65,6 +65,7 @@ artifact.
 Columns:
 
 * **aid** (`integer`): Artifact id, references the id in the artifact table
+* **target** (`text`): Target tuple of the compiler artifact
 * **component** (`text`): Normalized name of the component (hashes are removed)
 * **size** (`integer`): Size of the component in bytes
 

--- a/database/src/bin/postgres-to-sqlite.rs
+++ b/database/src/bin/postgres-to-sqlite.rs
@@ -333,12 +333,12 @@ impl Table for ArtifactSize {
     }
 
     fn postgres_select_statement(&self, since_weeks_ago: Option<u32>) -> String {
-        let s = "select aid, component, size from ".to_string() + self.name();
+        let s = "select aid, target, component, size from ".to_string() + self.name();
         with_filter_clause_maybe(s, ARTIFACT_JOIN_AND_WHERE, since_weeks_ago)
     }
 
     fn sqlite_insert_statement(&self) -> &'static str {
-        "insert into artifact_size (aid, component, size) VALUES (?, ?, ?)"
+        "insert into artifact_size (aid, target, component, size) VALUES (?, ?, ?, ?)"
     }
 
     fn sqlite_execute_insert(&self, statement: &mut rusqlite::Statement, row: tokio_postgres::Row) {
@@ -346,7 +346,8 @@ impl Table for ArtifactSize {
             .execute(params![
                 row.get::<_, i32>(0),
                 row.get::<_, &str>(1),
-                row.get::<_, i32>(2),
+                row.get::<_, &str>(2),
+                row.get::<_, i32>(3),
             ])
             .unwrap();
     }

--- a/database/src/bin/sqlite-to-postgres.rs
+++ b/database/src/bin/sqlite-to-postgres.rs
@@ -442,6 +442,7 @@ struct ArtifactSize;
 #[derive(Serialize)]
 struct ArtifactSizeRow<'a> {
     aid: i32,
+    target: &'a str,
     component: &'a str,
     size: i32,
 }
@@ -452,11 +453,11 @@ impl Table for ArtifactSize {
     }
 
     fn sqlite_attributes() -> &'static str {
-        "aid, component, size"
+        "aid, target, component, size"
     }
 
     fn postgres_attributes() -> &'static str {
-        "aid, component, size"
+        "aid, target, component, size"
     }
 
     fn postgres_generated_id_attribute() -> Option<&'static str> {
@@ -467,8 +468,9 @@ impl Table for ArtifactSize {
         writer
             .serialize(ArtifactSizeRow {
                 aid: row.get(0).unwrap(),
-                component: row.get_ref(1).unwrap().as_str().unwrap(),
-                size: row.get(2).unwrap(),
+                target: row.get_ref(1).unwrap().as_str().unwrap(),
+                component: row.get_ref(2).unwrap().as_str().unwrap(),
+                size: row.get(3).unwrap(),
             })
             .unwrap();
     }

--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -97,14 +97,17 @@ pub trait Connection: Send + Sync {
     );
 
     /// Returns the sizes of individual components of a single artifact.
-    async fn get_artifact_size(&self, aid: ArtifactIdNumber) -> HashMap<String, u64>;
+    async fn get_artifact_size(
+        &self,
+        aid: ArtifactIdNumber,
+    ) -> HashMap<Target, HashMap<String, u64>>;
 
     /// Returns the sizes of individual components of multiple artifacts.
     /// The key of the hashmap is the name of the component.
     async fn get_artifacts_size(
         &self,
         aids: &[ArtifactIdNumber],
-    ) -> HashMap<String, Vec<Option<u64>>>;
+    ) -> HashMap<Target, HashMap<String, Vec<Option<u64>>>>;
 
     /// Returns vector of bootstrap build times for the given artifacts. The kth
     /// element is the minimum build time for the kth artifact in `aids`, across
@@ -496,8 +499,18 @@ mod tests {
             )
             .await;
 
-            let result_one = db.get_artifact_size(artifact_one_id_number).await;
-            let result_two = db.get_artifact_size(artifact_two_id_number).await;
+            let result_one = db
+                .get_artifact_size(artifact_one_id_number)
+                .await
+                .get(&Target::X86_64UnknownLinuxGnu)
+                .unwrap()
+                .clone();
+            let result_two = db
+                .get_artifact_size(artifact_two_id_number)
+                .await
+                .get(&Target::X86_64UnknownLinuxGnu)
+                .unwrap()
+                .clone();
 
             // artifact one
             assert_eq!(Some(32u64), result_one.get("llvm.so").copied());

--- a/database/src/pool.rs
+++ b/database/src/pool.rs
@@ -88,7 +88,13 @@ pub trait Connection: Send + Sync {
 
     /// Records the size of an artifact component (like `librustc_driver.so` or `libLLVM.so`) in
     /// bytes.
-    async fn record_artifact_size(&self, artifact: ArtifactIdNumber, component: &str, size: u64);
+    async fn record_artifact_size(
+        &self,
+        artifact: ArtifactIdNumber,
+        component: &str,
+        size: u64,
+        target: Target,
+    );
 
     /// Returns the sizes of individual components of a single artifact.
     async fn get_artifact_size(&self, aid: ArtifactIdNumber) -> HashMap<String, u64>;
@@ -466,14 +472,29 @@ mod tests {
             // exist before attaching something to it.
 
             // Artifact one inserts
-            db.record_artifact_size(artifact_one_id_number, "llvm.so", 32)
-                .await;
-            db.record_artifact_size(artifact_one_id_number, "llvm.a", 64)
-                .await;
+            db.record_artifact_size(
+                artifact_one_id_number,
+                "llvm.so",
+                32,
+                Target::X86_64UnknownLinuxGnu,
+            )
+            .await;
+            db.record_artifact_size(
+                artifact_one_id_number,
+                "llvm.a",
+                64,
+                Target::X86_64UnknownLinuxGnu,
+            )
+            .await;
 
             // Artifact two inserts
-            db.record_artifact_size(artifact_two_id_number, "another-llvm.a", 128)
-                .await;
+            db.record_artifact_size(
+                artifact_two_id_number,
+                "another-llvm.a",
+                128,
+                Target::X86_64UnknownLinuxGnu,
+            )
+            .await;
 
             let result_one = db.get_artifact_size(artifact_one_id_number).await;
             let result_two = db.get_artifact_size(artifact_two_id_number).await;

--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -694,11 +694,11 @@ impl PostgresConnection {
                     set size = excluded.size
                 ").await.unwrap(),
                 get_artifact_size: conn.prepare("
-                    select component, size from artifact_size
+                    select component, target, size from artifact_size
                     where aid = $1
                 ").await.unwrap(),
                 get_artifacts_size: conn.prepare(r#"
-                    SELECT aid, component, size
+                    SELECT aid, component, target, size
                     FROM artifact_size
                     WHERE aid = ANY($1)
                 "#).await.unwrap(),
@@ -1198,16 +1198,29 @@ where
             .unwrap();
     }
 
-    async fn get_artifact_size(&self, aid: ArtifactIdNumber) -> HashMap<String, u64> {
+    async fn get_artifact_size(
+        &self,
+        aid: ArtifactIdNumber,
+    ) -> HashMap<Target, HashMap<String, u64>> {
         let rows = self
             .conn()
             .query(&self.statements().get_artifact_size, &[&(aid.0 as i32)])
             .await
             .unwrap();
 
-        rows.into_iter()
-            .map(|row| (row.get::<_, String>(0), row.get::<_, i32>(1) as u64))
-            .collect()
+        let mut targets: HashMap<Target, HashMap<String, u64>> = HashMap::new();
+        for (component, target, size) in rows.into_iter().map(|row| {
+            (
+                row.get::<_, String>(0),
+                row.get::<_, String>(1),
+                row.get::<_, i32>(2) as u64,
+            )
+        }) {
+            let target = Target::from_str(&target).expect("Invalid target");
+            let components = targets.entry(target).or_default();
+            components.insert(component, size);
+        }
+        targets
     }
 
     async fn artifact_id(&self, artifact: &ArtifactId) -> ArtifactIdNumber {
@@ -2170,8 +2183,8 @@ where
     async fn get_artifacts_size(
         &self,
         aids: &[ArtifactIdNumber],
-    ) -> HashMap<String, Vec<Option<u64>>> {
-        let mut result = HashMap::new();
+    ) -> HashMap<Target, HashMap<String, Vec<Option<u64>>>> {
+        let mut targets: HashMap<Target, HashMap<String, Vec<Option<u64>>>> = HashMap::new();
         let aid_to_idx = aids
             .iter()
             .copied()
@@ -2190,15 +2203,18 @@ where
         for row in rows {
             let aid = ArtifactIdNumber(row.get::<_, i32>(0) as u32);
             let component = row.get::<_, String>(1);
-            let size = row.get::<_, i32>(2);
+            let target = row.get::<_, String>(2);
+            let target = Target::from_str(&target).expect("Invalid target");
+            let size = row.get::<_, i32>(3);
 
-            let v = result
+            let components = targets.entry(target).or_default();
+            let v = components
                 .entry(component)
                 .or_insert_with(|| vec![None; aids.len()]);
             v[aid_to_idx[&aid]] = Some(size as u64);
         }
 
-        result
+        targets
     }
 }
 

--- a/database/src/pool/postgres.rs
+++ b/database/src/pool/postgres.rs
@@ -452,6 +452,11 @@ static MIGRATIONS: &[&str] = &[
     // Add benchmarks to benchmark_request
     r#"ALTER TABLE benchmark_request ADD COLUMN benchmarks TEXT NOT NULL DEFAULT ''"#,
     r#"ALTER TABLE job_queue ADD COLUMN benchmarks TEXT NOT NULL DEFAULT ''"#,
+    r#"
+    ALTER TABLE artifact_size ADD COLUMN target TEXT NOT NULL DEFAULT 'x86_64-unknown-linux-gnu';
+    ALTER TABLE artifact_size DROP CONSTRAINT artifact_size_aid_component_key;
+    ALTER TABLE artifact_size ADD CONSTRAINT aid_target_component UNIQUE(aid, target, component);
+    "#,
 ];
 
 #[async_trait::async_trait]
@@ -682,9 +687,9 @@ impl PostgresConnection {
                     .await
                     .unwrap(),
                 record_artifact_size: conn.prepare("
-                    insert into artifact_size (aid, component, size)
-                    values ($1, $2, $3)
-                    on conflict (aid, component)
+                    insert into artifact_size (aid, component, size, target)
+                    values ($1, $2, $3, $4)
+                    on conflict (aid, component, target)
                     do update
                     set size = excluded.size
                 ").await.unwrap(),
@@ -1176,12 +1181,18 @@ where
             .unwrap();
     }
 
-    async fn record_artifact_size(&self, artifact: ArtifactIdNumber, component: &str, size: u64) {
+    async fn record_artifact_size(
+        &self,
+        artifact: ArtifactIdNumber,
+        component: &str,
+        size: u64,
+        target: Target,
+    ) {
         let size: i32 = size.try_into().expect("Too large artifact");
         self.conn()
             .execute(
                 &self.statements().record_artifact_size,
-                &[&(artifact.0 as i32), &component, &size],
+                &[&(artifact.0 as i32), &component, &size, &target.as_str()],
             )
             .await
             .unwrap();

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -876,49 +876,67 @@ impl Connection for SqliteConnection {
             .unwrap();
     }
 
-    async fn get_artifact_size(&self, aid: ArtifactIdNumber) -> HashMap<String, u64> {
-        self.raw_ref()
-            .prepare("select component, size from artifact_size where aid = ?")
+    async fn get_artifact_size(
+        &self,
+        aid: ArtifactIdNumber,
+    ) -> HashMap<Target, HashMap<String, u64>> {
+        let mut targets: HashMap<Target, HashMap<String, u64>> = HashMap::new();
+        for (component, target, size) in self
+            .raw_ref()
+            .prepare("select component, target, size from artifact_size where aid = ?")
             .unwrap()
             .query_map(params![&aid.0], |row| {
-                Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)? as u64))
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, i64>(2)? as u64,
+                ))
             })
             .unwrap()
             .map(|r| r.unwrap())
-            .collect()
+        {
+            let target = Target::from_str(&target).expect("Invalid target");
+            let components = targets.entry(target).or_default();
+            components.insert(component, size);
+        }
+        targets
     }
 
     async fn get_artifacts_size(
         &self,
         aids: &[ArtifactIdNumber],
-    ) -> HashMap<String, Vec<Option<u64>>> {
-        let mut results = HashMap::new();
+    ) -> HashMap<Target, HashMap<String, Vec<Option<u64>>>> {
+        let mut targets: HashMap<Target, HashMap<String, Vec<Option<u64>>>> = HashMap::new();
 
         for (idx, aid) in aids.iter().copied().enumerate() {
-            let rows: Vec<(String, i64)> = self
+            let rows: Vec<(String, Target, i64)> = self
                 .raw_ref()
                 .prepare(
                     r#"
-            SELECT component, MIN(size)
-            FROM artifact_size WHERE aid = ?
-            GROUP BY component"#,
+            SELECT component, target, MIN(size)
+            FROM artifact_size
+            WHERE aid = ?
+            GROUP BY component, target"#,
                 )
                 .unwrap()
                 .query_map(params![&aid.0], |row| {
-                    Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+                    let target =
+                        Target::from_str(&row.get::<_, String>(1)?).expect("Invalid target");
+                    Ok((row.get::<_, String>(0)?, target, row.get::<_, i64>(2)?))
                 })
                 .unwrap()
                 .map(|r| r.unwrap())
                 .collect();
-            for (component, size) in rows {
-                let v = results
+            for (component, target, size) in rows {
+                let components = targets.entry(target).or_default();
+                let v = components
                     .entry(component)
                     .or_insert_with(|| vec![None; aids.len()]);
                 v[idx] = Some(size as u64);
             }
         }
 
-        results
+        targets
     }
 
     async fn get_bootstrap(&self, aids: &[ArtifactIdNumber]) -> Vec<Option<Duration>> {

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -468,6 +468,20 @@ static MIGRATIONS: &[Migration] = &[
         ALTER TABLE pstat_series_with_frontend_threads RENAME TO pstat_series;
     "#,
     ),
+    Migration::without_foreign_key_constraints(
+        r#"
+        create table artifact_size_new(
+            aid INTEGER REFERENCES artifact(id) ON DELETE CASCADE ON UPDATE CASCADE,
+            component TEXT NOT NULL,
+            target TEXT NOT NULL,
+            size INTEGER NOT NULL,
+            UNIQUE(aid, target, component)
+        );
+        insert into artifact_size_new select aid, component, 'x86_64-unknown-linux-gnu', size from artifact_size;
+        drop table artifact_size;
+        alter table artifact_size_new rename to artifact_size;
+    "#,
+    ),
 ];
 
 #[async_trait::async_trait]
@@ -846,12 +860,18 @@ impl Connection for SqliteConnection {
             .unwrap();
     }
 
-    async fn record_artifact_size(&self, artifact: ArtifactIdNumber, component: &str, size: u64) {
+    async fn record_artifact_size(
+        &self,
+        artifact: ArtifactIdNumber,
+        component: &str,
+        size: u64,
+        target: Target,
+    ) {
         self.raw_ref()
             .execute(
-                "insert or replace into artifact_size (aid, component, size)\
-                values (?, ?, ?)",
-                params![&artifact.0, &component, &(size as i64)],
+                "insert or replace into artifact_size (aid, component, size, target)\
+                values (?, ?, ?, ?)",
+                params![&artifact.0, &component, &(size as i64), &target.as_str()],
             )
             .unwrap();
     }

--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -944,7 +944,13 @@ impl ArtifactDescription {
             None
         };
 
-        let component_sizes = conn.get_artifact_size(aid).await.into_iter().collect();
+        let component_sizes = conn
+            .get_artifact_size(aid)
+            .await
+            .remove(&Target::X86_64UnknownLinuxGnu)
+            .into_iter()
+            .flatten()
+            .collect();
 
         Self {
             pr,

--- a/site/src/request_handlers/toolchain.rs
+++ b/site/src/request_handlers/toolchain.rs
@@ -2,7 +2,7 @@ use futures::stream::{FuturesOrdered, StreamExt};
 
 use crate::api::{toolchain, ServerResult};
 use crate::load::SiteCtxt;
-use database::ArtifactId;
+use database::{ArtifactId, Target};
 
 use std::time::Duration;
 
@@ -59,7 +59,13 @@ pub async fn handle_toolchain(
         .map(|v| v.map(duration_as_nanos_u64))
         .collect();
 
-    let artifact_sizes = conn.get_artifacts_size(&ids).await;
+    let artifact_sizes = conn
+        .get_artifacts_size(&ids)
+        .await
+        .remove(&Target::X86_64UnknownLinuxGnu)
+        .into_iter()
+        .flatten()
+        .collect();
 
     Ok(toolchain::Response {
         commits: commits


### PR DESCRIPTION
Without this, benchmarking both x64 and aarch64 was overwriting each other's artifact size results. The UI will only show x64 for now, I'll implement support for switching the targets in the UI later.