### PR TITLE
Speed up triage command

### DIFF
--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -18,20 +18,16 @@ pub const RUST_REPO_GITHUB_API_URL: &str = "https://api.github.com/repos/rust-la
 /// They are removed once a perf. run comparison summary is posted on a PR.
 pub const COMMENT_MARK_TEMPORARY: &str = "<!-- rust-timer: temporary -->";
 
+use crate::github::client::Commit;
 use database::{BenchmarkJobStatus, BenchmarkRequestStatus, Connection};
 
 /// Enqueues the given SHA and returns a message that should be sent as a comment to the corresponding PR.
 /// If not benchmark reques was found to which the commit SHA could be attached, returns `Ok(None)`.
 pub async fn enqueue_sha(
     ctxt: &SiteCtxt,
-    gh_client: &client::Client,
+    mut commit: Commit,
     pr_number: u32,
-    commit_sha: &str,
 ) -> Result<Option<String>, String> {
-    let mut commit = gh_client
-        .get_commit(commit_sha)
-        .await
-        .map_err(|e| e.to_string())?;
     if commit.parents.len() != 2 {
         return Err(format!(
             "Bors try commit {} unexpectedly has {} parents.",

--- a/site/src/github.rs
+++ b/site/src/github.rs
@@ -3,7 +3,7 @@ pub mod comparison_summary;
 pub mod triage;
 
 use crate::job_queue::build_queue;
-use crate::load::{SiteCtxt, TryCommit};
+use crate::load::SiteCtxt;
 use chrono::Utc;
 use serde::Deserialize;
 use std::time::Duration;
@@ -22,7 +22,7 @@ use crate::github::client::Commit;
 use database::{BenchmarkJobStatus, BenchmarkRequestStatus, Connection};
 
 /// Enqueues the given SHA and returns a message that should be sent as a comment to the corresponding PR.
-/// If not benchmark reques was found to which the commit SHA could be attached, returns `Ok(None)`.
+/// If no benchmark request was found to which the commit SHA could be attached, returns `Ok(None)`.
 pub async fn enqueue_sha(
     ctxt: &SiteCtxt,
     mut commit: Commit,
@@ -35,25 +35,23 @@ pub async fn enqueue_sha(
             commit.parents.len()
         ));
     }
-    let try_commit = TryCommit {
-        sha: commit.sha,
-        parent_sha: commit.parents.remove(0).sha,
-    };
+    let sha = commit.sha;
+    let parent_sha = commit.parents.remove(0).sha;
     let conn = ctxt.conn().await;
 
     let queued = conn.attach_shas_to_try_benchmark_request(
             pr_number,
-            &try_commit.sha,
-            &try_commit.parent_sha,
+            &sha,
+            &parent_sha,
             commit.commit.committer.date,
             )
             .await
-            .map_err(|error| format!("Cannot attach SHAs to try benchmark request on PR {pr_number} and SHA {}: {error:?}", try_commit.sha))?;
+            .map_err(|error| format!("Cannot attach SHAs to try benchmark request on PR {pr_number} and SHA {sha}: {error:?}"))?;
     if !queued {
         return Ok(None);
     }
 
-    let (preceding_artifacts, expected_duration) = estimate_queue_info(conn.as_ref(), &try_commit)
+    let (preceding_artifacts, expected_duration) = estimate_queue_info(conn.as_ref(), &sha)
         .await
         .map_err(|e| format!("{e:?}"))?;
 
@@ -70,18 +68,20 @@ It will probably take at least ~{:.1} hours until the benchmark run finishes."#,
     );
 
     Ok(Some(format!(
-        "Queued {} with parent {}, future [comparison URL]({}).\n{queue_msg}",
-        try_commit.sha,
-        try_commit.parent_sha,
-        try_commit.comparison_url(),
+        "Queued {sha} with parent {parent_sha}, future [comparison URL]({}).\n{queue_msg}",
+        comparison_url(&sha, &parent_sha),
     )))
+}
+
+fn comparison_url(commit: &str, parent: &str) -> String {
+    format!("https://perf.rust-lang.org/compare.html?start={parent}&end={commit}")
 }
 
 /// Counts how many artifacts are in the queue before the specified commit, and what is the expected
 /// duration until the specified commit will be finished.
 async fn estimate_queue_info(
     conn: &dyn Connection,
-    commit: &TryCommit,
+    commit_sha: &str,
 ) -> anyhow::Result<(u64, Duration)> {
     let queue = build_queue(conn).await?;
 
@@ -99,7 +99,7 @@ async fn estimate_queue_info(
     // How many commits are waiting (i.e. not running) in the queue before the specified commit?
     let preceding_waiting = queue_waiting
         .iter()
-        .position(|c| c.tag() == Some(commit.sha()))
+        .position(|c| c.tag() == Some(commit_sha))
         .unwrap_or(queue_waiting.len().saturating_sub(1)) as u64;
 
     // Guess the expected full run duration of a waiting commit
@@ -137,7 +137,7 @@ async fn estimate_queue_info(
         let Some(tag) = req.tag() else {
             continue;
         };
-        if tag == commit.sha {
+        if tag == commit_sha {
             continue;
         }
         let Some(jobs) = jobs.get(tag) else {

--- a/site/src/load.rs
+++ b/site/src/load.rs
@@ -15,25 +15,6 @@ use collector::{Bound, MasterCommit, SelfProfileStorage};
 pub use database::{ArtifactId, Benchmark, Commit};
 use database::{Pool, Target};
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct TryCommit {
-    pub sha: String,
-    pub parent_sha: String,
-}
-
-impl TryCommit {
-    pub fn sha(&self) -> &str {
-        self.sha.as_str()
-    }
-
-    pub fn comparison_url(&self) -> String {
-        format!(
-            "https://perf.rust-lang.org/compare.html?start={}&end={}",
-            self.parent_sha, self.sha
-        )
-    }
-}
-
 /// Keys for accessing various services
 ///
 /// At the moment only used for accessing GitHub

--- a/site/src/request_handlers/github.rs
+++ b/site/src/request_handlers/github.rs
@@ -6,7 +6,7 @@ use crate::load::SiteCtxt;
 use std::fmt::Write;
 
 use crate::benchmark_metadata::get_compile_benchmarks_metadata;
-use crate::github::client::Client;
+use crate::github::client::Commit;
 use crate::github::triage::{
     changed_benchmarks_in_rollup, triage_body_end_marker, triage_body_start_marker, TRIAGE_MARKER,
 };
@@ -55,7 +55,20 @@ async fn handle_issue(ctxt: Arc<SiteCtxt>, issue: github::Issue, comment: github
     let gh_client = client::Client::from_ctxt(&ctxt, RUST_REPO_GITHUB_API_URL.to_owned());
     if comment.body.contains(" homu: ") {
         if let Some(sha) = parse_homu_comment(&comment.body).await {
-            match enqueue_sha(&ctxt, &gh_client, issue.number, &sha).await {
+            let commit = match gh_client.get_commit(&sha).await {
+                Ok(commit) => commit,
+                Err(error) => {
+                    gh_client
+                        .post_comment(
+                            issue.number,
+                            format!("Cannot fetch commit `{sha}` info: {error:?}"),
+                        )
+                        .await;
+                    return;
+                }
+            };
+
+            match enqueue_sha(&ctxt, commit, issue.number).await {
                 Ok(Some(mut msg)) => {
                     msg.push_str(&format!("\n{COMMENT_MARK_TEMPORARY}"));
                     gh_client.post_comment(issue.number, msg).await;
@@ -231,7 +244,20 @@ async fn handle_rust_timer(
                 return;
             }
 
-            match enqueue_sha_build(&ctxt, main_client, issue.number, &cmd).await {
+            let commit = match main_client.get_commit(cmd.sha).await {
+                Ok(commit) => commit,
+                Err(error) => {
+                    main_client
+                        .post_comment(
+                            issue.number,
+                            format!("Cannot fetch commit `{}` info: {error:?}", cmd.sha),
+                        )
+                        .await;
+                    return;
+                }
+            };
+
+            match enqueue_sha_build(&ctxt, commit, issue.number, &cmd).await {
                 Ok(mut msg) => {
                     msg.push_str(&format!("\n{COMMENT_MARK_TEMPORARY}"));
                     main_client.post_comment(issue.number, msg).await;
@@ -319,7 +345,7 @@ For this rollup, these benchmarks are:\n", benchmarks_to_run.len()).unwrap();
                 .unwrap();
                 let (Ok(msg) | Err(msg)) = enqueue_sha_build(
                     &ctxt,
-                    main_client,
+                    commit,
                     unrolled_build_message.member_pr_number,
                     &BuildCommand {
                         sha,
@@ -390,7 +416,7 @@ pub fn parse_unrolled_build_message(commit_message: &str) -> Result<UnrolledBuil
 
 async fn enqueue_sha_build(
     ctxt: &Arc<SiteCtxt>,
-    main_client: &Client,
+    commit: Commit,
     issue_number: u32,
     cmd: &BuildCommand<'_>,
 ) -> Result<String, String> {
@@ -407,7 +433,7 @@ async fn enqueue_sha_build(
         .await;
     }
 
-    match enqueue_sha(ctxt, main_client, issue_number, cmd.sha).await {
+    match enqueue_sha(ctxt, commit, issue_number).await {
         Ok(Some(msg)) => Ok(msg),
         Ok(None) => Err(
             "Commit was not enqueued, since no previous benchmark request was found".to_string(),

--- a/site/src/request_handlers/github.rs
+++ b/site/src/request_handlers/github.rs
@@ -225,6 +225,12 @@ async fn handle_rust_timer(
             main_client.post_comment(issue.number, comment).await;
         }
         Ok(RustTimerCommand::Build(cmd)) => {
+            // Check if requested artifacts exist
+            if let Err(error) = validate_build_command(&cmd).await {
+                main_client.post_comment(issue.number, error).await;
+                return;
+            }
+
             match enqueue_sha_build(&ctxt, main_client, issue.number, &cmd).await {
                 Ok(mut msg) => {
                     msg.push_str(&format!("\n{COMMENT_MARK_TEMPORARY}"));
@@ -388,9 +394,6 @@ async fn enqueue_sha_build(
     issue_number: u32,
     cmd: &BuildCommand<'_>,
 ) -> Result<String, String> {
-    // requested artifacts do not exist errors
-    validate_build_command(cmd).await?;
-
     {
         let conn = ctxt.conn().await;
         record_try_benchmark_request_without_artifacts(


### PR DESCRIPTION
By removing unnecessary network requests. We could also remove the queue estimation, but DB queries should be relatively fast, and I didn't want to bother refactoring the code further.
