### PR TITLE
Add support for frontend threads to the UI

### DIFF
--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -25,6 +25,10 @@ intern!(pub struct TargetName);
 pub struct FrontendThreads(pub u32);
 
 impl FrontendThreads {
+    pub fn default_value() -> Self {
+        Self(1)
+    }
+
     // Default thread counts for the parallel frontend
     pub fn default_threads_counts() -> Vec<FrontendThreads> {
         vec![FrontendThreads(1)]
@@ -41,6 +45,12 @@ impl std::str::FromStr for FrontendThreads {
             .parse()
             .map_err(|e: std::num::ParseIntError| e.to_string())?;
         Ok(Self(v))
+    }
+}
+
+impl Display for FrontendThreads {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
     }
 }
 
@@ -361,6 +371,7 @@ impl Scenario {
 
 use anyhow::anyhow;
 use std::cmp::Ordering;
+use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
 // We sort println before all other patches.

--- a/site/frontend/src/api.ts
+++ b/site/frontend/src/api.ts
@@ -12,6 +12,7 @@ export interface BenchmarkInfo {
 }
 
 export const DEFAULT_COMPILE_TARGET_TRIPLE: Target = "x86_64-unknown-linux-gnu";
+export const DEFAULT_FRONTEND_THREAD_COUNT: string = "1";
 
 function compareDefaultCompileTarget(a: string, b: string) {
   return (

--- a/site/frontend/src/components/perfetto-link.vue
+++ b/site/frontend/src/components/perfetto-link.vue
@@ -13,11 +13,12 @@ const props = defineProps<{
 const link = computed(() => {
   return chromeProfileUrl(
     props.artifact.commit,
-    `${props.testCase.benchmark}`,
+    props.testCase.benchmark,
     props.testCase.scenario,
     props.testCase.profile.toLowerCase(),
     props.testCase.backend,
-    props.testCase.target
+    props.testCase.target,
+    props.testCase.frontend_threads
   );
 });
 

--- a/site/frontend/src/graph/api.ts
+++ b/site/frontend/src/graph/api.ts
@@ -5,16 +5,17 @@ import {GRAPH_DATA_URL} from "../urls";
 export async function loadGraphs(
   selector: GraphsSelector
 ): Promise<CompileGraphData> {
-  const params = {
+  const params: Dict<string> = {
     start: selector.start,
     end: selector.end,
     kind: selector.kind as string,
     stat: selector.stat,
-    benchmark: selector.benchmark,
-    scenario: selector.scenario,
-    profile: selector.profile,
-    backend: selector.backend,
-    target: selector.target,
+    benchmark: selector.benchmark as string,
+    scenario: selector.scenario as string,
+    profile: selector.profile as string,
+    backend: selector.backend as string,
+    target: selector.target as string,
+    frontend_threads: selector.frontend_threads as string,
   };
   return await getJson<CompileGraphData>(GRAPH_DATA_URL, params);
 }

--- a/site/frontend/src/graph/api.ts
+++ b/site/frontend/src/graph/api.ts
@@ -5,17 +5,17 @@ import {GRAPH_DATA_URL} from "../urls";
 export async function loadGraphs(
   selector: GraphsSelector
 ): Promise<CompileGraphData> {
-  const params: Dict<string> = {
+  const params: Dict<string | null> = {
     start: selector.start,
     end: selector.end,
     kind: selector.kind as string,
     stat: selector.stat,
-    benchmark: selector.benchmark as string,
-    scenario: selector.scenario as string,
-    profile: selector.profile as string,
-    backend: selector.backend as string,
-    target: selector.target as string,
-    frontend_threads: selector.frontend_threads as string,
+    benchmark: selector.benchmark,
+    scenario: selector.scenario,
+    profile: selector.profile,
+    backend: selector.backend,
+    target: selector.target,
+    frontend_threads: selector.frontend_threads,
   };
   return await getJson<CompileGraphData>(GRAPH_DATA_URL, params);
 }

--- a/site/frontend/src/graph/data.ts
+++ b/site/frontend/src/graph/data.ts
@@ -11,6 +11,7 @@ export interface GraphsSelector {
   profile: string | null;
   backend: string | null;
   target: string | null;
+  frontend_threads: string | null;
 }
 
 export interface Series {

--- a/site/frontend/src/pages/compare/compile/common.ts
+++ b/site/frontend/src/pages/compare/compile/common.ts
@@ -109,6 +109,9 @@ export interface CompileBenchmarkParameters {
   scenario: string;
   backend: CodegenBackend;
   target: Target;
+  // We treat the frontend thread count as a categorical variable, which is why
+  // it is represented as a string, and not a number.
+  frontend_threads: string;
 }
 
 export type CompileBenchmarkComparison = CompileBenchmarkParameters & {
@@ -121,7 +124,7 @@ export type CompileTestCase = CompileBenchmarkParameters & {
 
 // Add new attritbtues to this function when modifying the CompileTestCase!
 export function testCaseKey(testCase: CompileTestCase): string {
-  return `${testCase.benchmark};${testCase.profile};${testCase.scenario};${testCase.backend};${testCase.target};${testCase.category}`;
+  return `${testCase.benchmark};${testCase.profile};${testCase.scenario};${testCase.backend};${testCase.target};${testCase.frontend_threads};${testCase.category}`;
 }
 
 export function computeCompileComparisonsWithNonRelevant(
@@ -214,12 +217,13 @@ export function computeCompileComparisonsWithNonRelevant(
   let filteredComparisons = comparisons
     .map(
       (c: CompileBenchmarkComparison): TestCaseComparison<CompileTestCase> => {
-        let testCase = {
+        let testCase: CompileTestCase = {
           benchmark: c.benchmark,
           profile: c.profile,
           scenario: c.scenario,
           backend: c.backend,
           target: c.target,
+          frontend_threads: c.frontend_threads,
           category: (benchmarkMap[c.benchmark] || {}).category || "secondary",
         };
         return calculateComparison(c.comparison, testCase);

--- a/site/frontend/src/pages/compare/compile/common.ts
+++ b/site/frontend/src/pages/compare/compile/common.ts
@@ -1,7 +1,10 @@
 import {BenchmarkFilter, CompareResponse, StatComparison} from "../types";
 import {calculateComparison, TestCaseComparison} from "../data";
 import {benchmarkNameMatchesFilter, targetMatchesFilter} from "../shared";
-import {DEFAULT_COMPILE_TARGET_TRIPLE} from "../../../api";
+import {
+  DEFAULT_COMPILE_TARGET_TRIPLE,
+  DEFAULT_FRONTEND_THREAD_COUNT,
+} from "../../../api";
 
 export type CompileBenchmarkFilter = {
   profile: {
@@ -22,6 +25,7 @@ export type CompileBenchmarkFilter = {
     cranelift: boolean;
   };
   target: Target[];
+  frontendThreads: string[];
   category: {
     primary: boolean;
     secondary: boolean;
@@ -59,6 +63,7 @@ export const defaultCompileFilter: CompileBenchmarkFilter = {
     cranelift: true,
   },
   target: [DEFAULT_COMPILE_TARGET_TRIPLE],
+  frontendThreads: [DEFAULT_FRONTEND_THREAD_COUNT],
   category: {
     primary: true,
     secondary: true,
@@ -122,7 +127,7 @@ export type CompileTestCase = CompileBenchmarkParameters & {
   category: Category;
 };
 
-// Add new attritbtues to this function when modifying the CompileTestCase!
+// Add new attributes to this function when modifying the CompileTestCase!
 export function testCaseKey(testCase: CompileTestCase): string {
   return `${testCase.benchmark};${testCase.profile};${testCase.scenario};${testCase.backend};${testCase.target};${testCase.frontend_threads};${testCase.category}`;
 }
@@ -174,6 +179,13 @@ export function computeCompileComparisonsWithNonRelevant(
     }
   }
 
+  function frontendThreadsFilter(
+    frontendThreads: string,
+    frontendThreadsSet: string[]
+  ) {
+    return frontendThreadsSet.includes(frontendThreads);
+  }
+
   function artifactFilter(metadata: CompileBenchmarkMetadata | null): boolean {
     if (metadata === null || metadata?.binary === null) return true;
 
@@ -207,6 +219,10 @@ export function computeCompileComparisonsWithNonRelevant(
       scenarioFilter(comparison.testCase.scenario) &&
       backendFilter(comparison.testCase.backend) &&
       targetMatchesFilter(comparison.testCase.target, filter.target) &&
+      frontendThreadsFilter(
+        comparison.testCase.frontend_threads,
+        filter.frontendThreads
+      ) &&
       categoryFilter(comparison.testCase.category) &&
       artifactFilter(benchmarkMap[comparison.testCase.benchmark] ?? null) &&
       changeFilter(comparison) &&

--- a/site/frontend/src/pages/compare/compile/common.ts
+++ b/site/frontend/src/pages/compare/compile/common.ts
@@ -103,22 +103,25 @@ export interface CompileBenchmarkMetadata {
   dev_profile: CargoProfileMetadata;
 }
 
-export interface CompileBenchmarkComparison {
+export interface CompileBenchmarkParameters {
   benchmark: string;
   profile: Profile;
   scenario: string;
   backend: CodegenBackend;
   target: Target;
-  comparison: StatComparison;
 }
 
-export interface CompileTestCase {
-  benchmark: string;
-  profile: Profile;
-  scenario: string;
-  backend: CodegenBackend;
-  target: Target;
+export type CompileBenchmarkComparison = CompileBenchmarkParameters & {
+  comparison: StatComparison;
+};
+
+export type CompileTestCase = CompileBenchmarkParameters & {
   category: Category;
+};
+
+// Add new attritbtues to this function when modifying the CompileTestCase!
+export function testCaseKey(testCase: CompileTestCase): string {
+  return `${testCase.benchmark};${testCase.profile};${testCase.scenario};${testCase.backend};${testCase.target};${testCase.category}`;
 }
 
 export function computeCompileComparisonsWithNonRelevant(
@@ -243,10 +246,6 @@ export function createCompileBenchmarkMap(
     benchmarks[benchmark.name] = {...benchmark};
   }
   return benchmarks;
-}
-
-export function testCaseKey(testCase: CompileTestCase): string {
-  return `${testCase.benchmark};${testCase.profile};${testCase.scenario};${testCase.backend};${testCase.category}`;
 }
 
 // Transform compile comparisons to compare treat the given benchmark

--- a/site/frontend/src/pages/compare/compile/common.ts
+++ b/site/frontend/src/pages/compare/compile/common.ts
@@ -119,17 +119,25 @@ export interface CompileBenchmarkParameters {
   frontend_threads: string;
 }
 
-export type CompileBenchmarkComparison = CompileBenchmarkParameters & {
+export interface CompileBenchmarkComparison extends CompileBenchmarkParameters {
   comparison: StatComparison;
-};
+}
 
-export type CompileTestCase = CompileBenchmarkParameters & {
+export interface CompileTestCase extends CompileBenchmarkParameters {
   category: Category;
-};
+}
 
 // Add new attributes to this function when modifying the CompileTestCase!
 export function testCaseKey(testCase: CompileTestCase): string {
-  return `${testCase.benchmark};${testCase.profile};${testCase.scenario};${testCase.backend};${testCase.target};${testCase.frontend_threads};${testCase.category}`;
+  return [
+    testCase.benchmark,
+    testCase.profile,
+    testCase.scenario,
+    testCase.backend,
+    testCase.target,
+    testCase.frontend_threads,
+    testCase.category,
+  ].join(";");
 }
 
 export function computeCompileComparisonsWithNonRelevant(

--- a/site/frontend/src/pages/compare/compile/compile-page.vue
+++ b/site/frontend/src/pages/compare/compile/compile-page.vue
@@ -26,6 +26,7 @@ import {
   storeOrResetValue,
   storeOrResetStringArray,
   getStringOrDefault,
+  getStringArrayOrDefault,
 } from "../shared";
 
 const props = defineProps<{
@@ -51,6 +52,12 @@ function loadFilterFromUrl(
   ) {
     target = [props.data.compile_comparisons[0].target];
   }
+
+  const frontendThreads = getStringArrayOrDefault(
+    urlParams,
+    "frontendThreads",
+    defaultFilter.frontendThreads
+  );
 
   return {
     name: urlParams["name"] ?? defaultFilter.name,
@@ -106,6 +113,7 @@ function loadFilterFromUrl(
       ),
     },
     target,
+    frontendThreads,
     category: {
       primary: getBoolOrDefault(
         urlParams,
@@ -243,6 +251,12 @@ function storeFilterToUrl(
     "target",
     filter.target,
     defaultFilter.target
+  );
+  storeOrResetStringArray(
+    urlParams,
+    "frontendThreads",
+    filter.frontendThreads,
+    defaultFilter.frontendThreads
   );
   storeOrResetValue(
     urlParams,
@@ -382,6 +396,7 @@ const filteredSummary = computed(() => computeSummary(comparisons.value));
     :default-filter="defaultCompileFilter"
     :initial-filter="filter"
     :self-compare-enabled="selfCompareCanBeEnabled"
+    :all-comparisons="allComparisons"
     @change="updateFilter"
     @export="exportData"
   />

--- a/site/frontend/src/pages/compare/compile/filters.vue
+++ b/site/frontend/src/pages/compare/compile/filters.vue
@@ -1,15 +1,17 @@
 <script setup lang="ts">
 import Toggle from "../toggle.vue";
 import Tooltip from "../tooltip.vue";
-import {ref, toRaw, watch} from "vue";
+import {computed, ref, toRaw, watch} from "vue";
 import {deepCopy} from "../../../utils/copy";
 import {PREF_FILTERS_OPENED} from "../prefs";
 import {createPersistedRef} from "../../../storage";
-import {CompileBenchmarkFilter, Target} from "./common";
-import {BenchmarkInfo} from "../../../api";
+import {CompileBenchmarkFilter, CompileTestCase, Target} from "./common";
+import {BenchmarkInfo, DEFAULT_FRONTEND_THREAD_COUNT} from "../../../api";
+import {TestCaseComparison} from "../data";
 
 const props = defineProps<{
   info: BenchmarkInfo;
+  allComparisons: TestCaseComparison<CompileTestCase>[];
   // When reset, set filter to this value
   defaultFilter: CompileBenchmarkFilter;
   // Initialize the filter with this value
@@ -38,10 +40,38 @@ function toggleTarget(target: Target) {
   }
 }
 
+function hasFrontendThreadCount(count: string): boolean {
+  return filter.value.frontendThreads.includes(count);
+}
+
+function toggleFrontendThreadCount(count: string) {
+  if (hasFrontendThreadCount(count)) {
+    filter.value.frontendThreads = filter.value.frontendThreads.filter(
+      (c) => c !== count
+    );
+  } else {
+    filter.value.frontendThreads = [...filter.value.frontendThreads, count];
+  }
+}
+
 function updateSelfCompareParameter(event: Event) {
   let rawValue = (event.target as HTMLSelectElement).value;
   filter.value.selfCompareParameter = rawValue === "" ? null : rawValue;
 }
+
+const availableFrontendThreadsValues = computed((): string[] => {
+  if (props.allComparisons.length === 0) {
+    return [DEFAULT_FRONTEND_THREAD_COUNT];
+  }
+  const uniqueFrontendThreads = [
+    ...new Set(props.allComparisons.map((c) => c.testCase.frontend_threads)),
+  ];
+  // Compare the string values as numbers
+  uniqueFrontendThreads.sort((a, b) =>
+    a.localeCompare(b, undefined, {numeric: true})
+  );
+  return uniqueFrontendThreads;
+});
 
 let filter = ref(deepCopy(props.initialFilter));
 watch(
@@ -67,7 +97,7 @@ const opened = createPersistedRef(PREF_FILTERS_OPENED);
           </div>
           <div class="section section-list-wrapper">
             <div class="section-heading">
-              <div style="width: 160px">
+              <div>
                 <span>Profiles</span>
                 <Tooltip
                   >The different compilation profiles (check, debug, opt, doc).
@@ -142,7 +172,7 @@ const opened = createPersistedRef(PREF_FILTERS_OPENED);
           </div>
           <div class="section section-list-wrapper">
             <div class="section-heading">
-              <div style="width: 160px">
+              <div>
                 <span>Scenarios</span>
                 <Tooltip
                   >The different scenarios based on their incremental
@@ -212,7 +242,7 @@ const opened = createPersistedRef(PREF_FILTERS_OPENED);
           </div>
           <div class="section section-list-wrapper">
             <div class="section-heading">
-              <div style="width: 160px">
+              <div>
                 <span>Backends</span>
                 <Tooltip
                   >The different codegen backends used to generate executable
@@ -242,7 +272,29 @@ const opened = createPersistedRef(PREF_FILTERS_OPENED);
           </div>
           <div class="section section-list-wrapper">
             <div class="section-heading">
-              <div style="width: 160px">
+              <div>
+                <span>Frontend threads</span>
+                <Tooltip
+                  >The different frontend thread counts used for compilation.
+                </Tooltip>
+              </div>
+            </div>
+            <ul class="states-list">
+              <li v-for="count in availableFrontendThreadsValues" :id="count">
+                <label>
+                  <input
+                    type="checkbox"
+                    :checked="hasFrontendThreadCount(count)"
+                    @change="toggleFrontendThreadCount(count)"
+                  />
+                  <span class="label">{{ count }}</span>
+                </label>
+              </li>
+            </ul>
+          </div>
+          <div class="section section-list-wrapper">
+            <div class="section-heading">
+              <div>
                 <span>Targets</span>
                 <Tooltip>The host target of the benchmarked compiler. </Tooltip>
               </div>
@@ -262,7 +314,7 @@ const opened = createPersistedRef(PREF_FILTERS_OPENED);
           </div>
           <div class="section section-list-wrapper">
             <div class="section-heading">
-              <div style="width: 160px">
+              <div>
                 <span>Categories</span>
                 <Tooltip
                   >Select benchmarks based on their category (primary or
@@ -289,7 +341,7 @@ const opened = createPersistedRef(PREF_FILTERS_OPENED);
           </div>
           <div class="section section-list-wrapper">
             <div class="section-heading">
-              <div style="width: 160px">
+              <div>
                 <span>Artifacts</span>
                 <Tooltip>
                   Select benchmarks based on the artifact that they produce
@@ -314,7 +366,7 @@ const opened = createPersistedRef(PREF_FILTERS_OPENED);
           </div>
           <div class="section section-list-wrapper">
             <div class="section-heading">
-              <div style="width: 160px">
+              <div>
                 <span>Changes</span>
                 <Tooltip>
                   Select only improvements, only regressions, or both.
@@ -353,22 +405,14 @@ const opened = createPersistedRef(PREF_FILTERS_OPENED);
                 how relevance is calculated.
               </Tooltip>
             </div>
-            <input
-              type="checkbox"
-              v-model="filter.nonRelevant"
-              style="margin-left: 20px"
-            />
+            <input type="checkbox" v-model="filter.nonRelevant" />
           </div>
           <div class="section">
             <div class="section-heading">
               <span>Display raw data</span>
               <Tooltip>Whether to display or not raw data columns.</Tooltip>
             </div>
-            <input
-              type="checkbox"
-              v-model="filter.showRawData"
-              style="margin-left: 20px"
-            />
+            <input type="checkbox" v-model="filter.showRawData" />
           </div>
           <div
             class="section"
@@ -413,6 +457,7 @@ const opened = createPersistedRef(PREF_FILTERS_OPENED);
 <style scoped lang="scss">
 .section-heading {
   font-size: 16px;
+  width: 200px;
 }
 
 #filter {

--- a/site/frontend/src/pages/compare/compile/table/benchmark-detail-graph.vue
+++ b/site/frontend/src/pages/compare/compile/table/benchmark-detail-graph.vue
@@ -39,10 +39,11 @@ function createGraphsSelector(): CompileDetailGraphsSelector {
     profile: props.testCase.profile,
     scenario: props.testCase.scenario,
     backend: props.testCase.backend,
+    target: props.testCase.target,
+    frontendThreads: props.testCase.frontend_threads,
     stat: props.metric,
     start,
     end,
-    target: props.testCase.target,
     kinds: ["percentrelative", "percentfromfirst"] as GraphKind[],
   };
 }
@@ -79,6 +80,7 @@ async function renderGraphs(detail: CompileDetailGraphs) {
       start: selector.start,
       end: selector.end,
       target: selector.target,
+      frontend_threads: selector.frontendThreads,
       backend: selector.backend,
       kind,
     };

--- a/site/frontend/src/pages/compare/compile/table/benchmark-detail.vue
+++ b/site/frontend/src/pages/compare/compile/table/benchmark-detail.vue
@@ -37,6 +37,7 @@ function createSectionsSelector(): CompileDetailSectionsSelector {
     scenario: props.testCase.scenario,
     backend: props.testCase.backend,
     target: props.testCase.target,
+    frontendThreads: props.testCase.frontend_threads,
     start: props.baseArtifact.commit,
     end: props.artifact.commit,
   };

--- a/site/frontend/src/pages/compare/compile/table/benchmark-detail.vue
+++ b/site/frontend/src/pages/compare/compile/table/benchmark-detail.vue
@@ -55,8 +55,9 @@ function detailedQueryLink(
   commit: ArtifactDescription,
   baseCommit?: ArtifactDescription
 ): string {
-  const {benchmark, profile, scenario, backend, target} = props.testCase;
-  let link = `/detailed-query.html?commit=${commit.commit}&benchmark=${benchmark}-${profile}&scenario=${scenario}&backend=${backend}&target=${target}`;
+  const {benchmark, profile, scenario, backend, target, frontend_threads} =
+    props.testCase;
+  let link = `/detailed-query.html?commit=${commit.commit}&benchmark=${benchmark}-${profile}&scenario=${scenario}&backend=${backend}&target=${target}&frontend_threads=${frontend_threads}`;
   if (baseCommit !== undefined) {
     link += `&base_commit=${baseCommit.commit}`;
   }
@@ -71,8 +72,9 @@ function graphLink(
   // Move to `30 days ago` to display history of the test case
   const start = formatDate(getPastDate(new Date(commit.date), 30));
   const end = commit.commit;
-  const {benchmark, profile, scenario, target, backend} = testCase;
-  return `/index.html?start=${start}&end=${end}&benchmark=${benchmark}&profile=${profile}&scenario=${scenario}&target=${target}&backend=${backend}&stat=${metric}`;
+  const {benchmark, profile, scenario, target, backend, frontend_threads} =
+    testCase;
+  return `/index.html?start=${start}&end=${end}&benchmark=${benchmark}&profile=${profile}&scenario=${scenario}&target=${target}&backend=${backend}&frontend_threads=${frontend_threads}&stat=${metric}`;
 }
 
 const metadata = computed(

--- a/site/frontend/src/pages/compare/compile/table/comparisons-table.vue
+++ b/site/frontend/src/pages/compare/compile/table/comparisons-table.vue
@@ -60,6 +60,7 @@ const unit = computed(() => {
           <th>Benchmark</th>
           <th>Profile</th>
           <th>Scenario</th>
+          <th>Threads</th>
           <th>Backend</th>
           <th>Target</th>
           <th>% Change</th>
@@ -100,6 +101,9 @@ const unit = computed(() => {
                 {{ comparison.testCase.profile }}
               </td>
               <td>{{ comparison.testCase.scenario }}</td>
+              <td title="Number of frontend threads used for compilation">
+                {{ comparison.testCase.frontend_threads }}
+              </td>
               <td>{{ comparison.testCase.backend }}</td>
               <td :title="comparison.testCase.target">
                 {{ formatTarget(comparison.testCase.target) }}

--- a/site/frontend/src/pages/compare/compile/table/detail-resolver.ts
+++ b/site/frontend/src/pages/compare/compile/table/detail-resolver.ts
@@ -6,17 +6,21 @@ import {
 } from "../../../../urls";
 import {CachedDataLoader} from "./utils";
 
-export interface CompileDetailGraphsSelector {
-  start: string;
-  end: string;
-  stat: string;
+interface CompileParameters {
   benchmark: string;
   scenario: string;
   profile: string;
   backend: string;
   target: string;
-  kinds: GraphKind[];
+  frontendThreads: string;
 }
+
+export type CompileDetailGraphsSelector = CompileParameters & {
+  start: string;
+  end: string;
+  stat: string;
+  kinds: GraphKind[];
+};
 
 // Compile benchmark detail received from the server
 export interface CompileDetailGraphs {
@@ -27,15 +31,10 @@ export interface CompileDetailGraphs {
   sections_after: CompilationSections | null;
 }
 
-export interface CompileDetailSectionsSelector {
+export type CompileDetailSectionsSelector = CompileParameters & {
   start: string;
   end: string;
-  benchmark: string;
-  scenario: string;
-  profile: string;
-  backend: string;
-  target: string;
-}
+};
 
 export interface CompileDetailSections {
   before: CompilationSections | null;
@@ -66,7 +65,7 @@ export const COMPILE_DETAIL_GRAPHS_RESOLVER: CachedDataLoader<
   CompileDetailGraphs
 > = new CachedDataLoader(
   (key: CompileDetailGraphsSelector) =>
-    `${key.benchmark};${key.profile};${key.scenario};${key.backend};${key.start};${key.end};${key.stat};${key.kinds};${key.target}`,
+    `${key.benchmark};${key.profile};${key.scenario};${key.backend};${key.target};${key.frontendThreads};${key.start};${key.end};${key.stat};${key.kinds}`,
   loadGraphsDetail
 );
 
@@ -82,6 +81,7 @@ async function loadGraphsDetail(
     profile: selector.profile,
     backend: selector.backend,
     target: selector.target,
+    frontend_threads: selector.frontendThreads,
     kinds: selector.kinds.join(","),
   };
   return await getJson<CompileDetailGraphs>(
@@ -96,7 +96,7 @@ export const COMPILE_DETAIL_SECTIONS_RESOLVER: CachedDataLoader<
   CompileDetailSections
 > = new CachedDataLoader(
   (key: CompileDetailSectionsSelector) =>
-    `${key.benchmark};${key.profile};${key.scenario};${key.backend};${key.target};${key.start};${key.end}`,
+    `${key.benchmark};${key.profile};${key.scenario};${key.backend};${key.target};${key.frontendThreads};${key.start};${key.end}`,
   loadSectionsDetail
 );
 
@@ -111,6 +111,7 @@ async function loadSectionsDetail(
     profile: selector.profile,
     backend: selector.backend,
     target: selector.target,
+    frontend_threads: selector.frontendThreads,
   };
   return await getJson<CompileDetailSections>(
     COMPARE_COMPILE_DETAIL_SECTIONS_DATA_URL,

--- a/site/frontend/src/pages/compare/compile/table/detail-resolver.ts
+++ b/site/frontend/src/pages/compare/compile/table/detail-resolver.ts
@@ -15,12 +15,12 @@ interface CompileParameters {
   frontendThreads: string;
 }
 
-export type CompileDetailGraphsSelector = CompileParameters & {
+export interface CompileDetailGraphsSelector extends CompileParameters {
   start: string;
   end: string;
   stat: string;
   kinds: GraphKind[];
-};
+}
 
 // Compile benchmark detail received from the server
 export interface CompileDetailGraphs {
@@ -31,10 +31,10 @@ export interface CompileDetailGraphs {
   sections_after: CompilationSections | null;
 }
 
-export type CompileDetailSectionsSelector = CompileParameters & {
+export interface CompileDetailSectionsSelector extends CompileParameters {
   start: string;
   end: string;
-};
+}
 
 export interface CompileDetailSections {
   before: CompilationSections | null;
@@ -65,7 +65,18 @@ export const COMPILE_DETAIL_GRAPHS_RESOLVER: CachedDataLoader<
   CompileDetailGraphs
 > = new CachedDataLoader(
   (key: CompileDetailGraphsSelector) =>
-    `${key.benchmark};${key.profile};${key.scenario};${key.backend};${key.target};${key.frontendThreads};${key.start};${key.end};${key.stat};${key.kinds}`,
+    [
+      key.benchmark,
+      key.profile,
+      key.scenario,
+      key.backend,
+      key.target,
+      key.frontendThreads,
+      key.start,
+      key.end,
+      key.stat,
+      key.kinds.join(","),
+    ].join(";"),
   loadGraphsDetail
 );
 
@@ -96,7 +107,16 @@ export const COMPILE_DETAIL_SECTIONS_RESOLVER: CachedDataLoader<
   CompileDetailSections
 > = new CachedDataLoader(
   (key: CompileDetailSectionsSelector) =>
-    `${key.benchmark};${key.profile};${key.scenario};${key.backend};${key.target};${key.frontendThreads};${key.start};${key.end}`,
+    [
+      key.benchmark,
+      key.profile,
+      key.scenario,
+      key.backend,
+      key.target,
+      key.frontendThreads,
+      key.start,
+      key.end,
+    ].join(";"),
   loadSectionsDetail
 );
 

--- a/site/frontend/src/pages/compare/runtime/benchmark-detail-graph.vue
+++ b/site/frontend/src/pages/compare/runtime/benchmark-detail-graph.vue
@@ -67,6 +67,7 @@ async function renderGraphs(detail: RuntimeDetailGraphs) {
       profile: null,
       scenario: null,
       target: selector.target,
+      frontend_threads: null,
       backend: null,
       kind,
     };

--- a/site/frontend/src/pages/detailed-query/page.vue
+++ b/site/frontend/src/pages/detailed-query/page.vue
@@ -189,7 +189,15 @@ function storeSortToUrl() {
 
 async function loadData() {
   const params = getUrlParams();
-  const {commit, base_commit, benchmark, scenario, backend, target} = params;
+  const {
+    commit,
+    base_commit,
+    benchmark,
+    scenario,
+    backend,
+    target,
+    frontend_threads,
+  } = params;
 
   // Load sort state from URL
   loadSortFromUrl(params);
@@ -214,6 +222,7 @@ async function loadData() {
     profile,
     backend,
     target,
+    frontend_threads,
   };
   selector.value = currentSelector;
 

--- a/site/frontend/src/pages/detailed-query/utils.ts
+++ b/site/frontend/src/pages/detailed-query/utils.ts
@@ -12,6 +12,7 @@ export interface Selector {
   scenario: string;
   backend: string;
   target: string;
+  frontend_threads: string;
 }
 
 export interface ProfileElement {
@@ -83,7 +84,8 @@ export function perfettoProfilerData(
   scenario: string,
   profile: string,
   backend: string,
-  target: string
+  target: string,
+  frontendThreads: string
 ): {link: string; traceTitle: string} {
   const link = chromeProfileUrl(
     commit,
@@ -91,7 +93,8 @@ export function perfettoProfilerData(
     scenario,
     profile,
     backend,
-    target
+    target,
+    frontendThreads
   );
   const traceTitle = `${benchmark}-${scenario} (${commit})`;
   return {link, traceTitle};
@@ -113,7 +116,7 @@ export function createTitleData(selector: Selector | null): {
   let selfHref = "";
 
   if (state.base_commit) {
-    const args = `&scenario=${state.scenario}&benchmark=${state.benchmark}-${state.profile}&backend=${state.backend}&target=${state.target}`;
+    const args = `&scenario=${state.scenario}&benchmark=${state.benchmark}-${state.profile}&backend=${state.backend}&target=${state.target}&frontend_threads=${state.frontend_threads}`;
     selfHref = `/detailed-query.html?commit=${state.commit}${args}`;
     baseHref = `/detailed-query.html?commit=${state.base_commit}${args}`;
   }
@@ -178,7 +181,7 @@ export function createDownloadLinksData(selector: Selector | null): {
       : "???";
 
   const createLinks = (commit: string) => ({
-    raw: `/perf/download-raw-self-profile?commit=${commit}&benchmark=${state.benchmark}&profile=${state.profile}&scenario=${state.scenario}&backend=${state.backend}&target=${state.target}`,
+    raw: `/perf/download-raw-self-profile?commit=${commit}&benchmark=${state.benchmark}&profile=${state.profile}&scenario=${state.scenario}&backend=${state.backend}&target=${state.target}&frontend_threads=${state.frontend_threads}`,
     flamegraph: processedSelfProfileRelativeUrl(
       commit,
       state.benchmark,
@@ -186,6 +189,7 @@ export function createDownloadLinksData(selector: Selector | null): {
       state.profile,
       state.backend,
       state.target,
+      state.frontend_threads,
       "flamegraph"
     ),
     crox: processedSelfProfileRelativeUrl(
@@ -195,6 +199,7 @@ export function createDownloadLinksData(selector: Selector | null): {
       state.profile,
       state.backend,
       state.target,
+      state.frontend_threads,
       "crox"
     ),
     codegen: processedSelfProfileRelativeUrl(
@@ -204,6 +209,7 @@ export function createDownloadLinksData(selector: Selector | null): {
       state.profile,
       state.backend,
       state.target,
+      state.frontend_threads,
       "codegen-schedule"
     ),
     perfetto: perfettoProfilerData(
@@ -212,7 +218,8 @@ export function createDownloadLinksData(selector: Selector | null): {
       state.scenario,
       state.profile,
       state.backend,
-      state.target
+      state.target,
+      state.frontend_threads
     ),
     firefox: `https://profiler.firefox.com/from-url/${encodeURIComponent(
       chromeProfileUrl(
@@ -221,7 +228,8 @@ export function createDownloadLinksData(selector: Selector | null): {
         state.scenario,
         state.profile,
         state.backend,
-        state.target
+        state.target,
+        state.frontend_threads
       )
     )}/marker-chart/?v=5`,
   });
@@ -230,7 +238,7 @@ export function createDownloadLinksData(selector: Selector | null): {
   const newLinks = createLinks(state.commit);
 
   const diffLink = state.base_commit
-    ? `/perf/processed-self-profile?commit=${state.commit}&base_commit=${state.base_commit}&benchmark=${state.benchmark}&profile=${state.profile}&scenario=${state.scenario}&backend=${state.backend}&target=${state.target}&type=codegen-schedule`
+    ? `/perf/processed-self-profile?commit=${state.commit}&base_commit=${state.base_commit}&benchmark=${state.benchmark}&profile=${state.profile}&scenario=${state.scenario}&backend=${state.backend}&target=${state.target}&frontend_threads=${state.frontend_threads}&type=codegen-schedule`
     : "";
 
   function cachegrindCommand(

--- a/site/frontend/src/pages/graphs/page.vue
+++ b/site/frontend/src/pages/graphs/page.vue
@@ -21,6 +21,7 @@ function loadSelectorFromUrl(urlParams: Dict<string>): GraphsSelector {
   const scenario = urlParams["scenario"] ?? null;
   const profile = urlParams["profile"] ?? null;
   const target = urlParams["target"] ?? null;
+  const frontend_threads = urlParams["frontendThreads"] ?? null;
   const backend = urlParams["backend"] ?? null;
   return {
     start,
@@ -32,6 +33,7 @@ function loadSelectorFromUrl(urlParams: Dict<string>): GraphsSelector {
     profile,
     backend,
     target,
+    frontend_threads,
   };
 }
 

--- a/site/frontend/src/self-profile.ts
+++ b/site/frontend/src/self-profile.ts
@@ -6,7 +6,8 @@ export function chromeProfileUrl(
   scenario: string,
   profile: string,
   backend: string,
-  target: string
+  target: string,
+  frontendThreads: string
 ): string {
   const relativeUrl = processedSelfProfileRelativeUrl(
     commit,
@@ -15,6 +16,7 @@ export function chromeProfileUrl(
     profile,
     backend,
     target,
+    frontendThreads,
     "crox"
   );
   return window.location.origin + relativeUrl;
@@ -27,7 +29,8 @@ export function processedSelfProfileRelativeUrl(
   profile: string,
   backend: string,
   target: string,
+  frontendThreads: string,
   type: string
 ): string {
-  return `/perf/processed-self-profile?commit=${commit}&benchmark=${benchmark}&profile=${profile}&scenario=${scenario}&backend=${backend}&target=${target}&type=${type}`;
+  return `/perf/processed-self-profile?commit=${commit}&benchmark=${benchmark}&profile=${profile}&scenario=${scenario}&backend=${backend}&target=${target}&frontend_threads=${frontendThreads}&type=${type}`;
 }

--- a/site/frontend/src/utils/requests.ts
+++ b/site/frontend/src/utils/requests.ts
@@ -20,7 +20,7 @@ export function jsonResponseHasError<T>(
 
 export async function getJson<T>(
   path: string,
-  params: Dict<string> = {}
+  params: Dict<string | null> = {}
 ): Promise<T> {
   let url = path;
 

--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -121,6 +121,7 @@ pub mod graphs {
         pub profile: Option<String>,
         pub backend: Option<String>,
         pub target: Option<String>,
+        pub frontend_threads: Option<String>,
     }
 
     #[derive(Debug, PartialEq, Copy, Clone, Serialize, Deserialize)]
@@ -166,6 +167,7 @@ pub mod detail_graphs {
         pub profile: String,
         pub backend: String,
         pub target: String,
+        pub frontend_threads: String,
         #[serde(deserialize_with = "vec_from_comma_separated")]
         pub kinds: Vec<GraphKind>,
     }
@@ -190,6 +192,7 @@ pub mod detail_sections {
         pub profile: String,
         pub backend: String,
         pub target: String,
+        pub frontend_threads: String,
     }
 
     #[derive(Default, Debug, Clone, Serialize)]

--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -457,6 +457,7 @@ pub mod self_profile_raw {
         pub scenario: String,
         pub backend: String,
         pub target: String,
+        pub frontend_threads: String,
     }
 }
 
@@ -481,6 +482,7 @@ pub mod self_profile_processed {
         pub profile: String,
         pub backend: String,
         pub target: String,
+        pub frontend_threads: String,
         #[serde(rename = "type")]
         pub processor_type: ProcessorType,
         #[serde(default, flatten)]
@@ -506,6 +508,8 @@ pub mod self_profile {
         pub backend: Option<String>,
         #[serde(default)]
         pub target: Option<String>,
+        #[serde(default)]
+        pub frontend_threads: Option<String>,
     }
 
     #[derive(Debug, Clone, Serialize)]

--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -346,6 +346,7 @@ pub mod comparison {
         pub scenario: String,
         pub backend: String,
         pub target: String,
+        pub frontend_threads: String,
         pub comparison: StatComparison,
     }
 

--- a/site/src/comparison.rs
+++ b/site/src/comparison.rs
@@ -173,6 +173,7 @@ pub async fn handle_compare(
             scenario: comparison.test_case.scenario.to_string(),
             backend: comparison.test_case.backend.to_string(),
             target: comparison.test_case.target.to_string(),
+            frontend_threads: comparison.test_case.frontend_threads.0.to_string(),
             comparison: comparison.comparison.into(),
         })
         .collect();

--- a/site/src/request_handlers/graph.rs
+++ b/site/src/request_handlers/graph.rs
@@ -261,7 +261,7 @@ async fn create_graphs(
     let backend_selector =
         create_selector(&request.backend).unwrap_or(Ok(Selector::One(CodegenBackend::Llvm)))?;
     let frontend_threads_selector = create_selector(&request.frontend_threads)
-        .unwrap_or(Ok(Selector::One(FrontendThreads(1))))?;
+        .unwrap_or(Ok(Selector::One(FrontendThreads::default_value())))?;
     let interpolated_responses: Vec<_> = ctxt
         .statistic_series(
             CompileBenchmarkQuery::default()

--- a/site/src/request_handlers/graph.rs
+++ b/site/src/request_handlers/graph.rs
@@ -39,6 +39,7 @@ pub async fn handle_compile_detail_graphs(
                 .scenario(Selector::One(scenario))
                 .backend(Selector::One(request.backend.parse()?))
                 .target(Selector::One(request.target.parse()?))
+                .frontend_threads(Selector::One(request.frontend_threads.parse()?))
                 .metric(Selector::One(request.stat.parse()?)),
             artifact_ids.clone(),
         )
@@ -89,6 +90,7 @@ pub async fn handle_compile_detail_sections(
     let profile: Profile = request.profile.parse()?;
     let backend: CodegenBackend = request.backend.parse()?;
     let target: Target = request.target.parse()?;
+    let frontend_threads: FrontendThreads = request.frontend_threads.parse()?;
 
     async fn calculate_sections(
         ctxt: &SiteCtxt,
@@ -98,8 +100,8 @@ pub async fn handle_compile_detail_sections(
         scenario: Scenario,
         backend: CodegenBackend,
         target: Target,
+        frontend_threads: FrontendThreads,
     ) -> Option<CompilationSections> {
-        const MOCK_FRONTEND_THREADS: FrontendThreads = FrontendThreads(1);
         let id = SelfProfileId::Simple {
             artifact_id: aid,
             benchmark: benchmark.into(),
@@ -107,7 +109,7 @@ pub async fn handle_compile_detail_sections(
             scenario,
             backend,
             target,
-            frontend_threads: MOCK_FRONTEND_THREADS,
+            frontend_threads,
         };
         fetch_self_profile(ctxt, id, None)
             .await
@@ -132,7 +134,8 @@ pub async fn handle_compile_detail_sections(
                 profile,
                 scenario,
                 backend,
-                target
+                target,
+                frontend_threads
             ),
             calculate_sections(
                 &ctxt,
@@ -141,7 +144,8 @@ pub async fn handle_compile_detail_sections(
                 profile,
                 scenario,
                 backend,
-                target
+                target,
+                frontend_threads
             )
         )
     } else {
@@ -210,6 +214,7 @@ pub async fn handle_graphs(
             profile: None,
             backend: None,
             target: None,
+            frontend_threads: None,
         };
 
     if is_default_query {
@@ -255,7 +260,8 @@ async fn create_graphs(
         .unwrap_or(Ok(Selector::One(Target::X86_64UnknownLinuxGnu)))?;
     let backend_selector =
         create_selector(&request.backend).unwrap_or(Ok(Selector::One(CodegenBackend::Llvm)))?;
-
+    let frontend_threads_selector = create_selector(&request.frontend_threads)
+        .unwrap_or(Ok(Selector::One(FrontendThreads(1))))?;
     let interpolated_responses: Vec<_> = ctxt
         .statistic_series(
             CompileBenchmarkQuery::default()
@@ -264,6 +270,7 @@ async fn create_graphs(
                 .scenario(scenario_selector)
                 .backend(backend_selector)
                 .target(target_selector)
+                .frontend_threads(frontend_threads_selector)
                 .metric(Selector::One(request.stat.parse()?)),
             artifact_ids.clone(),
         )

--- a/site/src/request_handlers/graph.rs
+++ b/site/src/request_handlers/graph.rs
@@ -92,6 +92,7 @@ pub async fn handle_compile_detail_sections(
     let target: Target = request.target.parse()?;
     let frontend_threads: FrontendThreads = request.frontend_threads.parse()?;
 
+    #[allow(clippy::too_many_arguments)]
     async fn calculate_sections(
         ctxt: &SiteCtxt,
         aid: ArtifactId,

--- a/site/src/request_handlers/self_profile.rs
+++ b/site/src/request_handlers/self_profile.rs
@@ -187,6 +187,7 @@ pub async fn handle_self_profile_processed_download(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn get_self_profile_id(
     ctxt: &SiteCtxt,
     benchmark: &str,

--- a/site/src/request_handlers/self_profile.rs
+++ b/site/src/request_handlers/self_profile.rs
@@ -61,6 +61,7 @@ pub async fn handle_self_profile_processed_download(
             &body.scenario,
             &body.backend,
             &body.target,
+            &body.frontend_threads,
         )
         .await
         {
@@ -102,6 +103,7 @@ pub async fn handle_self_profile_processed_download(
             &body.scenario,
             &body.backend,
             &body.target,
+            &body.frontend_threads,
         )
         .await
         {
@@ -193,6 +195,7 @@ async fn get_self_profile_id(
     scenario: &str,
     backend: &str,
     target: &str,
+    frontend_threads: &str,
 ) -> anyhow::Result<SelfProfileId> {
     let profile = profile
         .parse::<Profile>()
@@ -206,6 +209,9 @@ async fn get_self_profile_id(
     let target = target
         .parse::<Target>()
         .map_err(|e| anyhow::anyhow!("invalid target: {e:?}"))?;
+    let frontend_threads = frontend_threads
+        .parse::<FrontendThreads>()
+        .map_err(|e| anyhow::anyhow!("invalid frontend thread count: {e:?}"))?;
     let benchmark: BenchmarkName = benchmark.into();
 
     let conn = ctxt.conn().await;
@@ -225,7 +231,6 @@ async fn get_self_profile_id(
             &scenario.to_id(),
         )
         .await;
-    const MOCK_FRONTEND_THREADS: FrontendThreads = FrontendThreads(1);
 
     let id = match aids_and_cids.first().copied() {
         // We have a record in the DB, assume that it is the legacy ID
@@ -244,7 +249,7 @@ async fn get_self_profile_id(
             scenario,
             backend,
             target,
-            frontend_threads: MOCK_FRONTEND_THREADS,
+            frontend_threads,
         },
     };
 
@@ -372,6 +377,7 @@ pub async fn handle_self_profile_raw_download(
         &body.scenario,
         &body.backend,
         &body.target,
+        &body.frontend_threads,
     )
     .await
     {
@@ -444,6 +450,11 @@ pub async fn handle_self_profile(
     } else {
         Target::X86_64UnknownLinuxGnu
     };
+    let frontend_threads = if let Some(frontend_threads) = body.frontend_threads {
+        frontend_threads.parse()?
+    } else {
+        FrontendThreads::default_value()
+    };
 
     let query = selector::CompileBenchmarkQuery::default()
         .benchmark(selector::Selector::One(benchmark.to_string()))
@@ -451,6 +462,7 @@ pub async fn handle_self_profile(
         .scenario(selector::Selector::One(scenario))
         .backend(selector::Selector::One(backend))
         .target(selector::Selector::One(target))
+        .frontend_threads(selector::Selector::One(frontend_threads))
         .metric(selector::Selector::One(Metric::CpuClock));
 
     // Helper for finding an `ArtifactId` based on a commit sha
@@ -489,6 +501,7 @@ pub async fn handle_self_profile(
             &scenario.to_string(),
             backend.as_str(),
             target.as_str(),
+            &frontend_threads.to_string(),
         )
         .await
         .map_err(|e| e.to_string())?;
@@ -507,6 +520,7 @@ pub async fn handle_self_profile(
                 &scenario.to_string(),
                 backend.as_str(),
                 target.as_str(),
+                &frontend_threads.to_string(),
             )
             .await
             .map_err(|e| e.to_string())?;


### PR DESCRIPTION
This PR adds support for frontend threads to the UI. Even after many refactorings, adding a new benchmark axis to the frontend still requires a lot of changes :( And there is quite a lot of duplication, particularly in the various used TypeScript types. I did a very minor refactoring while adding frontend threads, but otherwise kept things as-is.

I did not adapt the changes from https://github.com/rust-lang/rustc-perf/pull/2529 in this PR, because I wanted to first get the frontend threads working at all, and then do refactorings separately.

Best reviewed commit-by-commit.

After merging this, we should consider doing some cleanup of the current `-4threads` benchmarks, because currently they will be shown as having one thread, which doesn't make much sense.