### PR TITLE
Run ARM benchmarks by default

### DIFF
--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -429,7 +429,7 @@ impl Target {
     /// Targets that will be benchmarked by default in benchmark requests when no explicit target
     /// is specified.
     pub fn default_targets() -> Vec<Self> {
-        vec![Self::X86_64UnknownLinuxGnu]
+        vec![Self::X86_64UnknownLinuxGnu, Self::AArch64UnknownLinuxGnu]
     }
 
     // 2026/01/12 (Jamesbarford) - presently rustc-perf only support `x86_64`'s

--- a/site/src/job_queue/mod.rs
+++ b/site/src/job_queue/mod.rs
@@ -872,8 +872,8 @@ mod tests {
                 .unwrap()
                 .remove("foo")
                 .unwrap();
-            // runtime + rustc + 10 compile-time jobs (two x64 sets)
-            assert_eq!(jobs.len(), 12);
+            // runtime + rustc + 10 compile-time jobs (two x64 sets + one arm set)
+            assert_eq!(jobs.len(), 18);
 
             Ok(ctx)
         })


### PR DESCRIPTION
We now run Aarch64 builds when doing `@bors try` by default, so we can also enable benchmarking it by default. Note that ARM benchmarks are still optional, so they won't block the completion of x64 benchmarks if they stall or fail for some reason. Their results are also not shown by default in the GitHub PR comment, triage, or the compare page.
