### PR TITLE
Ignore runtime benchmarks when a benchmark filter is set

### DIFF
--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -1755,7 +1755,9 @@ async fn create_benchmark_configs(
         None
     };
 
-    let runtime_config = if bench_runtime {
+    // We currently don't allow selecting a benchmark filter for runtime benchmarks
+    // If there is any filter set, just ignore runtime benchmarks altogether
+    let runtime_config = if bench_runtime && job.benchmarks().is_empty() {
         let runtime_suite = load_runtime_benchmarks(
             conn,
             &runtime_benchmark_dir(),
@@ -1768,7 +1770,7 @@ async fn create_benchmark_configs(
         .await?;
         Some(RuntimeBenchmarkConfig {
             runtime_suite,
-            filter: RuntimeBenchmarkFilter::new(vec![], job.benchmarks().to_vec()),
+            filter: RuntimeBenchmarkFilter::keep_all(),
             iterations: DEFAULT_RUNTIME_ITERATIONS,
             target: job.target().into(),
         })


### PR DESCRIPTION
We currently have a hybrid, where we don't set benchmark filter for runtime benchmarks in the website, but the collector was still trying to support it. But that was causing us to compile all runtime benchmarks before figuring out that we will run none of them. This PR just removes support for running runtime benchmarks if there is a benchmark filter configured.
