### PR TITLE
Allow benchmark to opt into different values of frontend threads

### DIFF
--- a/collector/compile-benchmarks/serde-1.0.219/perf-config.json
+++ b/collector/compile-benchmarks/serde-1.0.219/perf-config.json
@@ -1,5 +1,6 @@
 {
   "cargo_rustc_opts": "-Znext-solver=coherence",
   "artifact": "library",
-  "category": "primary"
+  "category": "primary",
+  "frontend_threads": [1, 4]
 }

--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -108,6 +108,25 @@ struct BenchmarkDirs<'a> {
     runtime: &'a Path,
 }
 
+enum FrontendThreadsConfig {
+    /// Use the frontend threads values set by the benchmark itself
+    FromBenchmark,
+    /// Use the following frontend thread values
+    Specific(Vec<FrontendThreads>),
+}
+
+impl FrontendThreadsConfig {
+    fn expand(&self, benchmark: &Benchmark) -> Vec<FrontendThreads> {
+        match self {
+            FrontendThreadsConfig::FromBenchmark => match benchmark.config().frontend_threads() {
+                Some(values) => values.to_vec(),
+                None => vec![FrontendThreads::new(1)],
+            },
+            FrontendThreadsConfig::Specific(values) => values.clone(),
+        }
+    }
+}
+
 struct CompileBenchmarkConfig {
     benchmarks: Vec<Benchmark>,
     profiles: Vec<Profile>,
@@ -117,7 +136,7 @@ struct CompileBenchmarkConfig {
     self_profile_storage: Option<Box<dyn SelfProfileStorage>>,
     bench_rustc: bool,
     targets: Vec<Target>,
-    frontend_threads_counts: Vec<FrontendThreads>,
+    frontend_threads_config: FrontendThreadsConfig,
 }
 
 struct RuntimeBenchmarkConfig {
@@ -168,14 +187,15 @@ fn generate_diffs(
     benchmarks: &[Benchmark],
     profiles: &[Profile],
     scenarios: &[Scenario],
-    frontend_threads_counts: &[FrontendThreads],
+    frontend_threads_config: &FrontendThreadsConfig,
     errors: &mut BenchmarkErrors,
     profiler: &Profiler,
 ) -> Vec<PathBuf> {
     let mut annotated_diffs = Vec::new();
     for benchmark in benchmarks {
         for &profile in profiles {
-            for &frontend_threads in frontend_threads_counts {
+            let frontend_threads = frontend_threads_config.expand(benchmark);
+            for frontend_threads in frontend_threads {
                 for scenario in scenarios.iter().flat_map(|scenario| {
                     if profile.is_doc() && scenario.is_incr() {
                         return vec![];
@@ -233,7 +253,7 @@ fn profile_compile(
     backends: &[CodegenBackend],
     errors: &mut BenchmarkErrors,
     targets: &[Target],
-    frontend_threads_counts: &[FrontendThreads],
+    frontend_threads_config: &FrontendThreadsConfig,
 ) {
     eprintln!("Profiling {} with {:?}", toolchain.id, profiler);
     if let Profiler::SelfProfile = profiler {
@@ -244,6 +264,8 @@ fn profile_compile(
         .par_iter()
         .enumerate()
         .map(|(i, benchmark)| {
+            let frontend_thread_counts = frontend_threads_config.expand(benchmark);
+
             let benchmark_id = format!("{} ({}/{})", benchmark.name, i + 1, benchmarks.len());
             eprintln!("Executing benchmark {benchmark_id}");
             let mut processor = ProfileProcessor::new(profiler, out_dir, &toolchain.id);
@@ -255,7 +277,7 @@ fn profile_compile(
                 toolchain,
                 Some(1),
                 targets,
-                frontend_threads_counts,
+                &frontend_thread_counts,
                 // We always want to profile everything
                 &hashbrown::HashSet::new(),
             ));
@@ -426,9 +448,9 @@ struct CompileTimeOptions {
 }
 
 impl CompileTimeOptions {
-    fn validate_and_normalize_frontend_threads(&self) -> Vec<FrontendThreads> {
+    fn get_frontend_threads(&self) -> FrontendThreadsConfig {
         if self.frontend_threads_counts.is_empty() {
-            return FrontendThreads::default_threads_counts();
+            return FrontendThreadsConfig::FromBenchmark;
         }
 
         let mut threads = self
@@ -438,7 +460,7 @@ impl CompileTimeOptions {
             .collect::<Vec<_>>();
         threads.sort();
         threads.dedup();
-        threads
+        FrontendThreadsConfig::Specific(threads)
     }
 }
 
@@ -1021,7 +1043,7 @@ fn main_result() -> anyhow::Result<i32> {
             purge,
         } => {
             log_db(&db);
-            let frontend_threads_counts = opts.validate_and_normalize_frontend_threads();
+            let frontend_threads_config = opts.get_frontend_threads();
             let profiles = opts.profiles.0;
             let scenarios = opts.scenarios.0;
             let backends = opts.codegen_backends.0;
@@ -1074,7 +1096,7 @@ fn main_result() -> anyhow::Result<i32> {
                 },
                 bench_rustc: bench_rustc.bench_rustc,
                 targets: vec![Target::host()],
-                frontend_threads_counts,
+                frontend_threads_config,
             };
 
             rt.block_on(run_benchmarks(conn.as_mut(), shared, Some(config), None))?;
@@ -1115,7 +1137,7 @@ fn main_result() -> anyhow::Result<i32> {
 
             let profiles = &opts.profiles.0;
             let scenarios = &opts.scenarios.0;
-            let frontend_threads_counts = opts.validate_and_normalize_frontend_threads();
+            let frontend_threads_config = opts.get_frontend_threads();
             let backends = &opts.codegen_backends.0;
 
             let mut benchmarks = get_compile_benchmarks(&compile_benchmark_dir, (&local).into())?;
@@ -1155,7 +1177,7 @@ fn main_result() -> anyhow::Result<i32> {
                         backends,
                         &mut errors,
                         &[Target::host()],
-                        &frontend_threads_counts,
+                        &frontend_threads_config,
                     );
                     Ok(id)
                 };
@@ -1174,7 +1196,7 @@ fn main_result() -> anyhow::Result<i32> {
                     &benchmarks,
                     profiles,
                     scenarios,
-                    &frontend_threads_counts,
+                    &frontend_threads_config,
                     &mut errors,
                     &profiler,
                 );
@@ -1749,7 +1771,7 @@ async fn create_benchmark_configs(
             },
             bench_rustc,
             targets: vec![job.target().into()],
-            frontend_threads_counts: FrontendThreads::default_threads_counts(),
+            frontend_threads_config: FrontendThreadsConfig::FromBenchmark,
         })
     } else {
         None
@@ -2207,10 +2229,10 @@ async fn bench_published_artifact(
     } else {
         Scenario::all_non_incr()
     };
-    let frontend_threads_counts = if collector::version_supports_parallel_frontend(&toolchain.id) {
-        FrontendThreads::default_threads_counts()
+    let frontend_threads_config = if collector::version_supports_parallel_frontend(&toolchain.id) {
+        FrontendThreadsConfig::FromBenchmark
     } else {
-        vec![FrontendThreads::new(1)]
+        FrontendThreadsConfig::Specific(vec![FrontendThreads::new(1)])
     };
 
     // Exclude benchmarks that don't work with a stable compiler.
@@ -2245,7 +2267,7 @@ async fn bench_published_artifact(
             self_profile_storage: None,
             bench_rustc: false,
             targets: vec![Target::host()],
-            frontend_threads_counts,
+            frontend_threads_config,
         }),
         Some(RuntimeBenchmarkConfig::new(
             runtime_suite,
@@ -2329,6 +2351,8 @@ async fn bench_compile(
 
     // Normal benchmarks.
     for (nth_benchmark, benchmark) in config.benchmarks.iter().enumerate() {
+        let frontend_threads = config.frontend_threads_config.expand(benchmark);
+
         measure_and_record(
             collector,
             shared,
@@ -2352,7 +2376,7 @@ async fn bench_compile(
                     &shared.toolchain,
                     config.iterations,
                     &config.targets,
-                    &config.frontend_threads_counts,
+                    &frontend_threads,
                     &collector.measured_compile_test_cases,
                 ))
                 .await

--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -36,7 +36,7 @@ use collector::benchmark_set::{get_benchmark_set, BenchmarkSetId, BenchmarkSetMe
 use collector::codegen::{codegen_diff, CodegenType};
 use collector::compile::benchmark::category::Category;
 use collector::compile::benchmark::codegen_backend::CodegenBackend;
-use collector::compile::benchmark::parallel_frontend::FrontendThreads;
+use collector::compile::benchmark::frontend_threads::FrontendThreads;
 use collector::compile::benchmark::profile::Profile;
 use collector::compile::benchmark::scenario::Scenario;
 use collector::compile::benchmark::target::Target;

--- a/collector/src/compile/benchmark/frontend_threads.rs
+++ b/collector/src/compile/benchmark/frontend_threads.rs
@@ -1,6 +1,6 @@
 use std::num::NonZeroU32;
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, serde::Deserialize)]
 pub struct FrontendThreads(NonZeroU32);
 
 impl FrontendThreads {

--- a/collector/src/compile/benchmark/frontend_threads.rs
+++ b/collector/src/compile/benchmark/frontend_threads.rs
@@ -14,13 +14,6 @@ impl FrontendThreads {
     pub fn get(&self) -> u32 {
         self.0.get()
     }
-    // Default thread counts for the parallel frontend
-    pub fn default_threads_counts() -> Vec<FrontendThreads> {
-        database::FrontendThreads::default_threads_counts()
-            .iter()
-            .map(|v| (*v).into())
-            .collect()
-    }
 }
 
 impl From<u32> for FrontendThreads {
@@ -37,6 +30,6 @@ impl From<database::FrontendThreads> for FrontendThreads {
 
 impl From<FrontendThreads> for database::FrontendThreads {
     fn from(value: FrontendThreads) -> Self {
-        database::FrontendThreads(value.get())
+        database::FrontendThreads(value.0.get())
     }
 }

--- a/collector/src/compile/benchmark/mod.rs
+++ b/collector/src/compile/benchmark/mod.rs
@@ -85,6 +85,10 @@ pub struct BenchmarkConfig {
     /// Which package from a workspace should be compiled
     #[serde(default)]
     package: Option<String>,
+
+    /// Override the default frontend thread counts with which this benchmark should be benchmarked.
+    #[serde(default)]
+    frontend_threads: Option<Vec<FrontendThreads>>,
 }
 
 impl BenchmarkConfig {
@@ -98,6 +102,10 @@ impl BenchmarkConfig {
 
     pub fn iterations(&self) -> usize {
         self.runs
+    }
+
+    pub fn frontend_threads(&self) -> Option<&[FrontendThreads]> {
+        self.frontend_threads.as_deref()
     }
 }
 
@@ -602,6 +610,10 @@ impl Benchmark {
                 !already_computed.contains(&test_case)
             }),
         }
+    }
+
+    pub fn config(&self) -> &BenchmarkConfig {
+        &self.config
     }
 }
 

--- a/collector/src/compile/benchmark/mod.rs
+++ b/collector/src/compile/benchmark/mod.rs
@@ -1,6 +1,6 @@
 use crate::compile::benchmark::category::Category;
 use crate::compile::benchmark::codegen_backend::CodegenBackend;
-use crate::compile::benchmark::parallel_frontend::FrontendThreads;
+use crate::compile::benchmark::frontend_threads::FrontendThreads;
 use crate::compile::benchmark::patch::Patch;
 use crate::compile::benchmark::profile::Profile;
 use crate::compile::benchmark::scenario::Scenario;
@@ -20,7 +20,7 @@ use tempfile::TempDir;
 
 pub mod category;
 pub mod codegen_backend;
-pub mod parallel_frontend;
+pub mod frontend_threads;
 pub(crate) mod patch;
 pub mod profile;
 pub mod scenario;

--- a/collector/src/compile/execute/mod.rs
+++ b/collector/src/compile/execute/mod.rs
@@ -1,7 +1,7 @@
 //! Execute benchmarks.
 
 use crate::compile::benchmark::codegen_backend::CodegenBackend;
-use crate::compile::benchmark::parallel_frontend::FrontendThreads;
+use crate::compile::benchmark::frontend_threads::FrontendThreads;
 use crate::compile::benchmark::patch::Patch;
 use crate::compile::benchmark::profile::Profile;
 use crate::compile::benchmark::scenario::Scenario;

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -28,14 +28,6 @@ impl FrontendThreads {
     pub fn default_value() -> Self {
         Self(1)
     }
-
-    // Default thread counts for the parallel frontend
-    pub fn default_threads_counts() -> Vec<FrontendThreads> {
-        vec![FrontendThreads(1)]
-    }
-    pub fn single(self) -> bool {
-        self.0 == 1
-    }
 }
 
 impl std::str::FromStr for FrontendThreads {


### PR DESCRIPTION
This allows specific benchmarks to opt into selected values of frontend thread counts. This allows us to benchmark only some benchmarks with different `-Zthread` values. You can still override the default via `--frontend-threads` passed to `bench_local` and `profile_local`.

If this works fine on production, I will remove the hardcoded `serde-1.0.219-threads4` benchmark. Together with https://github.com/rust-lang/rustc-perf/pull/2572, that should speed up the current suite slightly.

Note: `rust-lang/rust` should start using `--frontend-threads 1` once this PR is synchronized to `rust-lang/rust` (implemented in https://github.com/rust-lang/rust/pull/162428).